### PR TITLE
docs: Fix template-like example text in function documentation

### DIFF
--- a/Functions/Circuits/Circuits/New-NBCircuit.ps1
+++ b/Functions/Circuits/Circuits/New-NBCircuit.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     New-NBCircuit
 
-    Returns all ircuit objects.
+    Creates a new Circuit object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/Cables/Remove-NBDCIMCable.ps1
+++ b/Functions/DCIM/Cables/Remove-NBDCIMCable.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Remove-NBDCIMCable
 
-    Returns all DCIM Cable objects.
+    Deletes a DCIM Cable object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/ConsolePortTemplates/New-NBDCIMConsolePortTemplate.ps1
+++ b/Functions/DCIM/ConsolePortTemplates/New-NBDCIMConsolePortTemplate.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     New-NBDCIMConsolePortTemplate
 
-    Returns all DCIM ConsolePortTemplate objects.
+    Creates a new DCIM ConsolePortTemplate object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/ConsolePortTemplates/Remove-NBDCIMConsolePortTemplate.ps1
+++ b/Functions/DCIM/ConsolePortTemplates/Remove-NBDCIMConsolePortTemplate.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Remove-NBDCIMConsolePortTemplate
 
-    Returns all DCIM ConsolePortTemplate objects.
+    Deletes a DCIM ConsolePortTemplate object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/ConsolePortTemplates/Set-NBDCIMConsolePortTemplate.ps1
+++ b/Functions/DCIM/ConsolePortTemplates/Set-NBDCIMConsolePortTemplate.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Set-NBDCIMConsolePortTemplate
 
-    Returns all DCIM ConsolePortTemplate objects.
+    Updates an existing DCIM ConsolePortTemplate object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/ConsolePorts/New-NBDCIMConsolePort.ps1
+++ b/Functions/DCIM/ConsolePorts/New-NBDCIMConsolePort.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     New-NBDCIMConsolePort
 
-    Returns all DCIM ConsolePort objects.
+    Creates a new DCIM ConsolePort object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/ConsolePorts/Remove-NBDCIMConsolePort.ps1
+++ b/Functions/DCIM/ConsolePorts/Remove-NBDCIMConsolePort.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Remove-NBDCIMConsolePort
 
-    Returns all DCIM ConsolePort objects.
+    Deletes a DCIM ConsolePort object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/ConsolePorts/Set-NBDCIMConsolePort.ps1
+++ b/Functions/DCIM/ConsolePorts/Set-NBDCIMConsolePort.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Set-NBDCIMConsolePort
 
-    Returns all DCIM ConsolePort objects.
+    Updates an existing DCIM ConsolePort object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/ConsoleServerPortTemplates/New-NBDCIMConsoleServerPortTemplate.ps1
+++ b/Functions/DCIM/ConsoleServerPortTemplates/New-NBDCIMConsoleServerPortTemplate.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     New-NBDCIMConsoleServerPortTemplate
 
-    Returns all DCIM ConsoleServerPortTemplate objects.
+    Creates a new DCIM ConsoleServerPortTemplate object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/ConsoleServerPortTemplates/Remove-NBDCIMConsoleServerPortTemplate.ps1
+++ b/Functions/DCIM/ConsoleServerPortTemplates/Remove-NBDCIMConsoleServerPortTemplate.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Remove-NBDCIMConsoleServerPortTemplate
 
-    Returns all DCIM ConsoleServerPortTemplate objects.
+    Deletes a DCIM ConsoleServerPortTemplate object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/ConsoleServerPortTemplates/Set-NBDCIMConsoleServerPortTemplate.ps1
+++ b/Functions/DCIM/ConsoleServerPortTemplates/Set-NBDCIMConsoleServerPortTemplate.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Set-NBDCIMConsoleServerPortTemplate
 
-    Returns all DCIM ConsoleServerPortTemplate objects.
+    Updates an existing DCIM ConsoleServerPortTemplate object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/ConsoleServerPorts/New-NBDCIMConsoleServerPort.ps1
+++ b/Functions/DCIM/ConsoleServerPorts/New-NBDCIMConsoleServerPort.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     New-NBDCIMConsoleServerPort
 
-    Returns all DCIM ConsoleServerPort objects.
+    Creates a new DCIM ConsoleServerPort object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/ConsoleServerPorts/Remove-NBDCIMConsoleServerPort.ps1
+++ b/Functions/DCIM/ConsoleServerPorts/Remove-NBDCIMConsoleServerPort.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Remove-NBDCIMConsoleServerPort
 
-    Returns all DCIM ConsoleServerPort objects.
+    Deletes a DCIM ConsoleServerPort object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/ConsoleServerPorts/Set-NBDCIMConsoleServerPort.ps1
+++ b/Functions/DCIM/ConsoleServerPorts/Set-NBDCIMConsoleServerPort.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Set-NBDCIMConsoleServerPort
 
-    Returns all DCIM ConsoleServerPort objects.
+    Updates an existing DCIM ConsoleServerPort object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/DeviceBayTemplates/New-NBDCIMDeviceBayTemplate.ps1
+++ b/Functions/DCIM/DeviceBayTemplates/New-NBDCIMDeviceBayTemplate.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     New-NBDCIMDeviceBayTemplate
 
-    Returns all DCIM DeviceBayTemplate objects.
+    Creates a new DCIM DeviceBayTemplate object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/DeviceBayTemplates/Remove-NBDCIMDeviceBayTemplate.ps1
+++ b/Functions/DCIM/DeviceBayTemplates/Remove-NBDCIMDeviceBayTemplate.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Remove-NBDCIMDeviceBayTemplate
 
-    Returns all DCIM DeviceBayTemplate objects.
+    Deletes a DCIM DeviceBayTemplate object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/DeviceBayTemplates/Set-NBDCIMDeviceBayTemplate.ps1
+++ b/Functions/DCIM/DeviceBayTemplates/Set-NBDCIMDeviceBayTemplate.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Set-NBDCIMDeviceBayTemplate
 
-    Returns all DCIM DeviceBayTemplate objects.
+    Updates an existing DCIM DeviceBayTemplate object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/DeviceBays/New-NBDCIMDeviceBay.ps1
+++ b/Functions/DCIM/DeviceBays/New-NBDCIMDeviceBay.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     New-NBDCIMDeviceBay
 
-    Returns all DCIM DeviceBay objects.
+    Creates a new DCIM DeviceBay object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/DeviceBays/Remove-NBDCIMDeviceBay.ps1
+++ b/Functions/DCIM/DeviceBays/Remove-NBDCIMDeviceBay.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Remove-NBDCIMDeviceBay
 
-    Returns all DCIM DeviceBay objects.
+    Deletes a DCIM DeviceBay object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/DeviceBays/Set-NBDCIMDeviceBay.ps1
+++ b/Functions/DCIM/DeviceBays/Set-NBDCIMDeviceBay.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Set-NBDCIMDeviceBay
 
