### PR TITLE
fix: Add Content-Type check for improved proxy error handling (#154)

### DIFF
--- a/Tests/CrossPlatform.Tests.ps1
+++ b/Tests/CrossPlatform.Tests.ps1
@@ -268,12 +268,14 @@ Describe "GetNetboxAPIErrorBody Cross-Platform" -Tag 'CrossPlatform', 'Helper' {
         }
     }
 
-    It "Should return empty string for unknown response types" {
+    It "Should return object with empty body for unknown response types" {
         InModuleScope -ModuleName 'PowerNetbox' {
             # Pass an object that is neither HttpWebResponse nor HttpResponseMessage
             $unknownResponse = [PSCustomObject]@{ StatusCode = 403 }
             $result = GetNetboxAPIErrorBody -Response $unknownResponse
-            $result | Should -Be ''
+            $result | Should -Not -BeNullOrEmpty
+            $result.Body | Should -BeNullOrEmpty
+            $result.IsJson | Should -BeFalse
         }
     }
 }


### PR DESCRIPTION
## Summary
- Enhanced `GetNetboxAPIErrorBody` to return Content-Type and detect JSON vs HTML
- Added `ExtractHtmlErrorMessage` helper for proxy HTML error pages
- Improved error messages for proxy errors (nginx, Cloudflare, HAProxy, Apache, Varnish)
- Added 11 new tests for HTML extraction and Content-Type detection

## Problem
When a proxy (nginx, HAProxy, Cloudflare) returns an HTML error page (502/503/504), the error handling assumed JSON and produced unclear error messages like truncated HTML or generic parse failures.

## Changes

### GetNetboxAPIErrorBody
Now returns `PSCustomObject` with:
- `Body`: The response body content
- `ContentType`: The Content-Type header value
- `IsJson`: Boolean indicating if response is JSON (by header or content inspection)

### InvokeNetboxRequest
Updated error handling to:
1. Check `IsJson` flag before attempting JSON parse
2. For HTML responses, use `ExtractHtmlErrorMessage` helper
3. For other content types, show raw body (if short) or generic message

### ExtractHtmlErrorMessage
New helper that:
- Extracts `<title>` or `<h1>` from HTML
- Detects proxy signatures (nginx, Cloudflare, HAProxy, Apache, Varnish)
- Provides helpful context-specific messages

## Example improvements

| Before | After |
|--------|-------|
| `<!DOCTYPE html><html>...` (truncated) | `Proxy error: 502 Bad Gateway` |
| Empty or generic error | `nginx proxy error (HTTP 502) - The backend server may be unavailable` |
| JSON parse failure warning | `Cloudflare proxy error (HTTP 503) - The backend server may be unreachable` |

## Test plan
- [x] New HTML Error Extraction tests (6 tests)
- [x] New Content-Type Detection tests (5 tests)
- [x] All existing ErrorHandling tests pass
- [x] Module builds successfully

Fixes #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)