### PR TITLE
fix: Add central version parsing helper (closes #111)

### DIFF
--- a/Functions/Helpers/ConvertTo-NetboxVersion.ps1
+++ b/Functions/Helpers/ConvertTo-NetboxVersion.ps1
@@ -1,0 +1,71 @@
+function ConvertTo-NetboxVersion {
+<#
+.SYNOPSIS
+    Parses Netbox version strings to [System.Version] objects.
+
+.DESCRIPTION
+    Extracts semantic version from Netbox version strings that may contain
+    additional metadata (e.g., "4.2.9-Docker-3.2.1" -> "4.2.9").
+
+    This is a central helper function used throughout the module to ensure
+    consistent version parsing behavior.
+
+.PARAMETER VersionString
+    The raw version string from Netbox API (e.g., from Get-NBVersion).
+
+.EXAMPLE
+    ConvertTo-NetboxVersion -VersionString "4.4.8"
+    # Returns: [version]"4.4.8"
+
+.EXAMPLE
+    ConvertTo-NetboxVersion -VersionString "4.2.9-Docker-3.2.1"
+    # Returns: [version]"4.2.9"
+
+.EXAMPLE
+    ConvertTo-NetboxVersion -VersionString "v4.4.9-dev"
+    # Returns: [version]"4.4.9"
+
+.EXAMPLE
+    "4.4.8" | ConvertTo-NetboxVersion
+    # Pipeline support - Returns: [version]"4.4.8"
+
+.OUTPUTS
+    System.Version or $null if parsing fails
+
+.NOTES
+    Resolves issue #111: Version detection inconsistency
+#>
+    [CmdletBinding()]
+    [OutputType([System.Version])]
+    param(
+        [Parameter(Mandatory, ValueFromPipeline)]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [string]$VersionString
+    )
+
+    process {
+        if ([string]::IsNullOrWhiteSpace($VersionString)) {
+            Write-Verbose "Version string is null or empty"
+            return $null
+        }
+
+        # Pattern: Major.Minor.Patch (Patch optional)
+        # Handles: "4.4.8", "v4.4.8", "4.2.9-Docker-3.2.1", "4.4", "v4.4.9-dev"
+        # Stops at first non-numeric/non-dot character after version numbers
+        if ($VersionString -match '(\d+\.\d+(?:\.\d+)?)') {
+            try {
+                $version = [version]$Matches[1]
+                Write-Verbose "Parsed version '$VersionString' as '$version'"
+                return $version
+            }
+            catch {
+                Write-Verbose "Failed to convert '$($Matches[1])' to version: $_"
+                return $null
+            }
+        }
+
+        Write-Verbose "Could not extract version from '$VersionString'"
+        return $null
+    }
+}

--- a/Functions/Setup/Connect-NBAPI.ps1
+++ b/Functions/Setup/Connect-NBAPI.ps1
@@ -143,11 +143,16 @@ function Connect-NBAPI {
 
     Write-Verbose "Checking Netbox version compatibility"
     $script:NetboxConfig.NetboxVersion = Get-NBVersion
-    if ([version]$script:NetboxConfig.NetboxVersion.'netbox-version' -lt 2.8) {
+    $versionString = $script:NetboxConfig.NetboxVersion.'netbox-version'
+    $script:NetboxConfig.ParsedVersion = ConvertTo-NetboxVersion -VersionString $versionString
+
+    if ($null -eq $script:NetboxConfig.ParsedVersion) {
+        Write-Warning "Could not parse Netbox version '$versionString', assuming compatible"
+    } elseif ($script:NetboxConfig.ParsedVersion -lt [version]'4.1') {
         $Script:NetboxConfig.Connected = $false
-        throw "Netbox version is incompatible with this PS module. Requires >=2.8.*, found version $($script:NetboxConfig.NetboxVersion.'netbox-version')"
+        throw "Netbox version is incompatible with this PS module. Requires >=4.1, found version $versionString"
     } else {
-        Write-Verbose "Found compatible version [$($script:NetboxConfig.NetboxVersion.'netbox-version')]!"
+        Write-Verbose "Found compatible version [$versionString] (parsed: $($script:NetboxConfig.ParsedVersion))!"
     }
 
     $script:NetboxConfig.Connected = $true

--- a/Functions/Setup/Support/Get-NBContentType.ps1
+++ b/Functions/Setup/Support/Get-NBContentType.ps1
@@ -79,27 +79,13 @@ function Get-NBContentType {
     # We use 'extras' as the default for maximum compatibility across all 4.x versions
     $ObjectTypesEndpoint = @('extras', 'object-types')
 
-    # Check if we have version info and can use the newer endpoint
-    if ($script:NetboxConfig -and $script:NetboxConfig.NetboxVersion) {
-        $versionString = $script:NetboxConfig.NetboxVersion.'netbox-version'
-        if ($versionString) {
-            # Extract just the version number (e.g., "4.2.9" from "4.2.9-Docker-3.2.1")
-            if ($versionString -match '^(\d+\.\d+\.?\d*)') {
-                $versionPart = $Matches[1]
-                try {
-                    if ([version]$versionPart -ge [version]'4.4') {
-                        $ObjectTypesEndpoint = @('core', 'object-types')
-                        Write-Verbose "Using /api/core/object-types/ endpoint (Netbox $versionString)"
-                    } else {
-                        Write-Verbose "Using /api/extras/object-types/ endpoint (Netbox $versionString)"
-                    }
-                } catch {
-                    Write-Verbose "Could not parse version '$versionPart', using extras endpoint"
-                }
-            } else {
-                Write-Verbose "Could not extract version from '$versionString', using extras endpoint"
-            }
-        }
+    # Use cached ParsedVersion from Connect-NBAPI (set by ConvertTo-NetboxVersion)
+    $version = $script:NetboxConfig.ParsedVersion
+    if ($version -and $version -ge [version]'4.4') {
+        $ObjectTypesEndpoint = @('core', 'object-types')
+        Write-Verbose "Using /api/core/object-types/ endpoint (Netbox $version)"
+    } else {
+        Write-Verbose "Using /api/extras/object-types/ endpoint (Netbox $version)"
     }
 
     switch ($PSCmdlet.ParameterSetName) {

--- a/Tests/Helpers.Tests.ps1
+++ b/Tests/Helpers.Tests.ps1
@@ -284,4 +284,84 @@ Describe "Helpers tests" -Tag 'Core', 'Helpers' {
 
     # NOTE: ValidateChoice tests removed - function no longer exists in the module
     # The module now passes values directly to the API without client-side validation
+
+    Context "ConvertTo-NetboxVersion" {
+        It "Should parse standard three-part version" {
+            InModuleScope -ModuleName 'PowerNetbox' {
+                $result = ConvertTo-NetboxVersion -VersionString "4.4.8"
+                $result | Should -BeOfType [System.Version]
+                $result | Should -Be ([version]"4.4.8")
+            }
+        }
+
+        It "Should parse Docker-suffixed version" {
+            InModuleScope -ModuleName 'PowerNetbox' {
+                $result = ConvertTo-NetboxVersion -VersionString "4.2.9-Docker-3.2.1"
+                $result | Should -Be ([version]"4.2.9")
+            }
+        }
+
+        It "Should parse two-part version" {
+            InModuleScope -ModuleName 'PowerNetbox' {
+                $result = ConvertTo-NetboxVersion -VersionString "4.4"
+                $result | Should -Be ([version]"4.4")
+            }
+        }
+
+        It "Should parse version with v prefix" {
+            InModuleScope -ModuleName 'PowerNetbox' {
+                $result = ConvertTo-NetboxVersion -VersionString "v4.4.9-dev"
+                $result | Should -Be ([version]"4.4.9")
+            }
+        }
+
+        It "Should return null for null input" {
+            InModuleScope -ModuleName 'PowerNetbox' {
+                $result = ConvertTo-NetboxVersion -VersionString $null
+                $result | Should -BeNullOrEmpty
+            }
+        }
+
+        It "Should return null for empty string" {
+            InModuleScope -ModuleName 'PowerNetbox' {
+                $result = ConvertTo-NetboxVersion -VersionString ""
+                $result | Should -BeNullOrEmpty
+            }
+        }
+
+        It "Should return null for whitespace" {
+            InModuleScope -ModuleName 'PowerNetbox' {
+                $result = ConvertTo-NetboxVersion -VersionString "   "
+                $result | Should -BeNullOrEmpty
+            }
+        }
+
+        It "Should return null for invalid format" {
+            InModuleScope -ModuleName 'PowerNetbox' {
+                $result = ConvertTo-NetboxVersion -VersionString "invalid"
+                $result | Should -BeNullOrEmpty
+            }
+        }
+
+        It "Should return null for single number" {
+            InModuleScope -ModuleName 'PowerNetbox' {
+                $result = ConvertTo-NetboxVersion -VersionString "4"
+                $result | Should -BeNullOrEmpty
+            }
+        }
+
+        It "Should support pipeline input" {
+            InModuleScope -ModuleName 'PowerNetbox' {
+                $result = "4.4.8" | ConvertTo-NetboxVersion
+                $result | Should -Be ([version]"4.4.8")
+            }
+        }
+
+        It "Should handle version with build metadata" {
+            InModuleScope -ModuleName 'PowerNetbox' {
+                $result = ConvertTo-NetboxVersion -VersionString "4.4.9+build.123"
+                $result | Should -Be ([version]"4.4.9")
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- Add `ConvertTo-NetboxVersion` helper function for consistent version parsing across the module
- Update `Connect-NBAPI` to cache `ParsedVersion` in `$script:NetboxConfig`
- Simplify `Get-NBContentType` to use the cached parsed version
- Update minimum version check from 2.8 to 4.1

## Problem

Version parsing was inconsistent between `Connect-NBAPI.ps1` and `Get-NBContentType.ps1`:
- `Connect-NBAPI` used direct `[version]` cast which fails on strings like `"4.2.9-Docker-3.2.1"`
- `Get-NBContentType` had its own regex extraction logic

## Solution

Central helper function that handles all version string formats:
```powershell
ConvertTo-NetboxVersion "4.2.9-Docker-3.2.1"  # → [version]"4.2.9"
ConvertTo-NetboxVersion "v4.4.9-dev"          # → [version]"4.4.9"
ConvertTo-NetboxVersion "4.4"                 # → [version]"4.4"
```

## Test plan

- [x] 11 new unit tests for `ConvertTo-NetboxVersion` edge cases
- [x] All 29 Helpers tests passing
- [ ] Integration test with Docker Netbox image

🤖 Generated with [Claude Code](https://claude.com/claude-code)