-    Returns all DCIM DeviceBay objects.
+    Updates an existing DCIM DeviceBay object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/Devices/New-NBDCIMDeviceRole.ps1
+++ b/Functions/DCIM/Devices/New-NBDCIMDeviceRole.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     New-NBDCIMDeviceRole
 
-    Returns all DCIM DeviceRole objects.
+    Creates a new DCIM DeviceRole object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/Devices/New-NBDCIMDeviceType.ps1
+++ b/Functions/DCIM/Devices/New-NBDCIMDeviceType.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     New-NBDCIMDeviceType
 
-    Returns all DCIM DeviceType objects.
+    Creates a new DCIM DeviceType object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/Devices/Remove-NBDCIMDeviceRole.ps1
+++ b/Functions/DCIM/Devices/Remove-NBDCIMDeviceRole.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Remove-NBDCIMDeviceRole
 
-    Returns all DCIM DeviceRole objects.
+    Deletes a DCIM DeviceRole object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/Devices/Remove-NBDCIMDeviceType.ps1
+++ b/Functions/DCIM/Devices/Remove-NBDCIMDeviceType.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Remove-NBDCIMDeviceType
 
-    Returns all DCIM DeviceType objects.
+    Deletes a DCIM DeviceType object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/Devices/Set-NBDCIMDeviceRole.ps1
+++ b/Functions/DCIM/Devices/Set-NBDCIMDeviceRole.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Set-NBDCIMDeviceRole
 
-    Returns all DCIM DeviceRole objects.
+    Updates an existing DCIM DeviceRole object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/Devices/Set-NBDCIMDeviceType.ps1
+++ b/Functions/DCIM/Devices/Set-NBDCIMDeviceType.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Set-NBDCIMDeviceType
 
-    Returns all DCIM DeviceType objects.
+    Updates an existing DCIM DeviceType object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/FrontPortTemplates/New-NBDCIMFrontPortTemplate.ps1
+++ b/Functions/DCIM/FrontPortTemplates/New-NBDCIMFrontPortTemplate.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     New-NBDCIMFrontPortTemplate
 
-    Returns all DCIM FrontPortTemplate objects.
+    Creates a new DCIM FrontPortTemplate object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/FrontPortTemplates/Remove-NBDCIMFrontPortTemplate.ps1
+++ b/Functions/DCIM/FrontPortTemplates/Remove-NBDCIMFrontPortTemplate.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Remove-NBDCIMFrontPortTemplate
 
-    Returns all DCIM FrontPortTemplate objects.
+    Deletes a DCIM FrontPortTemplate object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/FrontPortTemplates/Set-NBDCIMFrontPortTemplate.ps1
+++ b/Functions/DCIM/FrontPortTemplates/Set-NBDCIMFrontPortTemplate.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Set-NBDCIMFrontPortTemplate
 
-    Returns all DCIM FrontPortTemplate objects.
+    Updates an existing DCIM FrontPortTemplate object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/FrontPorts/Remove-NBDCIMFrontPort.ps1
+++ b/Functions/DCIM/FrontPorts/Remove-NBDCIMFrontPort.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Remove-NBDCIMFrontPort
 
-    Returns all DCIM FrontPort objects.
+    Deletes a DCIM FrontPort object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/InterfaceTemplates/New-NBDCIMInterfaceTemplate.ps1
+++ b/Functions/DCIM/InterfaceTemplates/New-NBDCIMInterfaceTemplate.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     New-NBDCIMInterfaceTemplate
 
-    Returns all DCIM InterfaceTemplate objects.
+    Creates a new DCIM InterfaceTemplate object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/InterfaceTemplates/Remove-NBDCIMInterfaceTemplate.ps1
+++ b/Functions/DCIM/InterfaceTemplates/Remove-NBDCIMInterfaceTemplate.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Remove-NBDCIMInterfaceTemplate
 
-    Returns all DCIM InterfaceTemplate objects.
+    Deletes a DCIM InterfaceTemplate object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/InterfaceTemplates/Set-NBDCIMInterfaceTemplate.ps1
+++ b/Functions/DCIM/InterfaceTemplates/Set-NBDCIMInterfaceTemplate.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Set-NBDCIMInterfaceTemplate
 
-    Returns all DCIM InterfaceTemplate objects.
+    Updates an existing DCIM InterfaceTemplate object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/Interfaces/Remove-NBDCIMInterfaceConnection.ps1
+++ b/Functions/DCIM/Interfaces/Remove-NBDCIMInterfaceConnection.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Remove-NBDCIMInterfaceConnection
 
-    Returns all DCIM InterfaceConnection objects.
+    Deletes a DCIM InterfaceConnection object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/Interfaces/Set-NBDCIMInterface.ps1
+++ b/Functions/DCIM/Interfaces/Set-NBDCIMInterface.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Set-NBDCIMInterface
 
-    Returns all DCIM Interface objects.
+    Updates an existing DCIM Interface object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/InventoryItemRoles/New-NBDCIMInventoryItemRole.ps1
+++ b/Functions/DCIM/InventoryItemRoles/New-NBDCIMInventoryItemRole.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     New-NBDCIMInventoryItemRole
 
-    Returns all DCIM InventoryItemRole objects.
+    Creates a new DCIM InventoryItemRole object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/InventoryItemRoles/Remove-NBDCIMInventoryItemRole.ps1
+++ b/Functions/DCIM/InventoryItemRoles/Remove-NBDCIMInventoryItemRole.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Remove-NBDCIMInventoryItemRole
 
-    Returns all DCIM InventoryItemRole objects.
+    Deletes a DCIM InventoryItemRole object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/InventoryItemRoles/Set-NBDCIMInventoryItemRole.ps1
+++ b/Functions/DCIM/InventoryItemRoles/Set-NBDCIMInventoryItemRole.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Set-NBDCIMInventoryItemRole
 
-    Returns all DCIM InventoryItemRole objects.
+    Updates an existing DCIM InventoryItemRole object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/InventoryItemTemplates/New-NBDCIMInventoryItemTemplate.ps1
+++ b/Functions/DCIM/InventoryItemTemplates/New-NBDCIMInventoryItemTemplate.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     New-NBDCIMInventoryItemTemplate
 
-    Returns all DCIM InventoryItemTemplate objects.
+    Creates a new DCIM InventoryItemTemplate object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/InventoryItemTemplates/Remove-NBDCIMInventoryItemTemplate.ps1
+++ b/Functions/DCIM/InventoryItemTemplates/Remove-NBDCIMInventoryItemTemplate.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Remove-NBDCIMInventoryItemTemplate
 
-    Returns all DCIM InventoryItemTemplate objects.
+    Deletes a DCIM InventoryItemTemplate object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/InventoryItemTemplates/Set-NBDCIMInventoryItemTemplate.ps1
+++ b/Functions/DCIM/InventoryItemTemplates/Set-NBDCIMInventoryItemTemplate.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Set-NBDCIMInventoryItemTemplate
 
-    Returns all DCIM InventoryItemTemplate objects.
+    Updates an existing DCIM InventoryItemTemplate object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/InventoryItems/New-NBDCIMInventoryItem.ps1
+++ b/Functions/DCIM/InventoryItems/New-NBDCIMInventoryItem.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     New-NBDCIMInventoryItem
 
