### PR TITLE
fix: Support v2 Bearer tokens in Get-NBDCIMRackElevation

### DIFF
--- a/Functions/DCIM/Racks/Get-NBDCIMRackElevation.ps1
+++ b/Functions/DCIM/Racks/Get-NBDCIMRackElevation.ps1
@@ -137,33 +137,8 @@ function Get-NBDCIMRackElevation {
             # Use Invoke-WebRequest directly to get raw SVG string (Invoke-RestMethod parses as XML)
             Write-Verbose "Requesting SVG rendering from Netbox"
 
-            $creds = Get-NBCredential
-            $token = $creds.GetNetworkCredential().Password
-
-            # Detect token format: v2 tokens start with 'nbt_' and use Bearer auth
-            $authHeader = if ($token -match '^nbt_') {
-                "Bearer $token"
-            }
-            else {
-                "Token $token"
-            }
-
-            $headers = @{
-                'Authorization' = $authHeader
-            }
-
-            # Add branch context header if in a branch
-            if ($script:NetboxConfig.BranchStack -and $script:NetboxConfig.BranchStack.Count -gt 0) {
-                $branchContext = $script:NetboxConfig.BranchStack.Peek()
-                $schemaId = if ($branchContext -is [PSCustomObject]) {
-                    $branchContext.SchemaId
-                }
-                else {
-                    $branchContext
-                }
-                $headers['X-NetBox-Branch'] = $schemaId
-                Write-Verbose "Using branch context: $schemaId"
-            }
+            # Get authorization and branch context headers using centralized helper
+            $headers = Get-NBRequestHeaders
 
             $invokeParams = Get-NBInvokeParams
             $splat = @{

--- a/Functions/Helpers/Get-NBRequestHeaders.ps1
+++ b/Functions/Helpers/Get-NBRequestHeaders.ps1
@@ -1,0 +1,98 @@
+function Get-NBRequestHeaders {
+<#
+    .SYNOPSIS
+        Get standard request headers for Netbox API calls
+
+    .DESCRIPTION
+        Returns a hashtable containing the Authorization header (with proper v1/v2 token format)
+        and optionally the X-NetBox-Branch header if a branch context is active.
+
+        This function centralizes header construction to ensure consistent authentication
+        and branch context handling across all API request functions.
+
+    .PARAMETER Branch
+        Optional explicit branch schema_id to use instead of the stack context
+
+    .PARAMETER IncludeBranchContext
+        Whether to include branch context header. Defaults to $true.
+
+    .EXAMPLE
+        $headers = Get-NBRequestHeaders
+        Invoke-WebRequest -Uri $uri -Headers $headers
+
+    .EXAMPLE
+        $headers = Get-NBRequestHeaders -Branch "abc123"
+        # Uses explicit branch instead of stack context
+
+    .EXAMPLE
+        $headers = Get-NBRequestHeaders -IncludeBranchContext:$false
+        # Only returns Authorization header, no branch context
+#>
+
+    [CmdletBinding()]
+    [OutputType([hashtable])]
+    param(
+        [string]$Branch,
+
+        [switch]$IncludeBranchContext = $true
+    )
+
+    $creds = Get-NBCredential
+    $token = $creds.GetNetworkCredential().Password
+
+    # Detect token format: v2 tokens start with 'nbt_' and use Bearer auth
+    $authHeader = if ($token -match '^nbt_') {
+        "Bearer $token"
+    }
+    else {
+        # Legacy v1 token format
+        "Token $token"
+    }
+
+    $headers = @{
+        'Authorization' = $authHeader
+    }
+
+    # Add branch context if requested
+    if ($IncludeBranchContext) {
+        # Determine effective branch context: explicit param > stack context > main
+        $effectiveBranchContext = if ($Branch) {
+            # Explicit -Branch parameter (schema_id string)
+            $Branch
+        }
+        elseif ($script:NetboxConfig.BranchStack -and $script:NetboxConfig.BranchStack.Count -gt 0) {
+            # Get context from stack
+            $script:NetboxConfig.BranchStack.Peek()
+        }
+        else {
+            $null
+        }
+
+        if ($effectiveBranchContext) {
+            # Extract schema_id - handle both object (new) and string (legacy/explicit) formats
+            $schemaId = if ($effectiveBranchContext -is [PSCustomObject]) {
+                if (-not $effectiveBranchContext.SchemaId) {
+                    throw "Invalid branch context object: 'SchemaId' property is missing or empty."
+                }
+                $effectiveBranchContext.SchemaId
+            }
+            else {
+                # Assume it's already a schema_id string (e.g., from -Branch parameter)
+                $effectiveBranchContext
+            }
+
+            $headers['X-NetBox-Branch'] = $schemaId
+
+            # Log with branch name if available, otherwise just schema_id
+            $displayName = if ($effectiveBranchContext -is [PSCustomObject] -and $effectiveBranchContext.Name) {
+                "$($effectiveBranchContext.Name) ($schemaId)"
+            }
+            else {
+                $schemaId
+            }
+            Write-Verbose "Using branch context: $displayName"
+        }
+    }
+
+    return $headers
+}


### PR DESCRIPTION
## Summary
- Detect token format (v1 Token vs v2 Bearer) for SVG rendering requests
- Add branch context header (`X-NetBox-Branch`) support for branching plugin compatibility
- Fixes authentication failures on Netbox 4.5+ when using v2 tokens

Closes #229

## Changes
The `Get-NBDCIMRackElevation` function bypasses `InvokeNetboxRequest` for SVG rendering and was using hardcoded `Token` authentication. This fix:

1. **Token format detection**: v2 tokens (`nbt_*`) now use `Bearer` auth, v1 tokens continue using `Token` auth
2. **Branch context**: SVG rendering now respects the current branch context when using the branching plugin

## Test plan
- [x] Unit tests pass
- [ ] CI integration tests
- [ ] Manual test with v1 token on Netbox 4.4.x
- [ ] Manual test with v2 token on Netbox 4.5.x

🤖 Generated with [Claude Code](https://claude.com/claude-code)