### PR TITLE
ci: Migrate to netbox-docker 4.0.0 for Netbox 4.5.2

### DIFF
--- a/.github/workflows/branching-integration.yml
+++ b/.github/workflows/branching-integration.yml
@@ -34,7 +34,7 @@ on:
       netbox_version:
         description: 'Netbox Docker image tag (e.g., v4.5.0-3.4.2)'
         required: false
-        default: 'v4.5.0-3.4.2'
+        default: 'v4.5.2-4.0.0'
         type: string
       branching_version:
         description: 'Branching plugin version (e.g., 0.8.0)'
@@ -54,9 +54,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Netbox 4.5.x with branching 0.8.0
-          - netbox: "v4.5.0-3.4.2"
-            netbox_short: "4.5.0"
+          # Netbox 4.5.x with branching 0.8.0 (netbox-docker 4.0.0)
+          - netbox: "v4.5.2-4.0.0"
+            netbox_short: "4.5.2"
             branching: "0.8.0"
 
     env:

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -20,7 +20,7 @@ on:
       test_versions:
         description: 'Netbox versions to test (comma-separated)'
         required: false
-        default: '4.3.7,4.4.10,4.5.0'
+        default: '4.3.7,4.4.10,4.5.2'
         type: string
       include_beta:
         description: 'Include beta/pre-release versions'
@@ -62,8 +62,9 @@ jobs:
           # - Token v2 with Bearer auth (#102)
           # - New: cable-profiles, authentication-check (#103, #105)
           # - New fields: VM.interface_count, Token.allowed_ips (#106)
-          - netbox: "v4.5.0-3.4.2"
-            netbox_short: "4.5.0"
+          # Docker 4.0.0: Granian web server, PostgreSQL 18, Valkey 9
+          - netbox: "v4.5.2-4.0.0"
+            netbox_short: "4.5.2"
             is_beta: false
             expected_failures: []
 
@@ -127,11 +128,8 @@ jobs:
           else
             echo "V1 token failed (HTTP $RESPONSE) - creating v2 token for Netbox 4.5.0+"
 