-    Returns all DCIM InventoryItem objects.
+    Creates a new DCIM InventoryItem object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/InventoryItems/Remove-NBDCIMInventoryItem.ps1
+++ b/Functions/DCIM/InventoryItems/Remove-NBDCIMInventoryItem.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Remove-NBDCIMInventoryItem
 
-    Returns all DCIM InventoryItem objects.
+    Deletes a DCIM InventoryItem object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/InventoryItems/Set-NBDCIMInventoryItem.ps1
+++ b/Functions/DCIM/InventoryItems/Set-NBDCIMInventoryItem.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Set-NBDCIMInventoryItem
 
-    Returns all DCIM InventoryItem objects.
+    Updates an existing DCIM InventoryItem object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/MACAddresses/New-NBDCIMMACAddress.ps1
+++ b/Functions/DCIM/MACAddresses/New-NBDCIMMACAddress.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     New-NBDCIMMACAddress
 
-    Returns all CIMMACAddress objects.
+    Creates a new DCIM MAC Address object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/MACAddresses/Remove-NBDCIMMACAddress.ps1
+++ b/Functions/DCIM/MACAddresses/Remove-NBDCIMMACAddress.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Remove-NBDCIMMACAddress
 
-    Returns all CIMMACAddress objects.
+    Deletes a DCIM MAC Address object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/MACAddresses/Set-NBDCIMMACAddress.ps1
+++ b/Functions/DCIM/MACAddresses/Set-NBDCIMMACAddress.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Set-NBDCIMMACAddress
 
-    Returns all CIMMACAddress objects.
+    Updates an existing DCIM MAC Address object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/ModuleBayTemplates/New-NBDCIMModuleBayTemplate.ps1
+++ b/Functions/DCIM/ModuleBayTemplates/New-NBDCIMModuleBayTemplate.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     New-NBDCIMModuleBayTemplate
 
-    Returns all DCIM ModuleBayTemplate objects.
+    Creates a new DCIM ModuleBayTemplate object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/ModuleBayTemplates/Remove-NBDCIMModuleBayTemplate.ps1
+++ b/Functions/DCIM/ModuleBayTemplates/Remove-NBDCIMModuleBayTemplate.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Remove-NBDCIMModuleBayTemplate
 
-    Returns all DCIM ModuleBayTemplate objects.
+    Deletes a DCIM ModuleBayTemplate object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/ModuleBayTemplates/Set-NBDCIMModuleBayTemplate.ps1
+++ b/Functions/DCIM/ModuleBayTemplates/Set-NBDCIMModuleBayTemplate.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Set-NBDCIMModuleBayTemplate
 
-    Returns all DCIM ModuleBayTemplate objects.
+    Updates an existing DCIM ModuleBayTemplate object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/ModuleBays/New-NBDCIMModuleBay.ps1
+++ b/Functions/DCIM/ModuleBays/New-NBDCIMModuleBay.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     New-NBDCIMModuleBay
 
-    Returns all DCIM ModuleBay objects.
+    Creates a new DCIM ModuleBay object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/ModuleBays/Remove-NBDCIMModuleBay.ps1
+++ b/Functions/DCIM/ModuleBays/Remove-NBDCIMModuleBay.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Remove-NBDCIMModuleBay
 
-    Returns all DCIM ModuleBay objects.
+    Deletes a DCIM ModuleBay object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/ModuleBays/Set-NBDCIMModuleBay.ps1
+++ b/Functions/DCIM/ModuleBays/Set-NBDCIMModuleBay.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Set-NBDCIMModuleBay
 
-    Returns all DCIM ModuleBay objects.
+    Updates an existing DCIM ModuleBay object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/ModuleTypeProfiles/New-NBDCIMModuleTypeProfile.ps1
+++ b/Functions/DCIM/ModuleTypeProfiles/New-NBDCIMModuleTypeProfile.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     New-NBDCIMModuleTypeProfile
 
-    Returns all DCIM ModuleTypeProfile objects.
+    Creates a new DCIM ModuleTypeProfile object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/ModuleTypeProfiles/Remove-NBDCIMModuleTypeProfile.ps1
+++ b/Functions/DCIM/ModuleTypeProfiles/Remove-NBDCIMModuleTypeProfile.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Remove-NBDCIMModuleTypeProfile
 
-    Returns all DCIM ModuleTypeProfile objects.
+    Deletes a DCIM ModuleTypeProfile object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/ModuleTypeProfiles/Set-NBDCIMModuleTypeProfile.ps1
+++ b/Functions/DCIM/ModuleTypeProfiles/Set-NBDCIMModuleTypeProfile.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Set-NBDCIMModuleTypeProfile
 
-    Returns all DCIM ModuleTypeProfile objects.
+    Updates an existing DCIM ModuleTypeProfile object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/ModuleTypes/New-NBDCIMModuleType.ps1
+++ b/Functions/DCIM/ModuleTypes/New-NBDCIMModuleType.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     New-NBDCIMModuleType
 
-    Returns all DCIM ModuleType objects.
+    Creates a new DCIM ModuleType object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/ModuleTypes/Remove-NBDCIMModuleType.ps1
+++ b/Functions/DCIM/ModuleTypes/Remove-NBDCIMModuleType.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Remove-NBDCIMModuleType
 
-    Returns all DCIM ModuleType objects.
+    Deletes a DCIM ModuleType object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/ModuleTypes/Set-NBDCIMModuleType.ps1
+++ b/Functions/DCIM/ModuleTypes/Set-NBDCIMModuleType.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Set-NBDCIMModuleType
 
-    Returns all DCIM ModuleType objects.
+    Updates an existing DCIM ModuleType object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/Modules/New-NBDCIMModule.ps1
+++ b/Functions/DCIM/Modules/New-NBDCIMModule.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     New-NBDCIMModule
 
-    Returns all DCIM Module objects.
+    Creates a new DCIM Module object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/Modules/Remove-NBDCIMModule.ps1
+++ b/Functions/DCIM/Modules/Remove-NBDCIMModule.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Remove-NBDCIMModule
 
-    Returns all DCIM Module objects.
+    Deletes a DCIM Module object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/Modules/Set-NBDCIMModule.ps1
+++ b/Functions/DCIM/Modules/Set-NBDCIMModule.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Set-NBDCIMModule
 
-    Returns all DCIM Module objects.
+    Updates an existing DCIM Module object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/Platforms/New-NBDCIMPlatform.ps1
+++ b/Functions/DCIM/Platforms/New-NBDCIMPlatform.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     New-NBDCIMPlatform
 
-    Returns all DCIM Platform objects.
+    Creates a new DCIM Platform object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/Platforms/Remove-NBDCIMPlatform.ps1
+++ b/Functions/DCIM/Platforms/Remove-NBDCIMPlatform.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Remove-NBDCIMPlatform
 
