### PR TITLE
fix: Correct malformed verbose messages in 27 functions (#201)

### DIFF
--- a/Functions/DCIM/ModuleTypeProfiles/New-NBDCIMModuleTypeProfile.ps1
+++ b/Functions/DCIM/ModuleTypeProfiles/New-NBDCIMModuleTypeProfile.ps1
@@ -29,7 +29,7 @@ function New-NBDCIMModuleTypeProfile {
         [switch]$Raw
     )
     process {
-        Write-Verbose "Creating DCIM Module TypeP ro fi le"
+        Write-Verbose "Creating DCIM Module Type Profile"
         $Segments = [System.Collections.ArrayList]::new(@('dcim','module-type-profiles'))
         $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw'
         if ($PSCmdlet.ShouldProcess($Name, 'Create module type profile')) {

--- a/Functions/DCIM/ModuleTypeProfiles/Remove-NBDCIMModuleTypeProfile.ps1
+++ b/Functions/DCIM/ModuleTypeProfiles/Remove-NBDCIMModuleTypeProfile.ps1
@@ -25,7 +25,7 @@ function Remove-NBDCIMModuleTypeProfile {
         [switch]$Raw
     )
     process {
-        Write-Verbose "Removing DCIM Module TypeP ro fi le"
+        Write-Verbose "Removing DCIM Module Type Profile"
         if ($PSCmdlet.ShouldProcess($Id, 'Delete module type profile')) {
             InvokeNetboxRequest -URI (BuildNewURI -Segments @('dcim','module-type-profiles',$Id)) -Method DELETE -Raw:$Raw
         }

--- a/Functions/DCIM/ModuleTypeProfiles/Set-NBDCIMModuleTypeProfile.ps1
+++ b/Functions/DCIM/ModuleTypeProfiles/Set-NBDCIMModuleTypeProfile.ps1
@@ -30,7 +30,7 @@ function Set-NBDCIMModuleTypeProfile {
         [switch]$Raw
     )
     process {
-        Write-Verbose "Updating DCIM Module TypeP ro fi le"
+        Write-Verbose "Updating DCIM Module Type Profile"
         $Segments = [System.Collections.ArrayList]::new(@('dcim','module-type-profiles',$Id))
         $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id','Raw'
         if ($PSCmdlet.ShouldProcess($Id, 'Update module type profile')) {

--- a/Functions/DCIM/RackReservations/New-NBDCIMRackReservation.ps1
+++ b/Functions/DCIM/RackReservations/New-NBDCIMRackReservation.ps1
@@ -32,7 +32,7 @@ function New-NBDCIMRackReservation {
         [switch]$Raw
     )
     process {
-        Write-Verbose "Creating DCIM RackR es er va ti on"
+        Write-Verbose "Creating DCIM Rack Reservation"
         $Segments = [System.Collections.ArrayList]::new(@('dcim','rack-reservations'))
         $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw'
         if ($PSCmdlet.ShouldProcess("Rack $Rack", 'Create rack reservation')) {

--- a/Functions/DCIM/RackReservations/Remove-NBDCIMRackReservation.ps1
+++ b/Functions/DCIM/RackReservations/Remove-NBDCIMRackReservation.ps1
@@ -25,7 +25,7 @@ function Remove-NBDCIMRackReservation {
         [switch]$Raw
     )
     process {
-        Write-Verbose "Removing DCIM RackR es er va ti on"
+        Write-Verbose "Removing DCIM Rack Reservation"
         if ($PSCmdlet.ShouldProcess($Id, 'Delete rack reservation')) {
             InvokeNetboxRequest -URI (BuildNewURI -Segments @('dcim','rack-reservations',$Id)) -Method DELETE -Raw:$Raw
         }

--- a/Functions/DCIM/RackReservations/Set-NBDCIMRackReservation.ps1
+++ b/Functions/DCIM/RackReservations/Set-NBDCIMRackReservation.ps1
@@ -33,7 +33,7 @@ function Set-NBDCIMRackReservation {
         [switch]$Raw
     )
     process {
-        Write-Verbose "Updating DCIM RackR es er va ti on"
+        Write-Verbose "Updating DCIM Rack Reservation"
         $Segments = [System.Collections.ArrayList]::new(@('dcim','rack-reservations',$Id))
         $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id','Raw'
         if ($PSCmdlet.ShouldProcess($Id, 'Update rack reservation')) {

--- a/Functions/DCIM/RackRoles/New-NBDCIMRackRole.ps1
+++ b/Functions/DCIM/RackRoles/New-NBDCIMRackRole.ps1
@@ -30,7 +30,7 @@ function New-NBDCIMRackRole {
         [switch]$Raw
     )
     process {
-        Write-Verbose "Creating DCIM RackR ol e"
+        Write-Verbose "Creating DCIM Rack Role"
         $Segments = [System.Collections.ArrayList]::new(@('dcim','rack-roles'))
         $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw'
         if ($PSCmdlet.ShouldProcess($Name, 'Create rack role')) {

--- a/Functions/DCIM/RackRoles/Remove-NBDCIMRackRole.ps1
+++ b/Functions/DCIM/RackRoles/Remove-NBDCIMRackRole.ps1
@@ -25,7 +25,7 @@ function Remove-NBDCIMRackRole {
         [switch]$Raw
     )
     process {
-        Write-Verbose "Removing DCIM RackR ol e"
+        Write-Verbose "Removing DCIM Rack Role"
         if ($PSCmdlet.ShouldProcess($Id, 'Delete rack role')) {
             InvokeNetboxRequest -URI (BuildNewURI -Segments @('dcim','rack-roles',$Id)) -Method DELETE -Raw:$Raw
         }

--- a/Functions/DCIM/RackRoles/Set-NBDCIMRackRole.ps1
+++ b/Functions/DCIM/RackRoles/Set-NBDCIMRackRole.ps1
@@ -31,7 +31,7 @@ function Set-NBDCIMRackRole {
         [switch]$Raw
     )
     process {
-        Write-Verbose "Updating DCIM RackR ol e"
+        Write-Verbose "Updating DCIM Rack Role"
         $Segments = [System.Collections.ArrayList]::new(@('dcim','rack-roles',$Id))
         $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id','Raw'
         if ($PSCmdlet.ShouldProcess($Id, 'Update rack role')) {

--- a/Functions/DCIM/RackTypes/New-NBDCIMRackType.ps1
+++ b/Functions/DCIM/RackTypes/New-NBDCIMRackType.ps1
@@ -42,7 +42,7 @@ function New-NBDCIMRackType {
         [switch]$Raw
     )
     process {
-        Write-Verbose "Creating DCIM RackT yp e"
+        Write-Verbose "Creating DCIM Rack Type"
         $Segments = [System.Collections.ArrayList]::new(@('dcim','rack-types'))
         $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw'
         if ($PSCmdlet.ShouldProcess($Model, 'Create rack type')) {

--- a/Functions/DCIM/RackTypes/Remove-NBDCIMRackType.ps1
+++ b/Functions/DCIM/RackTypes/Remove-NBDCIMRackType.ps1
@@ -25,7 +25,7 @@ function Remove-NBDCIMRackType {
         [switch]$Raw
     )
     process {
-        Write-Verbose "Removing DCIM RackT yp e"
+        Write-Verbose "Removing DCIM Rack Type"
         if ($PSCmdlet.ShouldProcess($Id, 'Delete rack type')) {
             InvokeNetboxRequest -URI (BuildNewURI -Segments @('dcim','rack-types',$Id)) -Method DELETE -Raw:$Raw
         }

--- a/Functions/DCIM/RackTypes/Set-NBDCIMRackType.ps1
+++ b/Functions/DCIM/RackTypes/Set-NBDCIMRackType.ps1
@@ -43,7 +43,7 @@ function Set-NBDCIMRackType {
         [switch]$Raw
     )
     process {
-        Write-Verbose "Updating DCIM RackT yp e"
+        Write-Verbose "Updating DCIM Rack Type"
         $Segments = [System.Collections.ArrayList]::new(@('dcim','rack-types',$Id))
         $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id','Raw'
         if ($PSCmdlet.ShouldProcess($Id, 'Update rack type')) {

--- a/Functions/DCIM/RearPortTemplates/New-NBDCIMRearPortTemplate.ps1
+++ b/Functions/DCIM/RearPortTemplates/New-NBDCIMRearPortTemplate.ps1
@@ -32,7 +32,7 @@ function New-NBDCIMRearPortTemplate {
         [switch]$Raw
     )
     process {
-        Write-Verbose "Creating DCIM Rear PortT em pl at e"
+        Write-Verbose "Creating DCIM Rear Port Template"
         $Segments = [System.Collections.ArrayList]::new(@('dcim','rear-port-templates'))
         $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw'
         if ($PSCmdlet.ShouldProcess($Name, 'Create rear port template')) {

--- a/Functions/DCIM/RearPortTemplates/Remove-NBDCIMRearPortTemplate.ps1
+++ b/Functions/DCIM/RearPortTemplates/Remove-NBDCIMRearPortTemplate.ps1
@@ -25,7 +25,7 @@ function Remove-NBDCIMRearPortTemplate {
         [switch]$Raw
     )
     process {
-        Write-Verbose "Removing DCIM Rear PortT em pl at e"
+        Write-Verbose "Removing DCIM Rear Port Template"
         if ($PSCmdlet.ShouldProcess($Id, 'Delete rear port template')) {
             InvokeNetboxRequest -URI (BuildNewURI -Segments @('dcim','rear-port-templates',$Id)) -Method DELETE -Raw:$Raw
         }

--- a/Functions/DCIM/RearPortTemplates/Set-NBDCIMRearPortTemplate.ps1
+++ b/Functions/DCIM/RearPortTemplates/Set-NBDCIMRearPortTemplate.ps1
@@ -33,7 +33,7 @@ function Set-NBDCIMRearPortTemplate {
         [switch]$Raw
     )
     process {
-        Write-Verbose "Updating DCIM Rear PortT em pl at e"
+        Write-Verbose "Updating DCIM Rear Port Template"
         $Segments = [System.Collections.ArrayList]::new(@('dcim','rear-port-templates',$Id))
         $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id','Raw'
         if ($PSCmdlet.ShouldProcess($Id, 'Update rear port template')) {

--- a/Functions/DCIM/SiteGroups/New-NBDCIMSiteGroup.ps1
+++ b/Functions/DCIM/SiteGroups/New-NBDCIMSiteGroup.ps1
@@ -63,7 +63,7 @@ function New-NBDCIMSiteGroup {
     )
 
     process {
-        Write-Verbose "Creating DCIM SiteG ro up"
+        Write-Verbose "Creating DCIM Site Group"
         $Segments = [System.Collections.ArrayList]::new(@('dcim', 'site-groups'))
 
         $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw'

--- a/Functions/DCIM/SiteGroups/Remove-NBDCIMSiteGroup.ps1
+++ b/Functions/DCIM/SiteGroups/Remove-NBDCIMSiteGroup.ps1
@@ -34,7 +34,7 @@ function Remove-NBDCIMSiteGroup {
     )
 
     process {
-        Write-Verbose "Removing DCIM SiteG ro up"
+        Write-Verbose "Removing DCIM Site Group"
         $Segments = [System.Collections.ArrayList]::new(@('dcim', 'site-groups', $Id))
 
         $URI = BuildNewURI -Segments $Segments

--- a/Functions/DCIM/SiteGroups/Set-NBDCIMSiteGroup.ps1
+++ b/Functions/DCIM/SiteGroups/Set-NBDCIMSiteGroup.ps1
@@ -64,7 +64,7 @@ function Set-NBDCIMSiteGroup {
     )
 
     process {
-        Write-Verbose "Updating DCIM SiteG ro up"
+        Write-Verbose "Updating DCIM Site Group"
         $Segments = [System.Collections.ArrayList]::new(@('dcim', 'site-groups', $Id))
 
         $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw'

--- a/Functions/IPAM/VLANGroup/New-NBIPAMVLANGroup.ps1
+++ b/Functions/IPAM/VLANGroup/New-NBIPAMVLANGroup.ps1
@@ -33,7 +33,7 @@ function New-NBIPAMVLANGroup {
         [switch]$Raw
     )
     process {
-        Write-Verbose "Creating IPAM VLANG ro up"
+        Write-Verbose "Creating IPAM VLAN Group"
         $Segments = [System.Collections.ArrayList]::new(@('ipam','vlan-groups'))
         $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw'
         if ($PSCmdlet.ShouldProcess($Name, 'Create VLAN group')) {

--- a/Functions/IPAM/VLANGroup/Remove-NBIPAMVLANGroup.ps1
+++ b/Functions/IPAM/VLANGroup/Remove-NBIPAMVLANGroup.ps1
@@ -25,7 +25,7 @@ function Remove-NBIPAMVLANGroup {
         [switch]$Raw
     )
     process {
-        Write-Verbose "Removing IPAM VLANG ro up"
+        Write-Verbose "Removing IPAM VLAN Group"
         if ($PSCmdlet.ShouldProcess($Id, 'Delete VLAN group')) {
             InvokeNetboxRequest -URI (BuildNewURI -Segments @('ipam','vlan-groups',$Id)) -Method DELETE -Raw:$Raw
         }

--- a/Functions/IPAM/VLANGroup/Set-NBIPAMVLANGroup.ps1
+++ b/Functions/IPAM/VLANGroup/Set-NBIPAMVLANGroup.ps1
@@ -34,7 +34,7 @@ function Set-NBIPAMVLANGroup {
         [switch]$Raw
     )
     process {
-        Write-Verbose "Updating IPAM VLANG ro up"
+        Write-Verbose "Updating IPAM VLAN Group"
         $Segments = [System.Collections.ArrayList]::new(@('ipam','vlan-groups',$Id))
         $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id','Raw'
         if ($PSCmdlet.ShouldProcess($Id, 'Update VLAN group')) {

--- a/Functions/IPAM/VLANTranslationPolicy/New-NBIPAMVLANTranslationPolicy.ps1
+++ b/Functions/IPAM/VLANTranslationPolicy/New-NBIPAMVLANTranslationPolicy.ps1
@@ -29,7 +29,7 @@ function New-NBIPAMVLANTranslationPolicy {
         [switch]$Raw
     )
     process {
-        Write-Verbose "Creating IPAM VLANT ra ns la ti on Policy"
+        Write-Verbose "Creating IPAM VLAN Translation Policy"
         $Segments = [System.Collections.ArrayList]::new(@('ipam','vlan-translation-policies'))
         $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw'
         if ($PSCmdlet.ShouldProcess($Name, 'Create VLAN translation policy')) {

--- a/Functions/IPAM/VLANTranslationPolicy/Remove-NBIPAMVLANTranslationPolicy.ps1
+++ b/Functions/IPAM/VLANTranslationPolicy/Remove-NBIPAMVLANTranslationPolicy.ps1
@@ -25,7 +25,7 @@ function Remove-NBIPAMVLANTranslationPolicy {
         [switch]$Raw
     )
     process {
-        Write-Verbose "Removing IPAM VLANT ra ns la ti on Policy"
+        Write-Verbose "Removing IPAM VLAN Translation Policy"
         if ($PSCmdlet.ShouldProcess($Id, 'Delete VLAN translation policy')) {
             InvokeNetboxRequest -URI (BuildNewURI -Segments @('ipam','vlan-translation-policies',$Id)) -Method DELETE -Raw:$Raw
         }

--- a/Functions/IPAM/VLANTranslationPolicy/Set-NBIPAMVLANTranslationPolicy.ps1
+++ b/Functions/IPAM/VLANTranslationPolicy/Set-NBIPAMVLANTranslationPolicy.ps1
@@ -30,7 +30,7 @@ function Set-NBIPAMVLANTranslationPolicy {
         [switch]$Raw
     )
     process {
-        Write-Verbose "Updating IPAM VLANT ra ns la ti on Policy"
+        Write-Verbose "Updating IPAM VLAN Translation Policy"
         $Segments = [System.Collections.ArrayList]::new(@('ipam','vlan-translation-policies',$Id))
         $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id','Raw'
         if ($PSCmdlet.ShouldProcess($Id, 'Update VLAN translation policy')) {

--- a/Functions/IPAM/VLANTranslationRule/New-NBIPAMVLANTranslationRule.ps1
+++ b/Functions/IPAM/VLANTranslationRule/New-NBIPAMVLANTranslationRule.ps1
@@ -30,7 +30,7 @@ function New-NBIPAMVLANTranslationRule {
         [switch]$Raw
     )
     process {
-        Write-Verbose "Creating IPAM VLANT ra ns la ti on Ru le"
+        Write-Verbose "Creating IPAM VLAN Translation Rule"
         $Segments = [System.Collections.ArrayList]::new(@('ipam','vlan-translation-rules'))
         $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw'
         if ($PSCmdlet.ShouldProcess("$Local_Vid -> $Remote_Vid", 'Create VLAN translation rule')) {

--- a/Functions/IPAM/VLANTranslationRule/Remove-NBIPAMVLANTranslationRule.ps1
+++ b/Functions/IPAM/VLANTranslationRule/Remove-NBIPAMVLANTranslationRule.ps1
@@ -25,7 +25,7 @@ function Remove-NBIPAMVLANTranslationRule {
         [switch]$Raw
     )
     process {
-        Write-Verbose "Removing IPAM VLANT ra ns la ti on Ru le"
+        Write-Verbose "Removing IPAM VLAN Translation Rule"
         if ($PSCmdlet.ShouldProcess($Id, 'Delete VLAN translation rule')) {
             InvokeNetboxRequest -URI (BuildNewURI -Segments @('ipam','vlan-translation-rules',$Id)) -Method DELETE -Raw:$Raw
         }

--- a/Functions/IPAM/VLANTranslationRule/Set-NBIPAMVLANTranslationRule.ps1
+++ b/Functions/IPAM/VLANTranslationRule/Set-NBIPAMVLANTranslationRule.ps1
@@ -31,7 +31,7 @@ function Set-NBIPAMVLANTranslationRule {
         [switch]$Raw
     )
     process {
-        Write-Verbose "Updating IPAM VLANT ra ns la ti on Ru le"
+        Write-Verbose "Updating IPAM VLAN Translation Rule"
         $Segments = [System.Collections.ArrayList]::new(@('ipam','vlan-translation-rules',$Id))
         $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id','Raw'
         if ($PSCmdlet.ShouldProcess($Id, 'Update VLAN translation rule')) {


### PR DESCRIPTION
## Summary

Fix verbose messages that had incorrect spacing from a previous search-and-replace operation.

## Issue

Fixes #201

## Changes

Fixed 27 files across 9 endpoints:

| Endpoint | Files | Before | After |
|----------|-------|--------|-------|
| ModuleTypeProfiles | 3 | `Module TypeP ro fi le` | `Module Type Profile` |
| RackReservations | 3 | `RackR es er va ti on` | `Rack Reservation` |
| RackRoles | 3 | `RackR ol e` | `Rack Role` |
| RackTypes | 3 | `RackT yp e` | `Rack Type` |
| RearPortTemplates | 3 | `Rear PortT em pl at e` | `Rear Port Template` |
| SiteGroups | 3 | `SiteG ro up` | `Site Group` |
| VLANGroup | 3 | `VLANG ro up` | `VLAN Group` |
| VLANTranslationPolicy | 3 | `VLANT ra ns la ti on Policy` | `VLAN Translation Policy` |
| VLANTranslationRule | 3 | `VLANT ra ns la ti on Ru le` | `VLAN Translation Rule` |

## Test plan

- [x] PSScriptAnalyzer passes
- [x] Pester tests pass (no functional changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)