### PR TITLE
fix: Cross-platform error handling for PowerShell Core (closes #100)

### DIFF
--- a/Functions/Helpers/GetNetboxAPIErrorBody.ps1
+++ b/Functions/Helpers/GetNetboxAPIErrorBody.ps1
@@ -4,57 +4,77 @@ function GetNetboxAPIErrorBody {
         Extracts the response body from a failed HTTP response.
 
     .DESCRIPTION
-        Safely extracts and returns the response body from an HttpWebResponse,
-        properly disposing of stream resources to prevent memory leaks.
-        Cross-platform compatible with proper UTF-8 encoding.
+        Safely extracts and returns the response body from an HTTP error response.
+        Cross-platform compatible: handles both HttpWebResponse (PowerShell Desktop)
+        and HttpResponseMessage (PowerShell Core).
 
     .PARAMETER Response
-        The HttpWebResponse object from a failed API call.
+        The HTTP response object from a failed API call.
+        Accepts both System.Net.HttpWebResponse (Desktop) and
+        System.Net.Http.HttpResponseMessage (Core).
 
     .OUTPUTS
         [string] The response body content, or empty string if extraction fails.
 
     .EXAMPLE
         $body = GetNetboxAPIErrorBody -Response $_.Exception.Response
+
+    .NOTES
+        Fixes issue #100: Cross-platform error handling compatibility.
     #>
     [CmdletBinding()]
     [OutputType([string])]
     param(
         [Parameter(Mandatory = $true)]
-        [System.Net.HttpWebResponse]$Response
+        $Response  # No type constraint - accept both HttpWebResponse and HttpResponseMessage
     )
 
-    $stream = $null
-    $reader = $null
-
     try {
-        $stream = $Response.GetResponseStream()
+        # PowerShell Core (7.x) - HttpClient-based response
+        if ($Response -is [System.Net.Http.HttpResponseMessage]) {
+            Write-Verbose "Extracting error body from HttpResponseMessage (PowerShell Core)"
+            return $Response.Content.ReadAsStringAsync().GetAwaiter().GetResult()
+        }
+        # PowerShell Desktop (5.1) - WebRequest-based response
+        elseif ($Response -is [System.Net.HttpWebResponse]) {
+            Write-Verbose "Extracting error body from HttpWebResponse (PowerShell Desktop)"
+            $stream = $null
+            $reader = $null
 
-        if ($null -eq $stream) {
+            try {
+                $stream = $Response.GetResponseStream()
+
+                if ($null -eq $stream) {
+                    return [string]::Empty
+                }
+
+                # Explicitly specify UTF-8 encoding for cross-platform consistency
+                $reader = [System.IO.StreamReader]::new($stream, [System.Text.Encoding]::UTF8)
+
+                # Some streams support seeking, reset position if possible
+                if ($stream.CanSeek) {
+                    $stream.Position = 0
+                }
+
+                return $reader.ReadToEnd()
+            }
+            finally {
+                # Proper disposal in reverse order of creation
+                if ($null -ne $reader) {
+                    $reader.Dispose()
+                }
+                if ($null -ne $stream) {
+                    $stream.Dispose()
+                }
+            }
+        }
+        else {
+            Write-Verbose "Unknown response type: $($Response.GetType().FullName)"
             return [string]::Empty
         }
-
-        # Explicitly specify UTF-8 encoding for cross-platform consistency
-        $reader = [System.IO.StreamReader]::new($stream, [System.Text.Encoding]::UTF8)
-
-        # Some streams support seeking, reset position if possible
-        if ($stream.CanSeek) {
-            $stream.Position = 0
-        }
-
-        return $reader.ReadToEnd()
     }
     catch {
         Write-Verbose "Could not read response body: $($_.Exception.Message)"
         return [string]::Empty
-    }
-    finally {
-        # Proper disposal in reverse order of creation
-        if ($null -ne $reader) {
-            $reader.Dispose()
-        }
-        if ($null -ne $stream) {
-            $stream.Dispose()
-        }
     }
 }


### PR DESCRIPTION
## Summary

Fixes type casting error when API errors occur on PowerShell 7.x, as reported by @Christophoclese in #100.

### Problem
The `GetNetboxAPIErrorBody` function had a strongly typed parameter:
```powershell
[System.Net.HttpWebResponse]$Response
```

PowerShell Core uses `HttpResponseMessage` (HttpClient-based), while Desktop uses `HttpWebResponse` (WebRequest-based). This caused the error:
```
Cannot convert "System.Net.Http.HttpResponseMessage" to type "System.Net.HttpWebResponse"
```

### Solution
- Remove type constraint, accept any response type
- Add runtime type detection for both response types
- Use appropriate method for each:
  - **Core**: `$Response.Content.ReadAsStringAsync().GetAwaiter().GetResult()`
  - **Desktop**: `$Response.GetResponseStream()` + StreamReader

## Changes
- `Functions/Helpers/GetNetboxAPIErrorBody.ps1` - Cross-platform type handling
- `Tests/CrossPlatform.Tests.ps1` - 5 new unit tests

## Test plan
- [x] All existing ErrorHandling tests pass (11/11)
- [x] All CrossPlatform Helper tests pass (7/7)
- [x] New test: Extract body from HttpResponseMessage on Core
- [x] New test: Return empty string for unknown types
- [ ] CI: Verify on Windows PS 5.1, Windows PS 7.x, Ubuntu, macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)