-    Returns all DCIM Platform objects.
+    Deletes a DCIM Platform object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/Platforms/Set-NBDCIMPlatform.ps1
+++ b/Functions/DCIM/Platforms/Set-NBDCIMPlatform.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Set-NBDCIMPlatform
 
-    Returns all DCIM Platform objects.
+    Updates an existing DCIM Platform object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/PowerFeeds/New-NBDCIMPowerFeed.ps1
+++ b/Functions/DCIM/PowerFeeds/New-NBDCIMPowerFeed.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     New-NBDCIMPowerFeed
 
-    Returns all DCIM PowerFeed objects.
+    Creates a new DCIM PowerFeed object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/PowerFeeds/Remove-NBDCIMPowerFeed.ps1
+++ b/Functions/DCIM/PowerFeeds/Remove-NBDCIMPowerFeed.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Remove-NBDCIMPowerFeed
 
-    Returns all DCIM PowerFeed objects.
+    Deletes a DCIM PowerFeed object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/PowerFeeds/Set-NBDCIMPowerFeed.ps1
+++ b/Functions/DCIM/PowerFeeds/Set-NBDCIMPowerFeed.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Set-NBDCIMPowerFeed
 
-    Returns all DCIM PowerFeed objects.
+    Updates an existing DCIM PowerFeed object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/PowerOutletTemplates/New-NBDCIMPowerOutletTemplate.ps1
+++ b/Functions/DCIM/PowerOutletTemplates/New-NBDCIMPowerOutletTemplate.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     New-NBDCIMPowerOutletTemplate
 
-    Returns all DCIM PowerOutletTemplate objects.
+    Creates a new DCIM PowerOutletTemplate object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/PowerOutletTemplates/Remove-NBDCIMPowerOutletTemplate.ps1
+++ b/Functions/DCIM/PowerOutletTemplates/Remove-NBDCIMPowerOutletTemplate.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Remove-NBDCIMPowerOutletTemplate
 
-    Returns all DCIM PowerOutletTemplate objects.
+    Deletes a DCIM PowerOutletTemplate object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/PowerOutletTemplates/Set-NBDCIMPowerOutletTemplate.ps1
+++ b/Functions/DCIM/PowerOutletTemplates/Set-NBDCIMPowerOutletTemplate.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Set-NBDCIMPowerOutletTemplate
 
-    Returns all DCIM PowerOutletTemplate objects.
+    Updates an existing DCIM PowerOutletTemplate object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/PowerOutlets/New-NBDCIMPowerOutlet.ps1
+++ b/Functions/DCIM/PowerOutlets/New-NBDCIMPowerOutlet.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     New-NBDCIMPowerOutlet
 
-    Returns all DCIM PowerOutlet objects.
+    Creates a new DCIM PowerOutlet object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/PowerOutlets/Remove-NBDCIMPowerOutlet.ps1
+++ b/Functions/DCIM/PowerOutlets/Remove-NBDCIMPowerOutlet.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Remove-NBDCIMPowerOutlet
 
-    Returns all DCIM PowerOutlet objects.
+    Deletes a DCIM PowerOutlet object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/PowerOutlets/Set-NBDCIMPowerOutlet.ps1
+++ b/Functions/DCIM/PowerOutlets/Set-NBDCIMPowerOutlet.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Set-NBDCIMPowerOutlet
 
-    Returns all DCIM PowerOutlet objects.
+    Updates an existing DCIM PowerOutlet object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/PowerPanels/New-NBDCIMPowerPanel.ps1
+++ b/Functions/DCIM/PowerPanels/New-NBDCIMPowerPanel.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     New-NBDCIMPowerPanel
 
-    Returns all DCIM PowerPanel objects.
+    Creates a new DCIM PowerPanel object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/PowerPanels/Remove-NBDCIMPowerPanel.ps1
+++ b/Functions/DCIM/PowerPanels/Remove-NBDCIMPowerPanel.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Remove-NBDCIMPowerPanel
 
-    Returns all DCIM PowerPanel objects.
+    Deletes a DCIM PowerPanel object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/PowerPanels/Set-NBDCIMPowerPanel.ps1
+++ b/Functions/DCIM/PowerPanels/Set-NBDCIMPowerPanel.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Set-NBDCIMPowerPanel
 
-    Returns all DCIM PowerPanel objects.
+    Updates an existing DCIM PowerPanel object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/PowerPortTemplates/New-NBDCIMPowerPortTemplate.ps1
+++ b/Functions/DCIM/PowerPortTemplates/New-NBDCIMPowerPortTemplate.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     New-NBDCIMPowerPortTemplate
 
-    Returns all DCIM PowerPortTemplate objects.
+    Creates a new DCIM PowerPortTemplate object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/PowerPortTemplates/Remove-NBDCIMPowerPortTemplate.ps1
+++ b/Functions/DCIM/PowerPortTemplates/Remove-NBDCIMPowerPortTemplate.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Remove-NBDCIMPowerPortTemplate
 
-    Returns all DCIM PowerPortTemplate objects.
+    Deletes a DCIM PowerPortTemplate object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/PowerPortTemplates/Set-NBDCIMPowerPortTemplate.ps1
+++ b/Functions/DCIM/PowerPortTemplates/Set-NBDCIMPowerPortTemplate.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Set-NBDCIMPowerPortTemplate
 
-    Returns all DCIM PowerPortTemplate objects.
+    Updates an existing DCIM PowerPortTemplate object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/PowerPorts/New-NBDCIMPowerPort.ps1
+++ b/Functions/DCIM/PowerPorts/New-NBDCIMPowerPort.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     New-NBDCIMPowerPort
 
-    Returns all DCIM PowerPort objects.
+    Creates a new DCIM PowerPort object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/PowerPorts/Remove-NBDCIMPowerPort.ps1
+++ b/Functions/DCIM/PowerPorts/Remove-NBDCIMPowerPort.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Remove-NBDCIMPowerPort
 
-    Returns all DCIM PowerPort objects.
+    Deletes a DCIM PowerPort object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/PowerPorts/Set-NBDCIMPowerPort.ps1
+++ b/Functions/DCIM/PowerPorts/Set-NBDCIMPowerPort.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Set-NBDCIMPowerPort
 
-    Returns all DCIM PowerPort objects.
+    Updates an existing DCIM PowerPort object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/RackReservations/New-NBDCIMRackReservation.ps1
+++ b/Functions/DCIM/RackReservations/New-NBDCIMRackReservation.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     New-NBDCIMRackReservation
 
-    Returns all DCIM RackReservation objects.
+    Creates a new DCIM RackReservation object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/RackReservations/Remove-NBDCIMRackReservation.ps1
+++ b/Functions/DCIM/RackReservations/Remove-NBDCIMRackReservation.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Remove-NBDCIMRackReservation
 
-    Returns all DCIM RackReservation objects.
+    Deletes a DCIM RackReservation object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/RackReservations/Set-NBDCIMRackReservation.ps1
+++ b/Functions/DCIM/RackReservations/Set-NBDCIMRackReservation.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Set-NBDCIMRackReservation
 
