### PR TITLE
test: Add pagination parameter tests for VPN and Wireless

### DIFF
--- a/Tests/VPN.Tests.ps1
+++ b/Tests/VPN.Tests.ps1
@@ -465,4 +465,60 @@ Describe "VPN Module Tests" -Tag 'VPN' {
         }
     }
     #endregion
+
+    #region Pagination Parameter Tests
+    Context "VPN Get- Functions Pagination Support" {
+        It "Get-NBVPNIKEPolicy should have -All parameter" {
+            $cmd = Get-Command Get-NBVPNIKEPolicy
+            $cmd.Parameters.Keys | Should -Contain 'All'
+            $cmd.Parameters['All'].ParameterType.Name | Should -Be 'SwitchParameter'
+        }
+
+        It "Get-NBVPNIKEPolicy should have -PageSize parameter" {
+            $cmd = Get-Command Get-NBVPNIKEPolicy
+            $cmd.Parameters.Keys | Should -Contain 'PageSize'
+            $cmd.Parameters['PageSize'].ParameterType.Name | Should -Be 'Int32'
+        }
+
+        It "Get-NBVPNIKEProposal should have -All parameter" {
+            $cmd = Get-Command Get-NBVPNIKEProposal
+            $cmd.Parameters.Keys | Should -Contain 'All'
+        }
+
+        It "Get-NBVPNIPSecPolicy should have -All parameter" {
+            $cmd = Get-Command Get-NBVPNIPSecPolicy
+            $cmd.Parameters.Keys | Should -Contain 'All'
+        }
+
+        It "Get-NBVPNIPSecProfile should have -All parameter" {
+            $cmd = Get-Command Get-NBVPNIPSecProfile
+            $cmd.Parameters.Keys | Should -Contain 'All'
+        }
+
+        It "Get-NBVPNIPSecProposal should have -All parameter" {
+            $cmd = Get-Command Get-NBVPNIPSecProposal
+            $cmd.Parameters.Keys | Should -Contain 'All'
+        }
+
+        It "Get-NBVPNL2VPN should have -All parameter" {
+            $cmd = Get-Command Get-NBVPNL2VPN
+            $cmd.Parameters.Keys | Should -Contain 'All'
+        }
+
+        It "Get-NBVPNL2VPNTermination should have -All parameter" {
+            $cmd = Get-Command Get-NBVPNL2VPNTermination
+            $cmd.Parameters.Keys | Should -Contain 'All'
+        }
+
+        It "Get-NBVPNTunnelGroup should have -All parameter" {
+            $cmd = Get-Command Get-NBVPNTunnelGroup
+            $cmd.Parameters.Keys | Should -Contain 'All'
+        }
+
+        It "Get-NBVPNTunnelTermination should have -All parameter" {
+            $cmd = Get-Command Get-NBVPNTunnelTermination
+            $cmd.Parameters.Keys | Should -Contain 'All'
+        }
+    }
+    #endregion
 }

--- a/Tests/Wireless.Tests.ps1
+++ b/Tests/Wireless.Tests.ps1
@@ -314,4 +314,40 @@ Describe "Wireless Module Tests" -Tag 'Wireless' {
         }
     }
     #endregion
+
+    #region Pagination Parameter Tests
+    Context "Wireless Get- Functions Pagination Support" {
+        It "Get-NBWirelessLAN should have -All parameter" {
+            $cmd = Get-Command Get-NBWirelessLAN
+            $cmd.Parameters.Keys | Should -Contain 'All'
+            $cmd.Parameters['All'].ParameterType.Name | Should -Be 'SwitchParameter'
+        }
+
+        It "Get-NBWirelessLAN should have -PageSize parameter" {
+            $cmd = Get-Command Get-NBWirelessLAN
+            $cmd.Parameters.Keys | Should -Contain 'PageSize'
+            $cmd.Parameters['PageSize'].ParameterType.Name | Should -Be 'Int32'
+        }
+
+        It "Get-NBWirelessLANGroup should have -All parameter" {
+            $cmd = Get-Command Get-NBWirelessLANGroup
+            $cmd.Parameters.Keys | Should -Contain 'All'
+        }
+
+        It "Get-NBWirelessLANGroup should have -PageSize parameter" {
+            $cmd = Get-Command Get-NBWirelessLANGroup
+            $cmd.Parameters.Keys | Should -Contain 'PageSize'
+        }
+
+        It "Get-NBWirelessLink should have -All parameter" {
+            $cmd = Get-Command Get-NBWirelessLink
+            $cmd.Parameters.Keys | Should -Contain 'All'
+        }
+
+        It "Get-NBWirelessLink should have -PageSize parameter" {
+            $cmd = Get-Command Get-NBWirelessLink
+            $cmd.Parameters.Keys | Should -Contain 'PageSize'
+        }
+    }
+    #endregion
 }


### PR DESCRIPTION
## Summary
- Adds tests to verify `-All` and `-PageSize` parameters exist on VPN and Wireless Get- functions
- These parameters were added in PR #250

## Tests Added

**VPN Module (+10 tests):**
- Get-NBVPNIKEPolicy
- Get-NBVPNIKEProposal
- Get-NBVPNIPSecPolicy
- Get-NBVPNIPSecProfile
- Get-NBVPNIPSecProposal
- Get-NBVPNL2VPN
- Get-NBVPNL2VPNTermination
- Get-NBVPNTunnelGroup
- Get-NBVPNTunnelTermination

**Wireless Module (+6 tests):**
- Get-NBWirelessLAN
- Get-NBWirelessLANGroup
- Get-NBWirelessLink

## Test Results
- VPN: 64 tests (was 54)
- Wireless: 47 tests (was 41)
- All passing

## Test plan
- [x] Pester tests pass locally
- [ ] CI tests pass

Addresses #240

🤖 Generated with [Claude Code](https://claude.com/claude-code)