### PR TITLE
fix: Fix verbose message issues (#192, #218, #197, #216)

### DIFF
--- a/Functions/IPAM/Range/New-NBIPAMAddressRange.ps1
+++ b/Functions/IPAM/Range/New-NBIPAMAddressRange.ps1
@@ -89,7 +89,7 @@ function New-NBIPAMAddressRange {
     )
 
     process {
-        Write-Verbose "Creating IPA MA dd re ss Range"
+        Write-Verbose "Creating IPAM Address Range"
         $Segments = [System.Collections.ArrayList]::new(@('ipam', 'ip-ranges'))
         $Method = 'POST'
 

--- a/Functions/IPAM/Range/Remove-NBIPAMAddressRange.ps1
+++ b/Functions/IPAM/Range/Remove-NBIPAMAddressRange.ps1
@@ -31,7 +31,7 @@ function Remove-NBIPAMAddressRange {
     )
 
     process {
-        Write-Verbose "Removing IPA MA dd re ss Range"
+        Write-Verbose "Removing IPAM Address Range"
         foreach ($Range_Id in $Id) {
             $CurrentRange = Get-NBIPAMAddressRange -Id $Range_Id -ErrorAction Stop
 

--- a/Functions/IPAM/RouteTarget/New-NBIPAMRouteTarget.ps1
+++ b/Functions/IPAM/RouteTarget/New-NBIPAMRouteTarget.ps1
@@ -56,7 +56,7 @@ function New-NBIPAMRouteTarget {
     )
 
     process {
-        Write-Verbose "Creating IPA MR ou te Target"
+        Write-Verbose "Creating IPAM Route Target"
         $Segments = [System.Collections.ArrayList]::new(@('ipam', 'route-targets'))
 
         $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw'

--- a/Functions/IPAM/RouteTarget/Remove-NBIPAMRouteTarget.ps1
+++ b/Functions/IPAM/RouteTarget/Remove-NBIPAMRouteTarget.ps1
@@ -34,7 +34,7 @@ function Remove-NBIPAMRouteTarget {
     )
 
     process {
-        Write-Verbose "Removing IPA MR ou te Target"
+        Write-Verbose "Removing IPAM Route Target"
         $Segments = [System.Collections.ArrayList]::new(@('ipam', 'route-targets', $Id))
 
         $URI = BuildNewURI -Segments $Segments

--- a/Functions/IPAM/RouteTarget/Set-NBIPAMRouteTarget.ps1
+++ b/Functions/IPAM/RouteTarget/Set-NBIPAMRouteTarget.ps1
@@ -59,7 +59,7 @@ function Set-NBIPAMRouteTarget {
     )
 
     process {
-        Write-Verbose "Updating IPA MR ou te Target"
+        Write-Verbose "Updating IPAM Route Target"
         $Segments = [System.Collections.ArrayList]::new(@('ipam', 'route-targets', $Id))
 
         $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw'

--- a/Functions/Plugins/Branching/Branch/Undo-NBBranchMerge.ps1
+++ b/Functions/Plugins/Branching/Branch/Undo-NBBranchMerge.ps1
@@ -38,7 +38,7 @@ function Undo-NBBranchMerge {
     )
 
     process {
-        Write-Verbose "Processing Undo-NBBranch Merge"
+        Write-Verbose "Processing Undo-NBBranchMerge"
         CheckNetboxIsConnected
 
         $Segments = [System.Collections.ArrayList]::new(@('plugins', 'branching', 'branches', $Id, 'revert'))

--- a/Functions/Users/OwnerGroups/Get-NBOwnerGroup.ps1
+++ b/Functions/Users/OwnerGroups/Get-NBOwnerGroup.ps1
@@ -75,6 +75,7 @@ function Get-NBOwnerGroup {
     )
 
     process {
+        Write-Verbose "Retrieving Owner Group"
         switch ($PSCmdlet.ParameterSetName) {
             'ById' {
                 foreach ($i in $Id) {

--- a/Functions/Users/OwnerGroups/New-NBOwnerGroup.ps1
+++ b/Functions/Users/OwnerGroups/New-NBOwnerGroup.ps1
@@ -39,6 +39,7 @@ function New-NBOwnerGroup {
     )
 
     process {
+        Write-Verbose "Creating Owner Group"
         $Segments = [System.Collections.ArrayList]::new(@('users', 'owner-groups'))
         $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw'
         $URI = BuildNewURI -Segments $URIComponents.Segments

--- a/Functions/Users/OwnerGroups/Remove-NBOwnerGroup.ps1
+++ b/Functions/Users/OwnerGroups/Remove-NBOwnerGroup.ps1
@@ -33,6 +33,7 @@ function Remove-NBOwnerGroup {
     )
 
     process {
+        Write-Verbose "Removing Owner Group"
         $Segments = [System.Collections.ArrayList]::new(@('users', 'owner-groups', $Id))
         $URI = BuildNewURI -Segments $Segments
 

--- a/Functions/Users/OwnerGroups/Set-NBOwnerGroup.ps1
+++ b/Functions/Users/OwnerGroups/Set-NBOwnerGroup.ps1
@@ -46,6 +46,7 @@ function Set-NBOwnerGroup {
     )
 
     process {
+        Write-Verbose "Updating Owner Group"
         $Segments = [System.Collections.ArrayList]::new(@('users', 'owner-groups', $Id))
         $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw'
         $URI = BuildNewURI -Segments $URIComponents.Segments

--- a/Functions/Users/Owners/Get-NBOwner.ps1
+++ b/Functions/Users/Owners/Get-NBOwner.ps1
@@ -90,6 +90,7 @@ function Get-NBOwner {
     )
 
     process {
+        Write-Verbose "Retrieving Owner"
         switch ($PSCmdlet.ParameterSetName) {
             'ById' {
                 foreach ($i in $Id) {

--- a/Functions/Users/Owners/New-NBOwner.ps1
+++ b/Functions/Users/Owners/New-NBOwner.ps1
@@ -57,6 +57,7 @@ function New-NBOwner {
     )
 
     process {
+        Write-Verbose "Creating Owner"
         $Segments = [System.Collections.ArrayList]::new(@('users', 'owners'))
         $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw'
         $URI = BuildNewURI -Segments $URIComponents.Segments

--- a/Functions/Users/Owners/Remove-NBOwner.ps1
+++ b/Functions/Users/Owners/Remove-NBOwner.ps1
@@ -33,6 +33,7 @@ function Remove-NBOwner {
     )
 
     process {
+        Write-Verbose "Removing Owner"
         $Segments = [System.Collections.ArrayList]::new(@('users', 'owners', $Id))
         $URI = BuildNewURI -Segments $Segments
 

--- a/Functions/Users/Owners/Set-NBOwner.ps1
+++ b/Functions/Users/Owners/Set-NBOwner.ps1
@@ -61,6 +61,7 @@ function Set-NBOwner {
     )
 
     process {
+        Write-Verbose "Updating Owner"
         $Segments = [System.Collections.ArrayList]::new(@('users', 'owners', $Id))
         $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw'
         $URI = BuildNewURI -Segments $URIComponents.Segments

--- a/Functions/Wireless/WirelessLANGroup/New-NBWirelessLANGroup.ps1
+++ b/Functions/Wireless/WirelessLANGroup/New-NBWirelessLANGroup.ps1
@@ -22,7 +22,7 @@ function New-NBWirelessLANGroup {
     [OutputType([PSCustomObject])]
     param([Parameter(Mandatory = $true)][string]$Name,[Parameter(Mandatory = $true)][string]$Slug,[uint64]$Parent,[string]$Description,[hashtable]$Custom_Fields,[switch]$Raw)
     process {
-        Write-Verbose "Creating Wireless LANGroup"
+        Write-Verbose "Creating Wireless LAN Group"
         $s = [System.Collections.ArrayList]::new(@('wireless','wireless-lan-groups')); $u = BuildURIComponents -URISegments $s.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw'
         if ($PSCmdlet.ShouldProcess($Name, 'Create wireless LAN group')) { InvokeNetboxRequest -URI (BuildNewURI -Segments $u.Segments) -Method POST -Body $u.Parameters -Raw:$Raw }
     }


### PR DESCRIPTION
## Summary

Fixes various verbose message issues across multiple modules.

### Changes

**Malformed IPAM verbose messages (#192):**
- `New-NBIPAMAddressRange`: "IPA MA dd re ss Range" → "IPAM Address Range"
- `Remove-NBIPAMAddressRange`: same fix
- `New/Set/Remove-NBIPAMRouteTarget`: "IPA MR ou te Target" → "IPAM Route Target"

**Branching verbose (#218):**
- `Undo-NBBranchMerge`: "Undo-NBBranch Merge" → "Undo-NBBranchMerge"

**Wireless verbose (#197):**
- `New-NBWirelessLANGroup`: "Wireless LANGroup" → "Wireless LAN Group"

**Missing Write-Verbose in Owner functions (#216):**
- Added `Write-Verbose` to all 8 Owner/OwnerGroup functions:
  - Get/New/Set/Remove-NBOwner
  - Get/New/Set/Remove-NBOwnerGroup

### Test Plan

- [ ] Run functions with `-Verbose` to verify correct messages
- [ ] Verify IPAM Address Range functions show correct verbose output
- [ ] Verify Owner functions now show verbose output

Fixes #192, #218, #197, #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)