-    Returns all DCIM RackReservation objects.
+    Updates an existing DCIM RackReservation object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/RackRoles/New-NBDCIMRackRole.ps1
+++ b/Functions/DCIM/RackRoles/New-NBDCIMRackRole.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     New-NBDCIMRackRole
 
-    Returns all DCIM RackRole objects.
+    Creates a new DCIM RackRole object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/RackRoles/Remove-NBDCIMRackRole.ps1
+++ b/Functions/DCIM/RackRoles/Remove-NBDCIMRackRole.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Remove-NBDCIMRackRole
 
-    Returns all DCIM RackRole objects.
+    Deletes a DCIM RackRole object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/RackRoles/Set-NBDCIMRackRole.ps1
+++ b/Functions/DCIM/RackRoles/Set-NBDCIMRackRole.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Set-NBDCIMRackRole
 
-    Returns all DCIM RackRole objects.
+    Updates an existing DCIM RackRole object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/RackTypes/New-NBDCIMRackType.ps1
+++ b/Functions/DCIM/RackTypes/New-NBDCIMRackType.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     New-NBDCIMRackType
 
-    Returns all DCIM RackType objects.
+    Creates a new DCIM RackType object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/RackTypes/Remove-NBDCIMRackType.ps1
+++ b/Functions/DCIM/RackTypes/Remove-NBDCIMRackType.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Remove-NBDCIMRackType
 
-    Returns all DCIM RackType objects.
+    Deletes a DCIM RackType object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/RackTypes/Set-NBDCIMRackType.ps1
+++ b/Functions/DCIM/RackTypes/Set-NBDCIMRackType.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Set-NBDCIMRackType
 
-    Returns all DCIM RackType objects.
+    Updates an existing DCIM RackType object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/RearPortTemplates/New-NBDCIMRearPortTemplate.ps1
+++ b/Functions/DCIM/RearPortTemplates/New-NBDCIMRearPortTemplate.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     New-NBDCIMRearPortTemplate
 
-    Returns all DCIM RearPortTemplate objects.
+    Creates a new DCIM RearPortTemplate object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/RearPortTemplates/Remove-NBDCIMRearPortTemplate.ps1
+++ b/Functions/DCIM/RearPortTemplates/Remove-NBDCIMRearPortTemplate.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Remove-NBDCIMRearPortTemplate
 
-    Returns all DCIM RearPortTemplate objects.
+    Deletes a DCIM RearPortTemplate object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/RearPortTemplates/Set-NBDCIMRearPortTemplate.ps1
+++ b/Functions/DCIM/RearPortTemplates/Set-NBDCIMRearPortTemplate.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Set-NBDCIMRearPortTemplate
 
-    Returns all DCIM RearPortTemplate objects.
+    Updates an existing DCIM RearPortTemplate object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/RearPorts/Remove-NBDCIMRearPort.ps1
+++ b/Functions/DCIM/RearPorts/Remove-NBDCIMRearPort.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Remove-NBDCIMRearPort
 
-    Returns all DCIM RearPort objects.
+    Deletes a DCIM RearPort object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/VirtualChassis/New-NBDCIMVirtualChassis.ps1
+++ b/Functions/DCIM/VirtualChassis/New-NBDCIMVirtualChassis.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     New-NBDCIMVirtualChassis
 
-    Returns all DCIM VirtualChassis objects.
+    Creates a new DCIM VirtualChassis object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/VirtualChassis/Remove-NBDCIMVirtualChassis.ps1
+++ b/Functions/DCIM/VirtualChassis/Remove-NBDCIMVirtualChassis.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Remove-NBDCIMVirtualChassis
 
-    Returns all DCIM VirtualChassis objects.
+    Deletes a DCIM VirtualChassis object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/VirtualChassis/Set-NBDCIMVirtualChassis.ps1
+++ b/Functions/DCIM/VirtualChassis/Set-NBDCIMVirtualChassis.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Set-NBDCIMVirtualChassis
 
-    Returns all DCIM VirtualChassis objects.
+    Updates an existing DCIM VirtualChassis object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/VirtualDeviceContexts/New-NBDCIMVirtualDeviceContext.ps1
+++ b/Functions/DCIM/VirtualDeviceContexts/New-NBDCIMVirtualDeviceContext.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     New-NBDCIMVirtualDeviceContext
 
-    Returns all DCIM VirtualDeviceContext objects.
+    Creates a new DCIM VirtualDeviceContext object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/VirtualDeviceContexts/Remove-NBDCIMVirtualDeviceContext.ps1
+++ b/Functions/DCIM/VirtualDeviceContexts/Remove-NBDCIMVirtualDeviceContext.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Remove-NBDCIMVirtualDeviceContext
 
-    Returns all DCIM VirtualDeviceContext objects.
+    Deletes a DCIM VirtualDeviceContext object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/VirtualDeviceContexts/Set-NBDCIMVirtualDeviceContext.ps1
+++ b/Functions/DCIM/VirtualDeviceContexts/Set-NBDCIMVirtualDeviceContext.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Set-NBDCIMVirtualDeviceContext
 
-    Returns all DCIM VirtualDeviceContext objects.
+    Updates an existing DCIM VirtualDeviceContext object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/Extras/Webhooks/New-NBWebhook.ps1
+++ b/Functions/Extras/Webhooks/New-NBWebhook.ps1
@@ -43,7 +43,9 @@
     Return the raw API response.
 
 .EXAMPLE
-    New-NBWebhook -Name "Slack Notification" -Payload_Url "https://hooks.slack.com/services/xxx"
+    # Create a webhook that sends notifications to a Slack channel
+    $secret = ConvertTo-SecureString "your-webhook-secret" -AsPlainText -Force
+    New-NBWebhook -Name "Slack Notification" -Payload_Url "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX" -Secret $secret
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/IPAM/Aggregate/New-NBIPAMAggregate.ps1
+++ b/Functions/IPAM/Aggregate/New-NBIPAMAggregate.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     New-NBIPAMAggregate
 
-    Returns all IPAM Aggregate objects.
+    Creates a new IPAM Aggregate object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/IPAM/Aggregate/Remove-NBIPAMAggregate.ps1
+++ b/Functions/IPAM/Aggregate/Remove-NBIPAMAggregate.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Remove-NBIPAMAggregate
 
-    Returns all IPAM Aggregate objects.
+    Deletes an IPAM Aggregate object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/IPAM/Aggregate/Set-NBIPAMAggregate.ps1
+++ b/Functions/IPAM/Aggregate/Set-NBIPAMAggregate.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Set-NBIPAMAggregate
 
-    Returns all IPAM Aggregate objects.
+    Updates an existing IPAM Aggregate object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/IPAM/FHRPGroup/New-NBIPAMFHRPGroup.ps1
+++ b/Functions/IPAM/FHRPGroup/New-NBIPAMFHRPGroup.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     New-NBIPAMFHRPGroup
 
