### PR TITLE
Remove obsolete Form_Factor parameter from interface functions

### DIFF
--- a/Functions/DCIM/Interfaces/Get-NBDCIMInterface.ps1
+++ b/Functions/DCIM/Interfaces/Get-NBDCIMInterface.ps1
@@ -39,8 +39,6 @@ function Get-NBDCIMInterface {
 
         [string]$Name,
 
-        [object]$Form_Factor,
-
         [bool]$Enabled,
 
         [uint16]$MTU,

--- a/Functions/DCIM/Interfaces/New-NBDCIMInterface.ps1
+++ b/Functions/DCIM/Interfaces/New-NBDCIMInterface.ps1
@@ -109,9 +109,6 @@ function New-NBDCIMInterface {
         [bool]$Enabled,
 
         [Parameter(ParameterSetName = 'Single')]
-        [object]$Form_Factor,
-
-        [Parameter(ParameterSetName = 'Single')]
         [ValidateRange(1, 65535)]
         [uint16]$MTU,
 
@@ -197,7 +194,6 @@ function New-NBDCIMInterface {
                         'mgmt_only' { $key = 'mgmt_only' }
                         'untagged_vlan' { $key = 'untagged_vlan' }
                         'tagged_vlans' { $key = 'tagged_vlans' }
-                        'form_factor' { $key = 'form_factor' }
                     }
 
                     # Convert Mode friendly names

--- a/Functions/DCIM/Interfaces/New-NBDCIMInterface.ps1
+++ b/Functions/DCIM/Interfaces/New-NBDCIMInterface.ps1
@@ -188,14 +188,6 @@ function New-NBDCIMInterface {
                     $key = $prop.Name.ToLower()
                     $value = $prop.Value
 
-                    # Handle property name mappings
-                    switch ($key) {
-                        'mac_address' { $key = 'mac_address' }
-                        'mgmt_only' { $key = 'mgmt_only' }
-                        'untagged_vlan' { $key = 'untagged_vlan' }
-                        'tagged_vlans' { $key = 'tagged_vlans' }
-                    }
-
                     # Convert Mode friendly names
                     if ($key -eq 'mode' -and $value -is [string]) {
                         $value = switch ($value) {

--- a/Functions/DCIM/Interfaces/Set-NBDCIMInterface.ps1
+++ b/Functions/DCIM/Interfaces/Set-NBDCIMInterface.ps1
@@ -33,8 +33,6 @@ function Set-NBDCIMInterface {
 
         [bool]$Enabled,
 
-        [object]$Form_Factor,
-
         [ValidateSet('virtual', 'bridge', 'lag', '100base-tx', '1000base-t', '2.5gbase-t', '5gbase-t', '10gbase-t', '10gbase-cx4', '1000base-x-gbic', '1000base-x-sfp', '10gbase-x-sfpp', '10gbase-x-xfp', '10gbase-x-xenpak', '10gbase-x-x2', '25gbase-x-sfp28', '50gbase-x-sfp56', '40gbase-x-qsfpp', '50gbase-x-sfp28', '100gbase-x-cfp', '100gbase-x-cfp2', '200gbase-x-cfp2', '100gbase-x-cfp4', '100gbase-x-cpak', '100gbase-x-qsfp28', '200gbase-x-qsfp56', '400gbase-x-qsfpdd', '400gbase-x-osfp', '1000base-kx', '10gbase-kr', '10gbase-kx4', '25gbase-kr', '40gbase-kr4', '50gbase-kr', '100gbase-kp4', '100gbase-kr2', '100gbase-kr4', 'ieee802.11a', 'ieee802.11g', 'ieee802.11n', 'ieee802.11ac', 'ieee802.11ad', 'ieee802.11ax', 'ieee802.11ay', 'ieee802.15.1', 'other-wireless', 'gsm', 'cdma', 'lte', 'sonet-oc3', 'sonet-oc12', 'sonet-oc48', 'sonet-oc192', 'sonet-oc768', 'sonet-oc1920', 'sonet-oc3840', '1gfc-sfp', '2gfc-sfp', '4gfc-sfp', '8gfc-sfpp', '16gfc-sfpp', '32gfc-sfp28', '64gfc-qsfpp', '128gfc-qsfp28', 'infiniband-sdr', 'infiniband-ddr', 'infiniband-qdr', 'infiniband-fdr10', 'infiniband-fdr', 'infiniband-edr', 'infiniband-hdr', 'infiniband-ndr', 'infiniband-xdr', 't1', 'e1', 't3', 'e3', 'xdsl', 'docsis', 'gpon', 'xg-pon', 'xgs-pon', 'ng-pon2', 'epon', '10g-epon', 'cisco-stackwise', 'cisco-stackwise-plus', 'cisco-flexstack', 'cisco-flexstack-plus', 'cisco-stackwise-80', 'cisco-stackwise-160', 'cisco-stackwise-320', 'cisco-stackwise-480', 'juniper-vcp', 'extreme-summitstack', 'extreme-summitstack-128', 'extreme-summitstack-256', 'extreme-summitstack-512', 'other', IgnoreCase = $true)]
         [string]$Type,
 

--- a/Tests/DCIM.Interfaces.Tests.ps1
+++ b/Tests/DCIM.Interfaces.Tests.ps1
@@ -63,17 +63,14 @@ Describe "DCIM Interfaces Tests" -Tag 'DCIM', 'Interfaces' {
             $Result.Uri | Should -BeExactly 'https://netbox.domain.com/api/dcim/interfaces/?enabled=True'
         }
 
-        It "Should request with a form factor name" {
-            $Result = Get-NBDCIMInterface -Form_Factor '10GBASE-T (10GE)'
-            # Form factor is passed through to API as-is (no client-side validation)
-            $Result.Uri | Should -Match 'form_factor='
+        It "Should request with a type filter" {
+            $Result = Get-NBDCIMInterface -Type '10gbase-t'
+            $Result.Uri | Should -Match 'type=10gbase-t'
         }
 
-        It "Should pass invalid form factor to API" {
-            # Invalid values are now passed through to the API
-            $Result = Get-NBDCIMInterface -Form_Factor 'Fake'
-            $Result.Method | Should -Be 'GET'
-            $Result.Uri | Should -Match 'form_factor=Fake'
+        It "Should throw for invalid type" {
+            # Type parameter has ValidateSet - invalid values throw at parameter binding
+            { Get-NBDCIMInterface -Type 'Fake' } | Should -Throw
         }
 
         It "Should request devices that are mgmt only" {
@@ -107,7 +104,7 @@ Describe "DCIM Interfaces Tests" -Tag 'DCIM', 'Interfaces' {
             $params = @{
                 Device      = 123
                 Name        = "TestInterface"
-                Form_Factor = '10GBASE-T (10GE)'
+                Type        = '10gbase-t'
                 MTU         = 9000
                 MGMT_Only   = $true
                 Description = 'Test Description'
@@ -119,6 +116,7 @@ Describe "DCIM Interfaces Tests" -Tag 'DCIM', 'Interfaces' {
             $bodyObj = $Result.Body | ConvertFrom-Json
             $bodyObj.name | Should -Be 'TestInterface'
             $bodyObj.device | Should -Be 123
+            $bodyObj.type | Should -Be '10gbase-t'
             $bodyObj.mtu | Should -Be 9000
             $bodyObj.mgmt_only | Should -Be $true
             $bodyObj.description | Should -Be 'Test Description'
@@ -165,10 +163,9 @@ Describe "DCIM Interfaces Tests" -Tag 'DCIM', 'Interfaces' {
             $Result.Uri | Should -BeExactly 'https://netbox.domain.com/api/dcim/interfaces/1234/', 'https://netbox.domain.com/api/dcim/interfaces/4231/'
         }
 
-        It "Should pass invalid form factor to API" {
-            # Invalid values are now passed through to the API
-            $Result = Set-NBDCIMInterface -Id 1234 -Form_Factor 'fake'
-            $Result.Method | Should -Be 'PATCH'
+        It "Should throw for invalid type" {
+            # Type parameter has ValidateSet - invalid values throw at parameter binding
+            { Set-NBDCIMInterface -Id 1234 -Type 'fake' } | Should -Throw
         }
     }
 


### PR DESCRIPTION
## Summary
- Remove `[object]$Form_Factor` from Get/New/Set-NBDCIMInterface
- Parameter was obsolete: Netbox 4.x uses `type` not `form_factor`
- All functions already have `$Type` parameter with ValidateSet
- Update tests to use Type parameter instead of Form_Factor
- Reduces `[object]` parameter count from 10 to 7

## Changes
| File | Change |
|------|--------|
| Get-NBDCIMInterface.ps1 | Remove Form_Factor parameter |
| New-NBDCIMInterface.ps1 | Remove Form_Factor parameter and bulk handling |
| Set-NBDCIMInterface.ps1 | Remove Form_Factor parameter |
| DCIM.Interfaces.Tests.ps1 | Update tests to use Type instead of Form_Factor |

## Test plan
- [x] All 28 DCIM.Interfaces tests pass
- [x] ValidateSet on Type parameter throws for invalid values

## Related
Partial fix for #237

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)