-            # Create a v2 token by generating it ourselves (don't rely on save() return value)
-            # This approach generates the key and plaintext manually, hashes it, and saves
+            # Create a v2 token using Netbox's Token model
             TOKEN_OUTPUT=$(docker exec powernetbox-netbox-1 /opt/netbox/venv/bin/python /opt/netbox/netbox/manage.py shell -c "
-          import secrets
-          from django.contrib.auth.hashers import make_password
           from users.models import Token
           from django.contrib.auth import get_user_model
 
@@ -143,17 +141,14 @@ jobs:
           # Delete existing tokens
           Token.objects.filter(user=user).delete()
 
-          # Generate token components ourselves (same logic as Netbox 4.5 Token model)
-          key = secrets.token_urlsafe(16)[:12]  # 12 char key
-          plaintext = secrets.token_urlsafe(48)[:40]  # 40 char secret
-          hashed = make_password(plaintext)
-
-          # Create and save token with pre-generated values
-          token = Token(user=user, key=key, hashed=hashed)
+          # Create token instance and use the proper Token API
+          token = Token(user=user)
+          secret = Token.generate()  # Static method for random secret
+          token.token = secret       # Property setter triggers key + HMAC digest
           token.save()
 
-          # Output the full token
-          print(f'nbt_{key}.{plaintext}')
+          # Output the full v2 token: nbt_{key}.{secret}
+          print(f'nbt_{token.key}.{secret}')
           " 2>&1 | grep -E '^nbt_' || true)
 
             if [ -n "$TOKEN_OUTPUT" ] && [[ "$TOKEN_OUTPUT" == nbt_* ]]; then
@@ -460,11 +455,11 @@ jobs:
           echo "" >> compatibility-report.md
           echo "Generated: $(date -u '+%Y-%m-%d %H:%M:%S UTC')" >> compatibility-report.md
           echo "" >> compatibility-report.md
-          echo "| Test | 4.3.7 | 4.4.10 | 4.5.0 |" >> compatibility-report.md
+          echo "| Test | 4.3.7 | 4.4.10 | 4.5.2 |" >> compatibility-report.md
           echo "|------|-------|--------|-------|" >> compatibility-report.md
 
           # Parse results from each version
-          for version in 4.3.7 4.4.10 4.5.0; do
+          for version in 4.3.7 4.4.10 4.5.2; do
             if [ -f "results/compatibility-$version/compatibility-results-$version.json" ]; then
               echo "Found results for $version"
               cat "results/compatibility-$version/compatibility-results-$version.json"

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -25,9 +25,9 @@ on:
   workflow_dispatch:
     inputs:
       netbox_version:
-        description: 'Netbox Docker image tag (e.g., v4.5.0-3.4.2)'
+        description: 'Netbox Docker image tag (e.g., v4.5.2-4.0.0)'
         required: false
-        default: 'v4.5.0-3.4.2'
+        default: 'v4.5.2-4.0.0'
         type: string
   # Run weekly to catch upstream Netbox changes
   schedule:
@@ -69,10 +69,10 @@ jobs:
             experimental: false
 
           # ----------------------------------------------------------
-          # Latest version - Netbox 4.5.0
+          # Latest version - Netbox 4.5.2 (netbox-docker 4.0.0)
           # ----------------------------------------------------------
-          - netbox: "v4.5.0-3.4.2"
-            netbox_short: "4.5.0"
+          - netbox: "v4.5.2-4.0.0"
+            netbox_short: "4.5.2"
             experimental: false
 
     env:

--- a/.github/workflows/pre-release-validation.yml
+++ b/.github/workflows/pre-release-validation.yml
@@ -609,9 +609,9 @@ jobs:
           # Stable version
           - netbox: "v4.4.10-3.4.2"
             netbox_short: "4.4.10"
-          # Latest version
-          - netbox: "v4.5.0-3.4.2"
-            netbox_short: "4.5.0"
+          # Latest version (netbox-docker 4.0.0)
+          - netbox: "v4.5.2-4.0.0"
+            netbox_short: "4.5.2"
 
     env:
       NETBOX_VERSION: ${{ matrix.netbox }}
@@ -939,7 +939,7 @@ jobs:
           $nbStatus = if ($skipIntegration) { 'SKIP' } elseif ($integration -eq 'success') { 'OK' } else { '?' }
           [void]$sb.AppendLine("| 4.3.7 | $nbStatus |")
           [void]$sb.AppendLine("| 4.4.10 | $nbStatus |")
-          [void]$sb.AppendLine("| 4.5.0 | $nbStatus |")
+          [void]$sb.AppendLine("| 4.5.2 | $nbStatus |")
           [void]$sb.AppendLine("")
           [void]$sb.AppendLine("---")
           [void]$sb.AppendLine("")

--- a/Dockerfile.branching
+++ b/Dockerfile.branching
@@ -6,16 +6,16 @@
 # netbox-branching plugin from NetboxLabs for CI integration testing.
 #
 # Usage:
-#   docker build --build-arg NETBOX_VERSION=v4.5.0-3.4.2 \
+#   docker build --build-arg NETBOX_VERSION=v4.5.2-4.0.0 \
 #                --build-arg BRANCHING_VERSION=0.8.0 \
 #                -f Dockerfile.branching -t netbox-branching .
 #
 # Compatibility Matrix:
-#   - Netbox 4.5.x: branching 0.7.4+ or 0.8.0
-#   - Netbox 4.4.x: branching 0.7.2, 0.7.3, 0.7.4, 0.8.0
-#   - Netbox 4.3.x: branching 0.5.7, 0.6.0, 0.6.1, 0.6.2
+#   - Netbox 4.5.x: branching 0.7.4+ or 0.8.0 (netbox-docker 4.0.0)
+#   - Netbox 4.4.x: branching 0.7.2, 0.7.3, 0.7.4, 0.8.0 (netbox-docker 3.x)
+#   - Netbox 4.3.x: branching 0.5.7, 0.6.0, 0.6.1, 0.6.2 (netbox-docker 3.x)
 
-ARG NETBOX_VERSION=v4.5.0-3.4.2
+ARG NETBOX_VERSION=v4.5.2-4.0.0
 FROM netboxcommunity/netbox:${NETBOX_VERSION}
 
 # Branching plugin version - must match Netbox version per compatibility matrix


### PR DESCRIPTION
## Summary

Migrate all CI workflows to use netbox-docker 4.0.0 for testing against Netbox 4.5.2.

## Changes

| File | Change |
|------|--------|
| `integration.yml` | v4.5.0-3.4.2 → v4.5.2-4.0.0 |
| `pre-release-validation.yml` | v4.5.0-3.4.2 → v4.5.2-4.0.0 |
| `compatibility.yml` | v4.5.0-3.4.2 → v4.5.2-4.0.0 + v2 token fix |
| `branching-integration.yml` | v4.5.0-3.4.2 → v4.5.2-4.0.0 |
| `Dockerfile.branching` | Update default version and docs |

## netbox-docker 4.0.0 Breaking Changes

- **Web server**: Nginx Unit → Granian
- **PostgreSQL**: v17 → v18
- **Valkey**: v8 → v9
- **Compatibility**: Only supports Netbox 4.5.x+

## Test Results

Integration workflow passed on feature branch:

| Netbox | Docker | Status |
|--------|--------|--------|
| 4.3.7 | 3.3.0 | ✅ Pass |
| 4.4.10 | 3.4.2 | ✅ Pass |
| 4.5.2 | 4.0.0 | ✅ Pass |

## Related Issues

Closes #254
Related to #253 (Netbox 4.5.2 support)

🤖 Generated with [Claude Code](https://claude.ai/code)