-    Returns all IPAM FHRP Group objects.
+    Creates a new IPAM FHRP Group object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/IPAM/FHRPGroup/Remove-NBIPAMFHRPGroup.ps1
+++ b/Functions/IPAM/FHRPGroup/Remove-NBIPAMFHRPGroup.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Remove-NBIPAMFHRPGroup
 
-    Returns all IPAM FHRPGroup objects.
+    Deletes an IPAM FHRP Group object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/IPAM/FHRPGroup/Set-NBIPAMFHRPGroup.ps1
+++ b/Functions/IPAM/FHRPGroup/Set-NBIPAMFHRPGroup.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Set-NBIPAMFHRPGroup
 
-    Returns all IPAM FHRPGroup objects.
+    Updates an existing IPAM FHRP Group object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/IPAM/FHRPGroupAssignment/New-NBIPAMFHRPGroupAssignment.ps1
+++ b/Functions/IPAM/FHRPGroupAssignment/New-NBIPAMFHRPGroupAssignment.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     New-NBIPAMFHRPGroupAssignment
 
-    Returns all IPAM FHRPGroupAssignment objects.
+    Creates a new IPAM FHRP Group Assignment object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/IPAM/FHRPGroupAssignment/Remove-NBIPAMFHRPGroupAssignment.ps1
+++ b/Functions/IPAM/FHRPGroupAssignment/Remove-NBIPAMFHRPGroupAssignment.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Remove-NBIPAMFHRPGroupAssignment
 
-    Returns all IPAM FHRPGroupAssignment objects.
+    Deletes an IPAM FHRP Group Assignment object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/IPAM/FHRPGroupAssignment/Set-NBIPAMFHRPGroupAssignment.ps1
+++ b/Functions/IPAM/FHRPGroupAssignment/Set-NBIPAMFHRPGroupAssignment.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Set-NBIPAMFHRPGroupAssignment
 
-    Returns all IPAM FHRPGroupAssignment objects.
+    Updates an existing IPAM FHRP Group Assignment object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/IPAM/Prefix/Remove-NBIPAMPrefix.ps1
+++ b/Functions/IPAM/Prefix/Remove-NBIPAMPrefix.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Remove-NBIPAMPrefix
 
-    Returns all IPAM Prefix objects.
+    Deletes an IPAM Prefix object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/IPAM/Prefix/Set-NBIPAMPrefix.ps1
+++ b/Functions/IPAM/Prefix/Set-NBIPAMPrefix.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Set-NBIPAMPrefix
 
-    Returns all IPAM Prefix objects.
+    Updates an existing IPAM Prefix object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/IPAM/RIR/New-NBIPAMRIR.ps1
+++ b/Functions/IPAM/RIR/New-NBIPAMRIR.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     New-NBIPAMRIR
 
-    Returns all IPAM RIR objects.
+    Creates a new IPAM RIR object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/IPAM/RIR/Remove-NBIPAMRIR.ps1
+++ b/Functions/IPAM/RIR/Remove-NBIPAMRIR.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Remove-NBIPAMRIR
 
-    Returns all IPAM RIR objects.
+    Deletes an IPAM RIR object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/IPAM/RIR/Set-NBIPAMRIR.ps1
+++ b/Functions/IPAM/RIR/Set-NBIPAMRIR.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Set-NBIPAMRIR
 
-    Returns all IPAM RIR objects.
+    Updates an existing IPAM RIR object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/IPAM/Range/Set-NBIPAMAddressRange.ps1
+++ b/Functions/IPAM/Range/Set-NBIPAMAddressRange.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Set-NBIPAMAddressRange
 
-    Returns all IPAM AddressRange objects.
+    Updates an existing IPAM Address Range object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/IPAM/Role/New-NBIPAMRole.ps1
+++ b/Functions/IPAM/Role/New-NBIPAMRole.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     New-NBIPAMRole
 
-    Returns all IPAM Role objects.
+    Creates a new IPAM Role object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/IPAM/Role/Remove-NBIPAMRole.ps1
+++ b/Functions/IPAM/Role/Remove-NBIPAMRole.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Remove-NBIPAMRole
 
-    Returns all IPAM Role objects.
+    Deletes an IPAM Role object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/IPAM/Role/Set-NBIPAMRole.ps1
+++ b/Functions/IPAM/Role/Set-NBIPAMRole.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Set-NBIPAMRole
 
-    Returns all IPAM Role objects.
+    Updates an existing IPAM Role object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/IPAM/VLAN/Remove-NBIPAMVLAN.ps1
+++ b/Functions/IPAM/VLAN/Remove-NBIPAMVLAN.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Remove-NBIPAMVLAN
 
-    Returns all IPAM VLAN objects.
+    Deletes an IPAM VLAN object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/IPAM/VLAN/Set-NBIPAMVLAN.ps1
+++ b/Functions/IPAM/VLAN/Set-NBIPAMVLAN.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Set-NBIPAMVLAN
 
-    Returns all IPAM VLAN objects.
+    Updates an existing IPAM VLAN object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/IPAM/VLANGroup/New-NBIPAMVLANGroup.ps1
+++ b/Functions/IPAM/VLANGroup/New-NBIPAMVLANGroup.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     New-NBIPAMVLANGroup
 
-    Returns all IPAM VLANGroup objects.
+    Creates a new IPAM VLAN Group object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/IPAM/VLANGroup/Remove-NBIPAMVLANGroup.ps1
+++ b/Functions/IPAM/VLANGroup/Remove-NBIPAMVLANGroup.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Remove-NBIPAMVLANGroup
 
-    Returns all IPAM VLANGroup objects.
+    Deletes an IPAM VLAN Group object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/IPAM/VLANGroup/Set-NBIPAMVLANGroup.ps1
+++ b/Functions/IPAM/VLANGroup/Set-NBIPAMVLANGroup.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Set-NBIPAMVLANGroup
 
-    Returns all IPAM VLANGroup objects.
+    Updates an existing IPAM VLAN Group object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/IPAM/VLANTranslationPolicy/New-NBIPAMVLANTranslationPolicy.ps1
+++ b/Functions/IPAM/VLANTranslationPolicy/New-NBIPAMVLANTranslationPolicy.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     New-NBIPAMVLANTranslationPolicy
 
-    Returns all IPAM VLANTranslationPolicy objects.
+    Creates a new IPAM VLAN Translation Policy object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/IPAM/VLANTranslationPolicy/Remove-NBIPAMVLANTranslationPolicy.ps1
+++ b/Functions/IPAM/VLANTranslationPolicy/Remove-NBIPAMVLANTranslationPolicy.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Remove-NBIPAMVLANTranslationPolicy
 
-    Returns all IPAM VLANTranslationPolicy objects.
+    Deletes an IPAM VLAN Translation Policy object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/IPAM/VLANTranslationPolicy/Set-NBIPAMVLANTranslationPolicy.ps1
+++ b/Functions/IPAM/VLANTranslationPolicy/Set-NBIPAMVLANTranslationPolicy.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Set-NBIPAMVLANTranslationPolicy
 
