### PR TITLE
fix(#164): PowerShell Core 7.x error message extraction

### DIFF
--- a/Tests/Helpers.Tests.ps1
+++ b/Tests/Helpers.Tests.ps1
@@ -626,6 +626,54 @@ Describe "Helpers tests" -Tag 'Core', 'Helpers' {
                 }
             }
         }
+
+        It "Should parse JSON error body from ErrorDetails.Message (PowerShell Core fix)" {
+            # Issue #164: In PowerShell Core 7.x, the response body is available in ErrorDetails.Message
+            # because HttpResponseMessage is disposed before we can read it from Exception.Response
+            InModuleScope -ModuleName 'PowerNetbox' {
+                # Create an error that simulates PowerShell Core behavior with ErrorDetails populated
+                Mock -CommandName 'Invoke-RestMethod' -MockWith {
+                    # PowerShell way to create error with ErrorDetails
+                    $errorMsg = '{"address": ["Duplicate IP address found in global table"]}'
+                    Write-Error -Message "Bad Request" -ErrorId "WebCmdletWebResponseException" -Category InvalidOperation -ErrorAction Stop -TargetObject $errorMsg
+                }
+
+                $URI = BuildNewURI -Segments 'ipam', 'ip-addresses' -SkipConnectedCheck
+                $body = @{ address = '10.0.0.1/24' }
+
+                $thrownError = $null
+                try {
+                    InvokeNetboxRequest -URI $URI -Method POST -Body $body
+                } catch {
+                    $thrownError = $_
+                }
+
+                # Verify an error was thrown
+                $thrownError | Should -Not -BeNullOrEmpty
+            }
+        }
+
+        It "Should parse JSON error with detail field" {
+            # Test that 'detail' field is correctly extracted from JSON errors
+            InModuleScope -ModuleName 'PowerNetbox' {
+                Mock -CommandName 'Invoke-RestMethod' -MockWith {
+                    throw [System.Exception]::new('{"detail": "Authentication credentials were not provided."}')
+                }
+
+                $URI = BuildNewURI -Segments 'dcim', 'devices' -SkipConnectedCheck
+
+                $thrownError = $null
+                try {
+                    InvokeNetboxRequest -URI $URI
+                } catch {
+                    $thrownError = $_
+                }
+
+                $thrownError | Should -Not -BeNullOrEmpty
+                # The message should contain the parsed detail
+                $thrownError.Exception.Message | Should -Match "Authentication credentials"
+            }
+        }
     }
 
     Context "InvokeNetboxRequest Branch Context" {


### PR DESCRIPTION
## Summary

Fixes #164: PowerShell Core 7.x does not show the correct error message from Netbox API responses.

**Root Cause:** In PowerShell Core 7.x, `HttpResponseMessage` is disposed before we can read the response body from `$_.Exception.Response`. The error body is available in `$_.ErrorDetails.Message` instead.

**Changes:**
- Check `$_.ErrorDetails.Message` first (PowerShell Core 7.x behavior)
- Fall back to `$_.Exception.Response` for Windows PowerShell 5.1
- Simplified JSON/HTML error parsing logic
- Added unit tests for error parsing

## Test Plan

- [x] Unit tests pass (67 helper tests)
- [x] IPAM tests pass (105 tests)
- [ ] Integration test against live Netbox 4.x with duplicate IP address error

## Before/After

**Before (PowerShell 7.x):**
```
Response status code does not indicate success: 400 (BAD REQUEST).
```

**After (PowerShell 7.x):**
```
address: Duplicate IP address found in global table
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)