### PR TITLE
fix: Use Stack[object] for BranchStack type consistency

### DIFF
--- a/Functions/Setup/Support/SetupNetboxConfigVariable.ps1
+++ b/Functions/Setup/Support/SetupNetboxConfigVariable.ps1
@@ -14,7 +14,7 @@ function SetupNetboxConfigVariable {
             }
             'APIDefinition' = $null
             'ContentTypes' = $null
-            'BranchStack'   = [System.Collections.Generic.Stack[string]]::new()
+            'BranchStack'   = [System.Collections.Generic.Stack[object]]::new()
         }
     }
 


### PR DESCRIPTION
## Summary
Fix type inconsistency where `SetupNetboxConfigVariable.ps1` created `Stack[string]` but `Enter-NBBranch.ps1` expects `Stack[object]` for branch context objects.

## Problem
- `SetupNetboxConfigVariable.ps1:17` initializes `BranchStack` as `Stack[string]`
- `Enter-NBBranch.ps1:100` reinitializes as `Stack[object]` to store branch context objects with `Name`, `SchemaId`, and `Id` properties

## Solution
Update initialization to use `Stack[object]` from the start, eliminating the need for runtime type checking and reinitialization.

## Test plan
- [ ] Run branching integration tests
- [ ] Verify `Enter-NBBranch` works without reinitialization

Fixes #238

🤖 Generated with [Claude Code](https://claude.com/claude-code)