-    Returns all IPAM VLANTranslationPolicy objects.
+    Updates an existing IPAM VLAN Translation Policy object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/IPAM/VLANTranslationRule/New-NBIPAMVLANTranslationRule.ps1
+++ b/Functions/IPAM/VLANTranslationRule/New-NBIPAMVLANTranslationRule.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     New-NBIPAMVLANTranslationRule
 
-    Returns all IPAM VLANTranslationRule objects.
+    Creates a new IPAM VLAN Translation Rule object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/IPAM/VLANTranslationRule/Remove-NBIPAMVLANTranslationRule.ps1
+++ b/Functions/IPAM/VLANTranslationRule/Remove-NBIPAMVLANTranslationRule.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Remove-NBIPAMVLANTranslationRule
 
-    Returns all IPAM VLANTranslationRule objects.
+    Deletes an IPAM VLAN Translation Rule object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/IPAM/VLANTranslationRule/Set-NBIPAMVLANTranslationRule.ps1
+++ b/Functions/IPAM/VLANTranslationRule/Set-NBIPAMVLANTranslationRule.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Set-NBIPAMVLANTranslationRule
 
-    Returns all IPAM VLANTranslationRule objects.
+    Updates an existing IPAM VLAN Translation Rule object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/Setup/Set-NBCredential.ps1
+++ b/Functions/Setup/Set-NBCredential.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Set-NBCredential
 
-    Returns all redential objects.
+    Sets the Netbox API credential.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/Setup/Set-NBHostName.ps1
+++ b/Functions/Setup/Set-NBHostName.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Set-NBHostName
 
-    Returns all ostName objects.
+    Sets the Netbox API hostname.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/Setup/Set-NBHostPort.ps1
+++ b/Functions/Setup/Set-NBHostPort.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Set-NBHostPort
 
-    Returns all ostPort objects.
+    Sets the Netbox API host port.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/Setup/Set-NBHostScheme.ps1
+++ b/Functions/Setup/Set-NBHostScheme.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Set-NBHostScheme
 
-    Returns all ostScheme objects.
+    Sets the Netbox API host scheme (http or https).
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/Setup/Set-NBInvokeParams.ps1
+++ b/Functions/Setup/Set-NBInvokeParams.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Set-NBInvokeParams
 
-    Returns all nvokeParams objects.
+    Sets additional parameters for Invoke-RestMethod calls.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/Setup/Set-NBTimeout.ps1
+++ b/Functions/Setup/Set-NBTimeout.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Set-NBTimeout
 
-    Returns all imeout objects.
+    Sets the Netbox API request timeout.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/VPN/IKEPolicy/Remove-NBVPNIKEPolicy.ps1
+++ b/Functions/VPN/IKEPolicy/Remove-NBVPNIKEPolicy.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Remove-NBVPNIKEPolicy
 
-    Returns all VPN IKEPolicy objects.
+    Deletes a VPN IKEPolicy object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/VPN/IKEPolicy/Set-NBVPNIKEPolicy.ps1
+++ b/Functions/VPN/IKEPolicy/Set-NBVPNIKEPolicy.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Set-NBVPNIKEPolicy
 
-    Returns all VPN IKEPolicy objects.
+    Updates an existing VPN IKEPolicy object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/VPN/IKEProposal/Remove-NBVPNIKEProposal.ps1
+++ b/Functions/VPN/IKEProposal/Remove-NBVPNIKEProposal.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Remove-NBVPNIKEProposal
 
-    Returns all VPN IKEProposal objects.
+    Deletes a VPN IKEProposal object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/VPN/IKEProposal/Set-NBVPNIKEProposal.ps1
+++ b/Functions/VPN/IKEProposal/Set-NBVPNIKEProposal.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Set-NBVPNIKEProposal
 
-    Returns all VPN IKEProposal objects.
+    Updates an existing VPN IKEProposal object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/VPN/IPSecPolicy/New-NBVPNIPSecPolicy.ps1
+++ b/Functions/VPN/IPSecPolicy/New-NBVPNIPSecPolicy.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     New-NBVPNIPSecPolicy
 
-    Returns all VPN IPSecPolicy objects.
+    Creates a new VPN IPSecPolicy object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/VPN/IPSecPolicy/Remove-NBVPNIPSecPolicy.ps1
+++ b/Functions/VPN/IPSecPolicy/Remove-NBVPNIPSecPolicy.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Remove-NBVPNIPSecPolicy
 
-    Returns all VPN IPSecPolicy objects.
+    Deletes a VPN IPSecPolicy object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/VPN/IPSecPolicy/Set-NBVPNIPSecPolicy.ps1
+++ b/Functions/VPN/IPSecPolicy/Set-NBVPNIPSecPolicy.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Set-NBVPNIPSecPolicy
 
-    Returns all VPN IPSecPolicy objects.
+    Updates an existing VPN IPSecPolicy object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/VPN/IPSecProfile/Remove-NBVPNIPSecProfile.ps1
+++ b/Functions/VPN/IPSecProfile/Remove-NBVPNIPSecProfile.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Remove-NBVPNIPSecProfile
 
-    Returns all VPN IPSecProfile objects.
+    Deletes a VPN IPSecProfile object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/VPN/IPSecProfile/Set-NBVPNIPSecProfile.ps1
+++ b/Functions/VPN/IPSecProfile/Set-NBVPNIPSecProfile.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Set-NBVPNIPSecProfile
 
-    Returns all VPN IPSecProfile objects.
+    Updates an existing VPN IPSecProfile object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/VPN/IPSecProposal/Remove-NBVPNIPSecProposal.ps1
+++ b/Functions/VPN/IPSecProposal/Remove-NBVPNIPSecProposal.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Remove-NBVPNIPSecProposal
 
-    Returns all VPN IPSecProposal objects.
+    Deletes a VPN IPSecProposal object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/VPN/IPSecProposal/Set-NBVPNIPSecProposal.ps1
+++ b/Functions/VPN/IPSecProposal/Set-NBVPNIPSecProposal.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Set-NBVPNIPSecProposal
 
-    Returns all VPN IPSecProposal objects.
+    Updates an existing VPN IPSecProposal object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/VPN/L2VPN/New-NBVPNL2VPN.ps1
+++ b/Functions/VPN/L2VPN/New-NBVPNL2VPN.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     New-NBVPNL2VPN
 
-    Returns all VPN L2VPN objects.
+    Creates a new VPN L2VPN object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/VPN/L2VPN/Remove-NBVPNL2VPN.ps1
+++ b/Functions/VPN/L2VPN/Remove-NBVPNL2VPN.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Remove-NBVPNL2VPN
 
-    Returns all VPN L2VPN objects.
+    Deletes a VPN L2VPN object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/VPN/L2VPN/Set-NBVPNL2VPN.ps1
+++ b/Functions/VPN/L2VPN/Set-NBVPNL2VPN.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Set-NBVPNL2VPN
 
-    Returns all VPN L2VPN objects.
+    Updates an existing VPN L2VPN object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/VPN/L2VPNTermination/New-NBVPNL2VPNTermination.ps1
+++ b/Functions/VPN/L2VPNTermination/New-NBVPNL2VPNTermination.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     New-NBVPNL2VPNTermination
 
