### PR TITLE
Verify Netbox 4.4.10 compatibility

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 MIT License
 
 Copyright (c) 2018 Ben Claussen
-Copyright (c) 2025 ctrl-alt-automate
+Copyright (c) 2026 ctrl-alt-automate
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/PowerNetbox.psd1
+++ b/PowerNetbox.psd1
@@ -322,11 +322,11 @@ PrivateData = @{
         # IconUri = ''
 
         # ReleaseNotes of this module
-        ReleaseNotes = 'v4.4.9 - PowerNetbox Release (matches Netbox 4.4.9)
-- Full Netbox 4.4.9 compatibility
-- Netbox 4.4.9 is a bugfix release with no breaking API changes
-- 494+ public functions with 100% API coverage
-- 946 unit tests, 79 integration tests
+        ReleaseNotes = 'v4.4.10 - PowerNetbox Release (matches Netbox 4.4.10)
+- Full Netbox 4.4.10 compatibility
+- New bridge_interfaces field on Interface API (read-only, automatic)
+- 498+ public functions with 100% API coverage
+- 952 unit tests, 94 integration tests
 - Cross-platform support (Windows, Linux, macOS)
 - Docker-based CI/CD integration testing'
 

--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@
 [![Tests](https://github.com/ctrl-alt-automate/PowerNetbox/actions/workflows/test.yml/badge.svg)](https://github.com/ctrl-alt-automate/PowerNetbox/actions/workflows/test.yml)
 [![Lint](https://github.com/ctrl-alt-automate/PowerNetbox/actions/workflows/pssa.yml/badge.svg)](https://github.com/ctrl-alt-automate/PowerNetbox/actions/workflows/pssa.yml)
 [![License](https://img.shields.io/github/license/ctrl-alt-automate/PowerNetbox)](LICENSE)
-[![Netbox Version](https://img.shields.io/badge/Netbox-4.4.9-blue?logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZmlsbD0id2hpdGUiIGQ9Ik0xMiAyTDIgN2wxMCA1IDEwLTV6TTIgMTdsMTAgNSAxMC01TTIgMTJsMTAgNSAxMC01Ii8+PC9zdmc+)](https://github.com/netbox-community/netbox)
+[![Netbox Version](https://img.shields.io/badge/Netbox-4.4.10-blue?logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZmlsbD0id2hpdGUiIGQ9Ik0xMiAyTDIgN2wxMCA1IDEwLTV6TTIgMTdsMTAgNSAxMC01TTIgMTJsMTAgNSAxMC01Ii8+PC9zdmc+)](https://github.com/netbox-community/netbox)
 [![Integration Tests](https://github.com/ctrl-alt-automate/PowerNetbox/actions/workflows/integration.yml/badge.svg)](https://github.com/ctrl-alt-automate/PowerNetbox/actions/workflows/integration.yml)
 
-**The** comprehensive PowerShell module for the [Netbox](https://github.com/netbox-community/netbox) REST API with **100% coverage**. Fully compatible with **Netbox 4.4.9**.
+**The** comprehensive PowerShell module for the [Netbox](https://github.com/netbox-community/netbox) REST API with **100% coverage**. Fully compatible with **Netbox 4.4.10**.
 
 ---
 
@@ -253,7 +253,7 @@ Import-Module PowerNetbox
 |----------|----------------|
 | PowerShell Desktop | 5.1 |
 | PowerShell Core | 7.0+ |
-| Netbox | 4.1+ (tested with 4.4.9) |
+| Netbox | 4.1+ (tested with 4.4.10) |
 
 > **Version Compatibility:** See the [Compatibility Guide](https://github.com/ctrl-alt-automate/PowerNetbox/wiki/Compatibility) for detailed information about supported Netbox versions and API differences.
 
@@ -282,6 +282,13 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 Original copyright (c) 2018 Ben Claussen. Fork maintained by ctrl-alt-automate.
 
 ## Changelog
+
+### v4.4.10.0
+
+- **Full Netbox 4.4.10 compatibility** - Tested with latest stable release
+- **New bridge_interfaces field** - Interface API now returns reverse bridge relationships (read-only)
+- **498 public functions** with 100% API coverage
+- **952 unit tests, 94 integration tests**
 
 ### v4.4.9.3
 


### PR DESCRIPTION
## Summary

- Verified full compatibility with Netbox 4.4.10 (released January 6, 2026)
- Tested against plasma-paint.exe.xyz running Netbox 4.4.10
- New `bridge_interfaces` field on Interface API response works automatically (read-only)
- **No code changes required** - PowerNetbox handles the new field transparently
- Updated module version to 4.4.10.0
- Updated copyright year to 2026

## Netbox 4.4.10 Changes Verified

| Change | Impact | Status |
|--------|--------|--------|
| Interface reverse bridge relationships (#20953) | New `bridge_interfaces` field in response | ✅ Works |
| Enhanced error reporting (#21071) | Server errors include method & URL | ✅ Works |
| Various bug fixes | No API changes | ✅ Works |

## Test Results

Tested against `plasma-paint.exe.xyz` (Netbox 4.4.10):
- ✅ Connect-NBAPI
- ✅ Get-NBVersion (returns 4.4.10)
- ✅ Get-NBDCIMInterface (includes bridge_interfaces field)
- ✅ All CRUD operations functional

## Test plan

- [ ] CI passes on all platforms
- [ ] Integration tests pass against Netbox 4.4.x

🤖 Generated with [Claude Code](https://claude.com/claude-code)