### PR TITLE
fix: Add input validation for URL segments in BuildNewURI

### DIFF
--- a/Functions/Helpers/BuildNewURI.ps1
+++ b/Functions/Helpers/BuildNewURI.ps1
@@ -48,9 +48,9 @@ function BuildNewURI {
 
     # Validate and sanitize segments (defense-in-depth)
     $sanitizedSegments = $Segments.ForEach({
-        $segment = $_.trim('/').trim()
-        # Warn if segment contains unexpected characters (not alphanumeric, hyphen, underscore, or digits)
-        if ($segment -and $segment -notmatch '^[\w\-]+$') {
+        $segment = ([string]$_).trim('/').trim()
+        # Warn if segment contains characters other than alphanumeric, underscore, or hyphen
+        if ($segment -and $segment -notmatch '^[a-zA-Z0-9_-]+$') {
             Write-Warning "URI segment contains unexpected characters: $segment"
         }
         $segment


### PR DESCRIPTION
## Summary
Add defense-in-depth validation for URI segments in `BuildNewURI.ps1`.

## Changes
- Validate segments match pattern `[\w\-]+` (alphanumeric, hyphen, underscore)
- Log warning for unexpected characters (non-breaking)
- Segments are still sanitized by trimming slashes/whitespace

## Rationale
While segments typically come from hardcoded values in functions, this provides an additional safety layer. The validation:
- Warns about unexpected characters but doesn't break functionality
- Helps catch potential issues during development
- Follows defense-in-depth security practices

## Test plan
- [ ] Run existing unit tests
- [ ] Verify normal API calls work without warnings
- [ ] Test that ID-based segments (numeric) work correctly

Fixes #239

🤖 Generated with [Claude Code](https://claude.com/claude-code)