-    Returns all VPN L2VPNTermination objects.
+    Creates a new VPN L2VPNTermination object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/VPN/L2VPNTermination/Remove-NBVPNL2VPNTermination.ps1
+++ b/Functions/VPN/L2VPNTermination/Remove-NBVPNL2VPNTermination.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Remove-NBVPNL2VPNTermination
 
-    Returns all VPN L2VPNTermination objects.
+    Deletes a VPN L2VPNTermination object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/VPN/L2VPNTermination/Set-NBVPNL2VPNTermination.ps1
+++ b/Functions/VPN/L2VPNTermination/Set-NBVPNL2VPNTermination.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Set-NBVPNL2VPNTermination
 
-    Returns all VPN L2VPNTermination objects.
+    Updates an existing VPN L2VPNTermination object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/VPN/Tunnel/New-NBVPNTunnel.ps1
+++ b/Functions/VPN/Tunnel/New-NBVPNTunnel.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     New-NBVPNTunnel
 
-    Returns all VPN Tunnel objects.
+    Creates a new VPN Tunnel object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/VPN/Tunnel/Remove-NBVPNTunnel.ps1
+++ b/Functions/VPN/Tunnel/Remove-NBVPNTunnel.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Remove-NBVPNTunnel
 
-    Returns all VPN Tunnel objects.
+    Deletes a VPN Tunnel object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/VPN/Tunnel/Set-NBVPNTunnel.ps1
+++ b/Functions/VPN/Tunnel/Set-NBVPNTunnel.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Set-NBVPNTunnel
 
-    Returns all VPN Tunnel objects.
+    Updates an existing VPN Tunnel object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/VPN/TunnelGroup/Remove-NBVPNTunnelGroup.ps1
+++ b/Functions/VPN/TunnelGroup/Remove-NBVPNTunnelGroup.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Remove-NBVPNTunnelGroup
 
-    Returns all VPN TunnelGroup objects.
+    Deletes a VPN TunnelGroup object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/VPN/TunnelGroup/Set-NBVPNTunnelGroup.ps1
+++ b/Functions/VPN/TunnelGroup/Set-NBVPNTunnelGroup.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Set-NBVPNTunnelGroup
 
-    Returns all VPN TunnelGroup objects.
+    Updates an existing VPN TunnelGroup object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/VPN/TunnelTermination/New-NBVPNTunnelTermination.ps1
+++ b/Functions/VPN/TunnelTermination/New-NBVPNTunnelTermination.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     New-NBVPNTunnelTermination
 
-    Returns all VPN TunnelTermination objects.
+    Creates a new VPN TunnelTermination object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/VPN/TunnelTermination/Remove-NBVPNTunnelTermination.ps1
+++ b/Functions/VPN/TunnelTermination/Remove-NBVPNTunnelTermination.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Remove-NBVPNTunnelTermination
 
-    Returns all VPN TunnelTermination objects.
+    Deletes a VPN TunnelTermination object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/VPN/TunnelTermination/Set-NBVPNTunnelTermination.ps1
+++ b/Functions/VPN/TunnelTermination/Set-NBVPNTunnelTermination.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Set-NBVPNTunnelTermination
 
-    Returns all VPN TunnelTermination objects.
+    Updates an existing VPN TunnelTermination object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/Virtualization/VirtualMachineInterface/Set-NBVirtualMachineInterface.ps1
+++ b/Functions/Virtualization/VirtualMachineInterface/Set-NBVirtualMachineInterface.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Set-NBVirtualMachineInterface
 
-    Returns all irtualMachineInterface objects.
+    Updates an existing Virtual Machine Interface object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/Wireless/WirelessLAN/New-NBWirelessLAN.ps1
+++ b/Functions/Wireless/WirelessLAN/New-NBWirelessLAN.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     New-NBWirelessLAN
 
-    Returns all irelessLAN objects.
+    Creates a new Wireless LAN object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/Wireless/WirelessLAN/Remove-NBWirelessLAN.ps1
+++ b/Functions/Wireless/WirelessLAN/Remove-NBWirelessLAN.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Remove-NBWirelessLAN
 
-    Returns all irelessLAN objects.
+    Deletes a Wireless LAN object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/Wireless/WirelessLAN/Set-NBWirelessLAN.ps1
+++ b/Functions/Wireless/WirelessLAN/Set-NBWirelessLAN.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Set-NBWirelessLAN
 
-    Returns all WirelessLAN objects.
+    Updates an existing Wireless LAN object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/Wireless/WirelessLANGroup/New-NBWirelessLANGroup.ps1
+++ b/Functions/Wireless/WirelessLANGroup/New-NBWirelessLANGroup.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     New-NBWirelessLANGroup
 
-    Returns all irelessLANGroup objects.
+    Creates a new Wireless LAN Group object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/Wireless/WirelessLANGroup/Remove-NBWirelessLANGroup.ps1
+++ b/Functions/Wireless/WirelessLANGroup/Remove-NBWirelessLANGroup.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Remove-NBWirelessLANGroup
 
-    Returns all irelessLANGroup objects.
+    Deletes a Wireless LAN Group object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/Wireless/WirelessLANGroup/Set-NBWirelessLANGroup.ps1
+++ b/Functions/Wireless/WirelessLANGroup/Set-NBWirelessLANGroup.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Set-NBWirelessLANGroup
 
-    Returns all irelessLANGroup objects.
+    Updates an existing Wireless LAN Group object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/Wireless/WirelessLink/New-NBWirelessLink.ps1
+++ b/Functions/Wireless/WirelessLink/New-NBWirelessLink.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     New-NBWirelessLink
 
-    Returns all irelessLink objects.
+    Creates a new Wireless Link object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/Wireless/WirelessLink/Remove-NBWirelessLink.ps1
+++ b/Functions/Wireless/WirelessLink/Remove-NBWirelessLink.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Remove-NBWirelessLink
 
-    Returns all irelessLink objects.
+    Deletes a Wireless Link object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/Wireless/WirelessLink/Set-NBWirelessLink.ps1
+++ b/Functions/Wireless/WirelessLink/Set-NBWirelessLink.ps1
@@ -12,7 +12,7 @@
 .EXAMPLE
     Set-NBWirelessLink
 
-    Returns all irelessLink objects.
+    Updates an existing Wireless Link object.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/


### PR DESCRIPTION
## Summary
- Fix "Returns all X objects" template text in 173 New/Set/Remove functions
- Replace with accurate descriptions (Creates/Updates/Deletes)
- Update webhook example URL with clearer placeholder

## Affected Modules
- DCIM (majority of functions)
- IPAM
- VPN
- Wireless
- Circuits
- Setup
- Virtualization

## Test plan
- [ ] Verify `Get-Help New-NBDCIMDevice` shows correct description
- [ ] Verify `Get-Help Set-NBVPNTunnel` shows correct description

Fixes #236, fixes #244

🤖 Generated with [Claude Code](https://claude.com/claude-code)