### PR TITLE
feat: Add -Omit parameter to all Get functions

### DIFF
--- a/Functions/Circuits/CircuitGroupAssignments/Get-NBCircuitGroupAssignment.ps1
+++ b/Functions/Circuits/CircuitGroupAssignments/Get-NBCircuitGroupAssignment.ps1
@@ -45,6 +45,9 @@ function Get-NBCircuitGroupAssignment {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'ById', ValueFromPipelineByPropertyName = $true)]
         [uint64[]]$Id,
 

--- a/Functions/Circuits/CircuitGroups/Get-NBCircuitGroup.ps1
+++ b/Functions/Circuits/CircuitGroups/Get-NBCircuitGroup.ps1
@@ -48,6 +48,9 @@ function Get-NBCircuitGroup {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'ById', ValueFromPipelineByPropertyName = $true)]
         [uint64[]]$Id,
 

--- a/Functions/Circuits/Circuits/Get-NBCircuit.ps1
+++ b/Functions/Circuits/Circuits/Get-NBCircuit.ps1
@@ -75,6 +75,9 @@ function Get-NBCircuit {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'ById')]
         [uint64[]]$Id,
 

--- a/Functions/Circuits/ProviderAccounts/Get-NBCircuitProviderAccount.ps1
+++ b/Functions/Circuits/ProviderAccounts/Get-NBCircuitProviderAccount.ps1
@@ -48,6 +48,9 @@ function Get-NBCircuitProviderAccount {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'ById', ValueFromPipelineByPropertyName = $true)]
         [uint64[]]$Id,
 

--- a/Functions/Circuits/ProviderNetworks/Get-NBCircuitProviderNetwork.ps1
+++ b/Functions/Circuits/ProviderNetworks/Get-NBCircuitProviderNetwork.ps1
@@ -45,6 +45,9 @@ function Get-NBCircuitProviderNetwork {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'ById', ValueFromPipelineByPropertyName = $true)]
         [uint64[]]$Id,
 

--- a/Functions/Circuits/Providers/Get-NBCircuitProvider.ps1
+++ b/Functions/Circuits/Providers/Get-NBCircuitProvider.ps1
@@ -28,6 +28,9 @@ function Get-NBCircuitProvider {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'ById',
                    Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
         [uint64[]]$Id,

--- a/Functions/Circuits/Terminations/Get-NBCircuitTermination.ps1
+++ b/Functions/Circuits/Terminations/Get-NBCircuitTermination.ps1
@@ -28,6 +28,9 @@ function Get-NBCircuitTermination {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'ById',
                    ValueFromPipelineByPropertyName = $true)]
         [uint64[]]$Id,

--- a/Functions/Circuits/Types/Get-NBCircuitType.ps1
+++ b/Functions/Circuits/Types/Get-NBCircuitType.ps1
@@ -28,6 +28,9 @@ function Get-NBCircuitType {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'ById', ValueFromPipelineByPropertyName = $true)]
         [uint64[]]$Id,
 

--- a/Functions/Circuits/VirtualCircuitTerminations/Get-NBVirtualCircuitTermination.ps1
+++ b/Functions/Circuits/VirtualCircuitTerminations/Get-NBVirtualCircuitTermination.ps1
@@ -48,6 +48,9 @@ function Get-NBVirtualCircuitTermination {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'ById', ValueFromPipelineByPropertyName = $true)]
         [uint64[]]$Id,
 

--- a/Functions/Circuits/VirtualCircuitTypes/Get-NBVirtualCircuitType.ps1
+++ b/Functions/Circuits/VirtualCircuitTypes/Get-NBVirtualCircuitType.ps1
@@ -45,6 +45,9 @@ function Get-NBVirtualCircuitType {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'ById', ValueFromPipelineByPropertyName = $true)]
         [uint64[]]$Id,
 

--- a/Functions/Circuits/VirtualCircuits/Get-NBVirtualCircuit.ps1
+++ b/Functions/Circuits/VirtualCircuits/Get-NBVirtualCircuit.ps1
@@ -60,6 +60,9 @@ function Get-NBVirtualCircuit {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'ById', ValueFromPipelineByPropertyName = $true)]
         [uint64[]]$Id,
 

--- a/Functions/Core/DataFiles/Get-NBDataFile.ps1
+++ b/Functions/Core/DataFiles/Get-NBDataFile.ps1
@@ -45,6 +45,9 @@ function Get-NBDataFile {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'ById', ValueFromPipelineByPropertyName = $true)]
         [uint64[]]$Id,
 

--- a/Functions/Core/DataSources/Get-NBDataSource.ps1
+++ b/Functions/Core/DataSources/Get-NBDataSource.ps1
@@ -48,6 +48,9 @@ function Get-NBDataSource {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'ById', ValueFromPipelineByPropertyName = $true)]
         [uint64[]]$Id,
 

--- a/Functions/Core/Jobs/Get-NBJob.ps1
+++ b/Functions/Core/Jobs/Get-NBJob.ps1
@@ -57,6 +57,9 @@ function Get-NBJob {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'ById', ValueFromPipelineByPropertyName = $true)]
         [uint64[]]$Id,
 

--- a/Functions/Core/ObjectChanges/Get-NBObjectChange.ps1
+++ b/Functions/Core/ObjectChanges/Get-NBObjectChange.ps1
@@ -57,6 +57,9 @@ function Get-NBObjectChange {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'ById', ValueFromPipelineByPropertyName = $true)]
         [uint64[]]$Id,
 

--- a/Functions/Core/ObjectTypes/Get-NBObjectType.ps1
+++ b/Functions/Core/ObjectTypes/Get-NBObjectType.ps1
@@ -48,6 +48,9 @@ function Get-NBObjectType {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'ById', ValueFromPipelineByPropertyName = $true)]
         [uint64[]]$Id,
 

--- a/Functions/DCIM/Cable Terminations/Get-NBDCIMCableTermination.ps1
+++ b/Functions/DCIM/Cable Terminations/Get-NBDCIMCableTermination.ps1
@@ -29,6 +29,9 @@ function Get-NBDCIMCableTermination {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [ValidateRange(1, 1000)]
         [uint16]$Limit,
 

--- a/Functions/DCIM/Cables/Get-NBDCIMCable.ps1
+++ b/Functions/DCIM/Cables/Get-NBDCIMCable.ps1
@@ -84,6 +84,9 @@ function Get-NBDCIMCable {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [ValidateRange(1, 1000)]
         [uint16]$Limit,
 

--- a/Functions/DCIM/ConnectedDevice/Get-NBDCIMConnectedDevice.ps1
+++ b/Functions/DCIM/ConnectedDevice/Get-NBDCIMConnectedDevice.ps1
@@ -27,6 +27,9 @@ function Get-NBDCIMConnectedDevice {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(Mandatory = $true)][string]$Peer_Device,
         [Parameter(Mandatory = $true)][string]$Peer_Interface,
         [switch]$Raw

--- a/Functions/DCIM/ConsolePortTemplates/Get-NBDCIMConsolePortTemplate.ps1
+++ b/Functions/DCIM/ConsolePortTemplates/Get-NBDCIMConsolePortTemplate.ps1
@@ -27,6 +27,9 @@ function Get-NBDCIMConsolePortTemplate {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'ByID', ValueFromPipelineByPropertyName = $true)][uint64[]]$Id,
         [Parameter(ParameterSetName = 'Query')][string]$Name,
         [Parameter(ParameterSetName = 'Query')][uint64]$Device_Type_Id,

--- a/Functions/DCIM/ConsolePorts/Get-NBDCIMConsolePort.ps1
+++ b/Functions/DCIM/ConsolePorts/Get-NBDCIMConsolePort.ps1
@@ -27,6 +27,9 @@ function Get-NBDCIMConsolePort {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'ByID', ValueFromPipelineByPropertyName = $true)][uint64[]]$Id,
         [Parameter(ParameterSetName = 'Query')][string]$Name,
         [Parameter(ParameterSetName = 'Query')][uint64]$Device_Id,

--- a/Functions/DCIM/ConsoleServerPortTemplates/Get-NBDCIMConsoleServerPortTemplate.ps1
+++ b/Functions/DCIM/ConsoleServerPortTemplates/Get-NBDCIMConsoleServerPortTemplate.ps1
@@ -27,6 +27,9 @@ function Get-NBDCIMConsoleServerPortTemplate {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'ByID', ValueFromPipelineByPropertyName = $true)][uint64[]]$Id,
         [Parameter(ParameterSetName = 'Query')][string]$Name,
         [Parameter(ParameterSetName = 'Query')][uint64]$Device_Type_Id,

--- a/Functions/DCIM/ConsoleServerPorts/Get-NBDCIMConsoleServerPort.ps1
+++ b/Functions/DCIM/ConsoleServerPorts/Get-NBDCIMConsoleServerPort.ps1
@@ -27,6 +27,9 @@ function Get-NBDCIMConsoleServerPort {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'ByID', ValueFromPipelineByPropertyName = $true)][uint64[]]$Id,
         [Parameter(ParameterSetName = 'Query')][string]$Name,
         [Parameter(ParameterSetName = 'Query')][uint64]$Device_Id,

--- a/Functions/DCIM/DeviceBayTemplates/Get-NBDCIMDeviceBayTemplate.ps1
+++ b/Functions/DCIM/DeviceBayTemplates/Get-NBDCIMDeviceBayTemplate.ps1
@@ -27,6 +27,9 @@ function Get-NBDCIMDeviceBayTemplate {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'ByID', ValueFromPipelineByPropertyName = $true)][uint64[]]$Id,
         [Parameter(ParameterSetName = 'Query')][string]$Name,
         [Parameter(ParameterSetName = 'Query')][uint64]$Device_Type_Id,

--- a/Functions/DCIM/DeviceBays/Get-NBDCIMDeviceBay.ps1
+++ b/Functions/DCIM/DeviceBays/Get-NBDCIMDeviceBay.ps1
@@ -27,6 +27,9 @@ function Get-NBDCIMDeviceBay {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'ByID', ValueFromPipelineByPropertyName = $true)][uint64[]]$Id,
         [Parameter(ParameterSetName = 'Query')][string]$Name,
         [Parameter(ParameterSetName = 'Query')][uint64]$Device_Id,

--- a/Functions/DCIM/Devices/Get-NBDCIMDeviceRole.ps1
+++ b/Functions/DCIM/Devices/Get-NBDCIMDeviceRole.ps1
@@ -28,6 +28,9 @@ function Get-NBDCIMDeviceRole {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [ValidateRange(1, 1000)]
         [uint16]$Limit,
 

--- a/Functions/DCIM/Devices/Get-NBDCIMDeviceType.ps1
+++ b/Functions/DCIM/Devices/Get-NBDCIMDeviceType.ps1
@@ -29,6 +29,9 @@ function Get-NBDCIMDeviceType {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [ValidateRange(0, [int]::MaxValue)]
         [uint16]$Offset,
 

--- a/Functions/DCIM/FrontPortTemplates/Get-NBDCIMFrontPortTemplate.ps1
+++ b/Functions/DCIM/FrontPortTemplates/Get-NBDCIMFrontPortTemplate.ps1
@@ -27,6 +27,9 @@ function Get-NBDCIMFrontPortTemplate {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'ByID', ValueFromPipelineByPropertyName = $true)][uint64[]]$Id,
         [Parameter(ParameterSetName = 'Query')][string]$Name,
         [Parameter(ParameterSetName = 'Query')][uint64]$Device_Type_Id,

--- a/Functions/DCIM/FrontPorts/Get-NBDCIMFrontPort.ps1
+++ b/Functions/DCIM/FrontPorts/Get-NBDCIMFrontPort.ps1
@@ -28,6 +28,9 @@ function Get-NBDCIMFrontPort {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [ValidateRange(1, 1000)]
         [uint16]$Limit,
 

--- a/Functions/DCIM/InterfaceTemplates/Get-NBDCIMInterfaceTemplate.ps1
+++ b/Functions/DCIM/InterfaceTemplates/Get-NBDCIMInterfaceTemplate.ps1
@@ -27,6 +27,9 @@ function Get-NBDCIMInterfaceTemplate {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'ByID', ValueFromPipelineByPropertyName = $true)][uint64[]]$Id,
         [Parameter(ParameterSetName = 'Query')][string]$Name,
         [Parameter(ParameterSetName = 'Query')][uint64]$Device_Type_Id,

--- a/Functions/DCIM/Interfaces/Get-NBDCIMInterfaceConnection.ps1
+++ b/Functions/DCIM/Interfaces/Get-NBDCIMInterfaceConnection.ps1
@@ -28,6 +28,9 @@ function Get-NBDCIMInterfaceConnection {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [ValidateRange(1, 1000)]
         [uint16]$Limit,
 

--- a/Functions/DCIM/InventoryItemRoles/Get-NBDCIMInventoryItemRole.ps1
+++ b/Functions/DCIM/InventoryItemRoles/Get-NBDCIMInventoryItemRole.ps1
@@ -27,6 +27,9 @@ function Get-NBDCIMInventoryItemRole {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'ByID', ValueFromPipelineByPropertyName = $true)][uint64[]]$Id,
         [Parameter(ParameterSetName = 'Query')][string]$Name,
         [Parameter(ParameterSetName = 'Query')][string]$Slug,

--- a/Functions/DCIM/InventoryItemTemplates/Get-NBDCIMInventoryItemTemplate.ps1
+++ b/Functions/DCIM/InventoryItemTemplates/Get-NBDCIMInventoryItemTemplate.ps1
@@ -27,6 +27,9 @@ function Get-NBDCIMInventoryItemTemplate {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'ByID', ValueFromPipelineByPropertyName = $true)][uint64[]]$Id,
         [Parameter(ParameterSetName = 'Query')][string]$Name,
         [Parameter(ParameterSetName = 'Query')][uint64]$Device_Type_Id,

--- a/Functions/DCIM/InventoryItems/Get-NBDCIMInventoryItem.ps1
+++ b/Functions/DCIM/InventoryItems/Get-NBDCIMInventoryItem.ps1
@@ -27,6 +27,9 @@ function Get-NBDCIMInventoryItem {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'ByID', ValueFromPipelineByPropertyName = $true)][uint64[]]$Id,
         [Parameter(ParameterSetName = 'Query')][string]$Name,
         [Parameter(ParameterSetName = 'Query')][uint64]$Device_Id,

--- a/Functions/DCIM/Locations/Get-NBDCIMLocation.ps1
+++ b/Functions/DCIM/Locations/Get-NBDCIMLocation.ps1
@@ -72,6 +72,9 @@ function Get-NBDCIMLocation {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'ByID',
                    ValueFromPipelineByPropertyName = $true)]
         [uint64[]]$Id,

--- a/Functions/DCIM/MACAddresses/Get-NBDCIMMACAddress.ps1
+++ b/Functions/DCIM/MACAddresses/Get-NBDCIMMACAddress.ps1
@@ -27,6 +27,9 @@ function Get-NBDCIMMACAddress {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'ByID', ValueFromPipelineByPropertyName = $true)][uint64[]]$Id,
         [Parameter(ParameterSetName = 'Query')][string]$Mac_Address,
         [Parameter(ParameterSetName = 'Query')][uint64]$Assigned_Object_Id,

--- a/Functions/DCIM/Manufacturers/Get-NBDCIMManufacturer.ps1
+++ b/Functions/DCIM/Manufacturers/Get-NBDCIMManufacturer.ps1
@@ -51,6 +51,9 @@ function Get-NBDCIMManufacturer {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'ByID',
                    ValueFromPipelineByPropertyName = $true)]
         [uint64[]]$Id,

--- a/Functions/DCIM/ModuleBayTemplates/Get-NBDCIMModuleBayTemplate.ps1
+++ b/Functions/DCIM/ModuleBayTemplates/Get-NBDCIMModuleBayTemplate.ps1
@@ -27,6 +27,9 @@ function Get-NBDCIMModuleBayTemplate {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'ByID', ValueFromPipelineByPropertyName = $true)][uint64[]]$Id,
         [Parameter(ParameterSetName = 'Query')][string]$Name,
         [Parameter(ParameterSetName = 'Query')][uint64]$Device_Type_Id,

--- a/Functions/DCIM/ModuleBays/Get-NBDCIMModuleBay.ps1
+++ b/Functions/DCIM/ModuleBays/Get-NBDCIMModuleBay.ps1
@@ -27,6 +27,9 @@ function Get-NBDCIMModuleBay {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'ByID', ValueFromPipelineByPropertyName = $true)][uint64[]]$Id,
         [Parameter(ParameterSetName = 'Query')][string]$Name,
         [Parameter(ParameterSetName = 'Query')][uint64]$Device_Id,

--- a/Functions/DCIM/ModuleTypeProfiles/Get-NBDCIMModuleTypeProfile.ps1
+++ b/Functions/DCIM/ModuleTypeProfiles/Get-NBDCIMModuleTypeProfile.ps1
@@ -27,6 +27,9 @@ function Get-NBDCIMModuleTypeProfile {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'ByID', ValueFromPipelineByPropertyName = $true)][uint64[]]$Id,
         [Parameter(ParameterSetName = 'Query')][string]$Name,
         [Parameter(ParameterSetName = 'Query')][string]$Query,

--- a/Functions/DCIM/ModuleTypes/Get-NBDCIMModuleType.ps1
+++ b/Functions/DCIM/ModuleTypes/Get-NBDCIMModuleType.ps1
@@ -27,6 +27,9 @@ function Get-NBDCIMModuleType {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'ByID', ValueFromPipelineByPropertyName = $true)][uint64[]]$Id,
         [Parameter(ParameterSetName = 'Query')][string]$Model,
         [Parameter(ParameterSetName = 'Query')][uint64]$Manufacturer_Id,

--- a/Functions/DCIM/Modules/Get-NBDCIMModule.ps1
+++ b/Functions/DCIM/Modules/Get-NBDCIMModule.ps1
@@ -27,6 +27,9 @@ function Get-NBDCIMModule {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'ByID', ValueFromPipelineByPropertyName = $true)][uint64[]]$Id,
         [Parameter(ParameterSetName = 'Query')][uint64]$Device_Id,
         [Parameter(ParameterSetName = 'Query')][uint64]$Module_Bay_Id,

--- a/Functions/DCIM/Platforms/Get-NBDCIMPlatform.ps1
+++ b/Functions/DCIM/Platforms/Get-NBDCIMPlatform.ps1
@@ -28,6 +28,9 @@ function Get-NBDCIMPlatform {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [ValidateRange(1, 1000)]
         [uint16]$Limit,
 

--- a/Functions/DCIM/PowerFeeds/Get-NBDCIMPowerFeed.ps1
+++ b/Functions/DCIM/PowerFeeds/Get-NBDCIMPowerFeed.ps1
@@ -27,6 +27,9 @@ function Get-NBDCIMPowerFeed {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'ByID', ValueFromPipelineByPropertyName = $true)][uint64[]]$Id,
         [Parameter(ParameterSetName = 'Query')][string]$Name,
         [Parameter(ParameterSetName = 'Query')][uint64]$Power_Panel_Id,

--- a/Functions/DCIM/PowerOutletTemplates/Get-NBDCIMPowerOutletTemplate.ps1
+++ b/Functions/DCIM/PowerOutletTemplates/Get-NBDCIMPowerOutletTemplate.ps1
@@ -27,6 +27,9 @@ function Get-NBDCIMPowerOutletTemplate {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'ByID', ValueFromPipelineByPropertyName = $true)][uint64[]]$Id,
         [Parameter(ParameterSetName = 'Query')][string]$Name,
         [Parameter(ParameterSetName = 'Query')][uint64]$Device_Type_Id,

--- a/Functions/DCIM/PowerOutlets/Get-NBDCIMPowerOutlet.ps1
+++ b/Functions/DCIM/PowerOutlets/Get-NBDCIMPowerOutlet.ps1
@@ -27,6 +27,9 @@ function Get-NBDCIMPowerOutlet {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'ByID', ValueFromPipelineByPropertyName = $true)][uint64[]]$Id,
         [Parameter(ParameterSetName = 'Query')][string]$Name,
         [Parameter(ParameterSetName = 'Query')][uint64]$Device_Id,

--- a/Functions/DCIM/PowerPanels/Get-NBDCIMPowerPanel.ps1
+++ b/Functions/DCIM/PowerPanels/Get-NBDCIMPowerPanel.ps1
@@ -27,6 +27,9 @@ function Get-NBDCIMPowerPanel {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'ByID', ValueFromPipelineByPropertyName = $true)][uint64[]]$Id,
         [Parameter(ParameterSetName = 'Query')][string]$Name,
         [Parameter(ParameterSetName = 'Query')][uint64]$Site_Id,

--- a/Functions/DCIM/PowerPortTemplates/Get-NBDCIMPowerPortTemplate.ps1
+++ b/Functions/DCIM/PowerPortTemplates/Get-NBDCIMPowerPortTemplate.ps1
@@ -27,6 +27,9 @@ function Get-NBDCIMPowerPortTemplate {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'ByID', ValueFromPipelineByPropertyName = $true)][uint64[]]$Id,
         [Parameter(ParameterSetName = 'Query')][string]$Name,
         [Parameter(ParameterSetName = 'Query')][uint64]$Device_Type_Id,

--- a/Functions/DCIM/PowerPorts/Get-NBDCIMPowerPort.ps1
+++ b/Functions/DCIM/PowerPorts/Get-NBDCIMPowerPort.ps1
@@ -27,6 +27,9 @@ function Get-NBDCIMPowerPort {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'ByID', ValueFromPipelineByPropertyName = $true)][uint64[]]$Id,
         [Parameter(ParameterSetName = 'Query')][string]$Name,
         [Parameter(ParameterSetName = 'Query')][uint64]$Device_Id,

--- a/Functions/DCIM/RackReservations/Get-NBDCIMRackReservation.ps1
+++ b/Functions/DCIM/RackReservations/Get-NBDCIMRackReservation.ps1
@@ -27,6 +27,9 @@ function Get-NBDCIMRackReservation {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'ByID', ValueFromPipelineByPropertyName = $true)][uint64[]]$Id,
         [Parameter(ParameterSetName = 'Query')][uint64]$Rack_Id,
         [Parameter(ParameterSetName = 'Query')][uint64]$Site_Id,

--- a/Functions/DCIM/RackRoles/Get-NBDCIMRackRole.ps1
+++ b/Functions/DCIM/RackRoles/Get-NBDCIMRackRole.ps1
@@ -27,6 +27,9 @@ function Get-NBDCIMRackRole {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'ByID', ValueFromPipelineByPropertyName = $true)][uint64[]]$Id,
         [Parameter(ParameterSetName = 'Query')][string]$Name,
         [Parameter(ParameterSetName = 'Query')][string]$Slug,

--- a/Functions/DCIM/RackTypes/Get-NBDCIMRackType.ps1
+++ b/Functions/DCIM/RackTypes/Get-NBDCIMRackType.ps1
@@ -27,6 +27,9 @@ function Get-NBDCIMRackType {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'ByID', ValueFromPipelineByPropertyName = $true)][uint64[]]$Id,
         [Parameter(ParameterSetName = 'Query')][string]$Model,
         [Parameter(ParameterSetName = 'Query')][string]$Slug,

--- a/Functions/DCIM/Racks/Get-NBDCIMRack.ps1
+++ b/Functions/DCIM/Racks/Get-NBDCIMRack.ps1
@@ -80,6 +80,9 @@ function Get-NBDCIMRack {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'ByID',
                    ValueFromPipelineByPropertyName = $true)]
         [uint64[]]$Id,

--- a/Functions/DCIM/Racks/Get-NBDCIMRackElevation.ps1
+++ b/Functions/DCIM/Racks/Get-NBDCIMRackElevation.ps1
@@ -73,6 +73,9 @@ function Get-NBDCIMRackElevation {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
         [uint64[]]$Id,
 

--- a/Functions/DCIM/RearPortTemplates/Get-NBDCIMRearPortTemplate.ps1
+++ b/Functions/DCIM/RearPortTemplates/Get-NBDCIMRearPortTemplate.ps1
@@ -27,6 +27,9 @@ function Get-NBDCIMRearPortTemplate {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'ByID', ValueFromPipelineByPropertyName = $true)][uint64[]]$Id,
         [Parameter(ParameterSetName = 'Query')][string]$Name,
         [Parameter(ParameterSetName = 'Query')][uint64]$Device_Type_Id,

--- a/Functions/DCIM/RearPorts/Get-NBDCIMRearPort.ps1
+++ b/Functions/DCIM/RearPorts/Get-NBDCIMRearPort.ps1
@@ -28,6 +28,9 @@ function Get-NBDCIMRearPort {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [ValidateRange(1, 1000)]
         [uint16]$Limit,
 

--- a/Functions/DCIM/Regions/Get-NBDCIMRegion.ps1
+++ b/Functions/DCIM/Regions/Get-NBDCIMRegion.ps1
@@ -60,6 +60,9 @@ function Get-NBDCIMRegion {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'ByID',
                    ValueFromPipelineByPropertyName = $true)]
         [uint64[]]$Id,

--- a/Functions/DCIM/SiteGroups/Get-NBDCIMSiteGroup.ps1
+++ b/Functions/DCIM/SiteGroups/Get-NBDCIMSiteGroup.ps1
@@ -60,6 +60,9 @@ function Get-NBDCIMSiteGroup {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'ByID',
                    ValueFromPipelineByPropertyName = $true)]
         [uint64[]]$Id,

--- a/Functions/DCIM/Sites/Get-NBDCIMSite.ps1
+++ b/Functions/DCIM/Sites/Get-NBDCIMSite.ps1
@@ -28,6 +28,9 @@ function Get-NBDCIMSite {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'ByID', ValueFromPipelineByPropertyName = $true)]
         [uint64[]]$Id,
 

--- a/Functions/DCIM/VirtualChassis/Get-NBDCIMVirtualChassis.ps1
+++ b/Functions/DCIM/VirtualChassis/Get-NBDCIMVirtualChassis.ps1
@@ -27,6 +27,9 @@ function Get-NBDCIMVirtualChassis {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'ByID', ValueFromPipelineByPropertyName = $true)][uint64[]]$Id,
         [Parameter(ParameterSetName = 'Query')][string]$Name,
         [Parameter(ParameterSetName = 'Query')][string]$Domain,

--- a/Functions/DCIM/VirtualDeviceContexts/Get-NBDCIMVirtualDeviceContext.ps1
+++ b/Functions/DCIM/VirtualDeviceContexts/Get-NBDCIMVirtualDeviceContext.ps1
@@ -27,6 +27,9 @@ function Get-NBDCIMVirtualDeviceContext {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'ByID', ValueFromPipelineByPropertyName = $true)][uint64[]]$Id,
         [Parameter(ParameterSetName = 'Query')][string]$Name,
         [Parameter(ParameterSetName = 'Query')][string]$Status,

--- a/Functions/Extras/Bookmarks/Get-NBBookmark.ps1
+++ b/Functions/Extras/Bookmarks/Get-NBBookmark.ps1
@@ -45,6 +45,9 @@ function Get-NBBookmark {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'ById', ValueFromPipelineByPropertyName = $true)]
         [uint64[]]$Id,
 

--- a/Functions/Extras/ConfigContexts/Get-NBConfigContext.ps1
+++ b/Functions/Extras/ConfigContexts/Get-NBConfigContext.ps1
@@ -45,6 +45,9 @@ function Get-NBConfigContext {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'ById', ValueFromPipelineByPropertyName = $true)]
         [uint64[]]$Id,
 

--- a/Functions/Extras/CustomFieldChoiceSets/Get-NBCustomFieldChoiceSet.ps1
+++ b/Functions/Extras/CustomFieldChoiceSets/Get-NBCustomFieldChoiceSet.ps1
@@ -42,6 +42,9 @@ function Get-NBCustomFieldChoiceSet {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'ById', ValueFromPipelineByPropertyName = $true)]
         [uint64[]]$Id,
 

--- a/Functions/Extras/CustomFields/Get-NBCustomField.ps1
+++ b/Functions/Extras/CustomFields/Get-NBCustomField.ps1
@@ -48,6 +48,9 @@ function Get-NBCustomField {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'ById', ValueFromPipelineByPropertyName = $true)]
         [uint64[]]$Id,
 

--- a/Functions/Extras/CustomLinks/Get-NBCustomLink.ps1
+++ b/Functions/Extras/CustomLinks/Get-NBCustomLink.ps1
@@ -45,6 +45,9 @@ function Get-NBCustomLink {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'ById', ValueFromPipelineByPropertyName = $true)]
         [uint64[]]$Id,
 

--- a/Functions/Extras/EventRules/Get-NBEventRule.ps1
+++ b/Functions/Extras/EventRules/Get-NBEventRule.ps1
@@ -54,6 +54,9 @@ function Get-NBEventRule {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'ById', ValueFromPipelineByPropertyName = $true)]
         [uint64[]]$Id,
 

--- a/Functions/Extras/ExportTemplates/Get-NBExportTemplate.ps1
+++ b/Functions/Extras/ExportTemplates/Get-NBExportTemplate.ps1
@@ -45,6 +45,9 @@ function Get-NBExportTemplate {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'ById', ValueFromPipelineByPropertyName = $true)]
         [uint64[]]$Id,
 

--- a/Functions/Extras/ImageAttachments/Get-NBImageAttachment.ps1
+++ b/Functions/Extras/ImageAttachments/Get-NBImageAttachment.ps1
@@ -48,6 +48,9 @@ function Get-NBImageAttachment {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'ById', ValueFromPipelineByPropertyName = $true)]
         [uint64[]]$Id,
 

--- a/Functions/Extras/JournalEntries/Get-NBJournalEntry.ps1
+++ b/Functions/Extras/JournalEntries/Get-NBJournalEntry.ps1
@@ -51,6 +51,9 @@ function Get-NBJournalEntry {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'ById', ValueFromPipelineByPropertyName = $true)]
         [uint64[]]$Id,
 

--- a/Functions/Extras/SavedFilters/Get-NBSavedFilter.ps1
+++ b/Functions/Extras/SavedFilters/Get-NBSavedFilter.ps1
@@ -57,6 +57,9 @@ function Get-NBSavedFilter {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'ById', ValueFromPipelineByPropertyName = $true)]
         [uint64[]]$Id,
 

--- a/Functions/Extras/Tags/Get-NBTag.ps1
+++ b/Functions/Extras/Tags/Get-NBTag.ps1
@@ -28,6 +28,9 @@ function Get-NBTag {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ValueFromPipelineByPropertyName = $true)]
         [uint64[]]$Id,
 

--- a/Functions/Extras/Webhooks/Get-NBWebhook.ps1
+++ b/Functions/Extras/Webhooks/Get-NBWebhook.ps1
@@ -45,6 +45,9 @@ function Get-NBWebhook {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'ById', ValueFromPipelineByPropertyName = $true)]
         [uint64[]]$Id,
 

--- a/Functions/IPAM/ASN/Get-NBIPAMASN.ps1
+++ b/Functions/IPAM/ASN/Get-NBIPAMASN.ps1
@@ -57,6 +57,9 @@ function Get-NBIPAMASN {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'ByID',
                    ValueFromPipelineByPropertyName = $true)]
         [uint64[]]$Id,

--- a/Functions/IPAM/ASNRange/Get-NBIPAMASNRange.ps1
+++ b/Functions/IPAM/ASNRange/Get-NBIPAMASNRange.ps1
@@ -54,6 +54,9 @@ function Get-NBIPAMASNRange {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'ByID',
                    ValueFromPipelineByPropertyName = $true)]
         [uint64[]]$Id,

--- a/Functions/IPAM/Address/Get-NBIPAMAvailableIP.ps1
+++ b/Functions/IPAM/Address/Get-NBIPAMAvailableIP.ps1
@@ -45,6 +45,9 @@ function Get-NBIPAMAvailableIP {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(Mandatory = $true,
             ValueFromPipelineByPropertyName = $true)]
         [Alias('Id')]

--- a/Functions/IPAM/Aggregate/Get-NBIPAMAggregate.ps1
+++ b/Functions/IPAM/Aggregate/Get-NBIPAMAggregate.ps1
@@ -28,6 +28,9 @@ function Get-NBIPAMAggregate {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'Query')]
         [string]$Query,
 

--- a/Functions/IPAM/FHRPGroup/Get-NBIPAMFHRPGroup.ps1
+++ b/Functions/IPAM/FHRPGroup/Get-NBIPAMFHRPGroup.ps1
@@ -27,6 +27,9 @@ function Get-NBIPAMFHRPGroup {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'ByID', ValueFromPipelineByPropertyName = $true)][uint64[]]$Id,
         [Parameter(ParameterSetName = 'Query')][string]$Name,
         [Parameter(ParameterSetName = 'Query')][string]$Protocol,

--- a/Functions/IPAM/FHRPGroupAssignment/Get-NBIPAMFHRPGroupAssignment.ps1
+++ b/Functions/IPAM/FHRPGroupAssignment/Get-NBIPAMFHRPGroupAssignment.ps1
@@ -27,6 +27,9 @@ function Get-NBIPAMFHRPGroupAssignment {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'ByID', ValueFromPipelineByPropertyName = $true)][uint64[]]$Id,
         [Parameter(ParameterSetName = 'Query')][uint64]$Group_Id,
         [Parameter(ParameterSetName = 'Query')][uint64]$Interface_Id,

--- a/Functions/IPAM/RIR/Get-NBIPAMRIR.ps1
+++ b/Functions/IPAM/RIR/Get-NBIPAMRIR.ps1
@@ -27,6 +27,9 @@ function Get-NBIPAMRIR {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'ByID', ValueFromPipelineByPropertyName = $true)][uint64[]]$Id,
         [Parameter(ParameterSetName = 'Query')][string]$Name,
         [Parameter(ParameterSetName = 'Query')][string]$Slug,

--- a/Functions/IPAM/Range/Get-NBIPAMAddressRange.ps1
+++ b/Functions/IPAM/Range/Get-NBIPAMAddressRange.ps1
@@ -28,6 +28,9 @@ function Get-NBIPAMAddressRange {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'Query',
                    Position = 0)]
         [string]$Range,

--- a/Functions/IPAM/RouteTarget/Get-NBIPAMRouteTarget.ps1
+++ b/Functions/IPAM/RouteTarget/Get-NBIPAMRouteTarget.ps1
@@ -61,6 +61,9 @@ function Get-NBIPAMRouteTarget {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'ByID',
                    ValueFromPipelineByPropertyName = $true)]
         [uint64[]]$Id,

--- a/Functions/IPAM/Service/Get-NBIPAMService.ps1
+++ b/Functions/IPAM/Service/Get-NBIPAMService.ps1
@@ -61,6 +61,9 @@ function Get-NBIPAMService {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'ByID',
                    ValueFromPipelineByPropertyName = $true)]
         [uint64[]]$Id,

--- a/Functions/IPAM/ServiceTemplate/Get-NBIPAMServiceTemplate.ps1
+++ b/Functions/IPAM/ServiceTemplate/Get-NBIPAMServiceTemplate.ps1
@@ -55,6 +55,9 @@ function Get-NBIPAMServiceTemplate {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'ByID',
                    ValueFromPipelineByPropertyName = $true)]
         [uint64[]]$Id,

--- a/Functions/IPAM/VLAN/Get-NBIPAMVLAN.ps1
+++ b/Functions/IPAM/VLAN/Get-NBIPAMVLAN.ps1
@@ -28,6 +28,9 @@ function Get-NBIPAMVLAN {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'Query',
                    Position = 0)]
         [ValidateRange(1, 4096)]

--- a/Functions/IPAM/VLANGroup/Get-NBIPAMVLANGroup.ps1
+++ b/Functions/IPAM/VLANGroup/Get-NBIPAMVLANGroup.ps1
@@ -27,6 +27,9 @@ function Get-NBIPAMVLANGroup {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'ByID', ValueFromPipelineByPropertyName = $true)][uint64[]]$Id,
         [Parameter(ParameterSetName = 'Query')][string]$Name,
         [Parameter(ParameterSetName = 'Query')][string]$Slug,

--- a/Functions/IPAM/VLANTranslationPolicy/Get-NBIPAMVLANTranslationPolicy.ps1
+++ b/Functions/IPAM/VLANTranslationPolicy/Get-NBIPAMVLANTranslationPolicy.ps1
@@ -27,6 +27,9 @@ function Get-NBIPAMVLANTranslationPolicy {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'ByID', ValueFromPipelineByPropertyName = $true)][uint64[]]$Id,
         [Parameter(ParameterSetName = 'Query')][string]$Name,
         [Parameter(ParameterSetName = 'Query')][string]$Query,

--- a/Functions/IPAM/VLANTranslationRule/Get-NBIPAMVLANTranslationRule.ps1
+++ b/Functions/IPAM/VLANTranslationRule/Get-NBIPAMVLANTranslationRule.ps1
@@ -27,6 +27,9 @@ function Get-NBIPAMVLANTranslationRule {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'ByID', ValueFromPipelineByPropertyName = $true)][uint64[]]$Id,
         [Parameter(ParameterSetName = 'Query')][uint64]$Policy_Id,
         [Parameter(ParameterSetName = 'Query')][uint64]$Local_Vid,

--- a/Functions/IPAM/VRF/Get-NBIPAMVRF.ps1
+++ b/Functions/IPAM/VRF/Get-NBIPAMVRF.ps1
@@ -65,6 +65,9 @@ function Get-NBIPAMVRF {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'ByID',
                    ValueFromPipelineByPropertyName = $true)]
         [uint64[]]$Id,

--- a/Functions/Plugins/Branching/Branch/Get-NBBranch.ps1
+++ b/Functions/Plugins/Branching/Branch/Get-NBBranch.ps1
@@ -73,6 +73,9 @@ function Get-NBBranch {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'ById', ValueFromPipelineByPropertyName = $true)]
         [uint64[]]$Id,
 

--- a/Functions/Plugins/Branching/BranchEvent/Get-NBBranchEvent.ps1
+++ b/Functions/Plugins/Branching/BranchEvent/Get-NBBranchEvent.ps1
@@ -58,6 +58,9 @@ function Get-NBBranchEvent {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'ById', ValueFromPipelineByPropertyName = $true)]
         [uint64[]]$Id,
 

--- a/Functions/Plugins/Branching/ChangeDiff/Get-NBChangeDiff.ps1
+++ b/Functions/Plugins/Branching/ChangeDiff/Get-NBChangeDiff.ps1
@@ -65,6 +65,9 @@ function Get-NBChangeDiff {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'ById', ValueFromPipelineByPropertyName = $true)]
         [uint64[]]$Id,
 

--- a/Functions/Setup/Support/Get-NBContentType.ps1
+++ b/Functions/Setup/Support/Get-NBContentType.ps1
@@ -55,6 +55,9 @@ function Get-NBContentType {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'Query',
                    Position = 0)]
         [string]$Model,

--- a/Functions/Tenancy/ContactAssignment/Get-NBContactAssignment.ps1
+++ b/Functions/Tenancy/ContactAssignment/Get-NBContactAssignment.ps1
@@ -56,6 +56,9 @@ function Get-NBContactAssignment {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'Query',
                    Position = 0)]
         [string]$Name,

--- a/Functions/Tenancy/ContactRoles/Get-NBContactRole.ps1
+++ b/Functions/Tenancy/ContactRoles/Get-NBContactRole.ps1
@@ -44,6 +44,9 @@ function Get-NBContactRole {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'Query',
                    Position = 0)]
         [string]$Name,

--- a/Functions/Tenancy/Contacts/Get-NBContact.ps1
+++ b/Functions/Tenancy/Contacts/Get-NBContact.ps1
@@ -61,6 +61,9 @@ function Get-NBContact {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'Query',
                    Position = 0)]
         [string]$Name,

--- a/Functions/Tenancy/TenantGroups/Get-NBTenantGroup.ps1
+++ b/Functions/Tenancy/TenantGroups/Get-NBTenantGroup.ps1
@@ -65,6 +65,9 @@ function Get-NBTenantGroup {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ValueFromPipelineByPropertyName = $true)]
         [uint64[]]$Id,
 

--- a/Functions/Tenancy/Tenants/Get-NBTenant.ps1
+++ b/Functions/Tenancy/Tenants/Get-NBTenant.ps1
@@ -56,6 +56,9 @@ function Get-NBTenant {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'Query',
                    Position = 0)]
         [string]$Name,

--- a/Functions/Users/Groups/Get-NBGroup.ps1
+++ b/Functions/Users/Groups/Get-NBGroup.ps1
@@ -42,6 +42,9 @@ function Get-NBGroup {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'ById', ValueFromPipelineByPropertyName = $true)]
         [uint64[]]$Id,
 

--- a/Functions/Users/OwnerGroups/Get-NBOwnerGroup.ps1
+++ b/Functions/Users/OwnerGroups/Get-NBOwnerGroup.ps1
@@ -56,6 +56,9 @@ function Get-NBOwnerGroup {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'ById', ValueFromPipelineByPropertyName = $true)]
         [uint64[]]$Id,
 

--- a/Functions/Users/Owners/Get-NBOwner.ps1
+++ b/Functions/Users/Owners/Get-NBOwner.ps1
@@ -65,6 +65,9 @@ function Get-NBOwner {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'ById', ValueFromPipelineByPropertyName = $true)]
         [uint64[]]$Id,
 

--- a/Functions/Users/Permissions/Get-NBPermission.ps1
+++ b/Functions/Users/Permissions/Get-NBPermission.ps1
@@ -54,6 +54,9 @@ function Get-NBPermission {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'ById', ValueFromPipelineByPropertyName = $true)]
         [uint64[]]$Id,
 

--- a/Functions/Users/Tokens/Get-NBToken.ps1
+++ b/Functions/Users/Tokens/Get-NBToken.ps1
@@ -48,6 +48,9 @@ function Get-NBToken {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'ById', ValueFromPipelineByPropertyName = $true)]
         [uint64[]]$Id,
 

--- a/Functions/Users/Users/Get-NBUser.ps1
+++ b/Functions/Users/Users/Get-NBUser.ps1
@@ -66,6 +66,9 @@ function Get-NBUser {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'ById', ValueFromPipelineByPropertyName = $true)]
         [uint64[]]$Id,
 

--- a/Functions/VPN/IKEPolicy/Get-NBVPNIKEPolicy.ps1
+++ b/Functions/VPN/IKEPolicy/Get-NBVPNIKEPolicy.ps1
@@ -13,6 +13,11 @@
     Specify which fields to include in the response.
     Supports nested field selection (e.g., 'site.name').
 
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .PARAMETER Raw
     Return the raw API response instead of the results array.
 
@@ -34,6 +39,9 @@ function Get-NBVPNIKEPolicy {
         [switch]$Brief,
 
         [string[]]$Fields,
+
+
+        [string[]]$Omit,
 
         [Parameter(ParameterSetName = 'ByID', ValueFromPipelineByPropertyName = $true)]
         [uint64[]]$Id,

--- a/Functions/VPN/IKEProposal/Get-NBVPNIKEProposal.ps1
+++ b/Functions/VPN/IKEProposal/Get-NBVPNIKEProposal.ps1
@@ -13,6 +13,11 @@
     Specify which fields to include in the response.
     Supports nested field selection (e.g., 'site.name').
 
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .PARAMETER Raw
     Return the raw API response instead of the results array.
 
@@ -34,6 +39,9 @@ function Get-NBVPNIKEProposal {
         [switch]$Brief,
 
         [string[]]$Fields,
+
+
+        [string[]]$Omit,
 
         [Parameter(ParameterSetName = 'ByID', ValueFromPipelineByPropertyName = $true)]
         [uint64[]]$Id,

--- a/Functions/VPN/IPSecPolicy/Get-NBVPNIPSecPolicy.ps1
+++ b/Functions/VPN/IPSecPolicy/Get-NBVPNIPSecPolicy.ps1
@@ -13,6 +13,11 @@
     Specify which fields to include in the response.
     Supports nested field selection (e.g., 'site.name').
 
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .PARAMETER Raw
     Return the raw API response instead of the results array.
 
@@ -34,6 +39,9 @@ function Get-NBVPNIPSecPolicy {
         [switch]$Brief,
 
         [string[]]$Fields,
+
+
+        [string[]]$Omit,
 
         [Parameter(ParameterSetName = 'ByID', ValueFromPipelineByPropertyName = $true)]
         [uint64[]]$Id,

--- a/Functions/VPN/IPSecProfile/Get-NBVPNIPSecProfile.ps1
+++ b/Functions/VPN/IPSecProfile/Get-NBVPNIPSecProfile.ps1
@@ -13,6 +13,11 @@
     Specify which fields to include in the response.
     Supports nested field selection (e.g., 'site.name').
 
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .PARAMETER Raw
     Return the raw API response instead of the results array.
 
@@ -34,6 +39,9 @@ function Get-NBVPNIPSecProfile {
         [switch]$Brief,
 
         [string[]]$Fields,
+
+
+        [string[]]$Omit,
 
         [Parameter(ParameterSetName = 'ByID', ValueFromPipelineByPropertyName = $true)]
         [uint64[]]$Id,

--- a/Functions/VPN/IPSecProposal/Get-NBVPNIPSecProposal.ps1
+++ b/Functions/VPN/IPSecProposal/Get-NBVPNIPSecProposal.ps1
@@ -13,6 +13,11 @@
     Specify which fields to include in the response.
     Supports nested field selection (e.g., 'site.name').
 
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .PARAMETER Raw
     Return the raw API response instead of the results array.
 
@@ -34,6 +39,9 @@ function Get-NBVPNIPSecProposal {
         [switch]$Brief,
 
         [string[]]$Fields,
+
+
+        [string[]]$Omit,
 
         [Parameter(ParameterSetName = 'ByID', ValueFromPipelineByPropertyName = $true)]
         [uint64[]]$Id,

--- a/Functions/VPN/L2VPN/Get-NBVPNL2VPN.ps1
+++ b/Functions/VPN/L2VPN/Get-NBVPNL2VPN.ps1
@@ -13,6 +13,11 @@
     Specify which fields to include in the response.
     Supports nested field selection (e.g., 'site.name').
 
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .PARAMETER Raw
     Return the raw API response instead of the results array.
 
@@ -34,6 +39,9 @@ function Get-NBVPNL2VPN {
         [switch]$Brief,
 
         [string[]]$Fields,
+
+
+        [string[]]$Omit,
 
         [Parameter(ParameterSetName = 'ByID', ValueFromPipelineByPropertyName = $true)]
         [uint64[]]$Id,

--- a/Functions/VPN/L2VPNTermination/Get-NBVPNL2VPNTermination.ps1
+++ b/Functions/VPN/L2VPNTermination/Get-NBVPNL2VPNTermination.ps1
@@ -13,6 +13,11 @@
     Specify which fields to include in the response.
     Supports nested field selection (e.g., 'site.name').
 
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .PARAMETER Raw
     Return the raw API response instead of the results array.
 
@@ -34,6 +39,9 @@ function Get-NBVPNL2VPNTermination {
         [switch]$Brief,
 
         [string[]]$Fields,
+
+
+        [string[]]$Omit,
 
         [Parameter(ParameterSetName = 'ByID', ValueFromPipelineByPropertyName = $true)]
         [uint64[]]$Id,

--- a/Functions/VPN/Tunnel/Get-NBVPNTunnel.ps1
+++ b/Functions/VPN/Tunnel/Get-NBVPNTunnel.ps1
@@ -28,6 +28,9 @@ function Get-NBVPNTunnel {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'ByID', ValueFromPipelineByPropertyName = $true)]
         [uint64[]]$Id,
         [Parameter(ParameterSetName = 'Query')][string]$Name,

--- a/Functions/VPN/TunnelGroup/Get-NBVPNTunnelGroup.ps1
+++ b/Functions/VPN/TunnelGroup/Get-NBVPNTunnelGroup.ps1
@@ -13,6 +13,11 @@
     Specify which fields to include in the response.
     Supports nested field selection (e.g., 'site.name').
 
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .PARAMETER Raw
     Return the raw API response instead of the results array.
 
@@ -34,6 +39,9 @@ function Get-NBVPNTunnelGroup {
         [switch]$Brief,
 
         [string[]]$Fields,
+
+
+        [string[]]$Omit,
 
         [Parameter(ParameterSetName = 'ByID', ValueFromPipelineByPropertyName = $true)]
         [uint64[]]$Id,

--- a/Functions/VPN/TunnelTermination/Get-NBVPNTunnelTermination.ps1
+++ b/Functions/VPN/TunnelTermination/Get-NBVPNTunnelTermination.ps1
@@ -13,6 +13,11 @@
     Specify which fields to include in the response.
     Supports nested field selection (e.g., 'site.name').
 
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .PARAMETER Raw
     Return the raw API response instead of the results array.
 
@@ -34,6 +39,9 @@ function Get-NBVPNTunnelTermination {
         [switch]$Brief,
 
         [string[]]$Fields,
+
+
+        [string[]]$Omit,
 
         [Parameter(ParameterSetName = 'ByID', ValueFromPipelineByPropertyName = $true)]
         [uint64[]]$Id,

--- a/Functions/Virtualization/VirtualMachineInterface/Get-NBVirtualMachineInterface.ps1
+++ b/Functions/Virtualization/VirtualMachineInterface/Get-NBVirtualMachineInterface.ps1
@@ -54,6 +54,9 @@ function Get-NBVirtualMachineInterface {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ValueFromPipeline = $true)]
         [uint64[]]$Id,
 

--- a/Functions/Virtualization/VirtualizationCluster/Get-NBVirtualizationCluster.ps1
+++ b/Functions/Virtualization/VirtualizationCluster/Get-NBVirtualizationCluster.ps1
@@ -60,6 +60,9 @@ function Get-NBVirtualizationCluster {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [string]$Name,
 
         [Alias('q')]

--- a/Functions/Virtualization/VirtualizationCluster/Get-NBVirtualizationClusterGroup.ps1
+++ b/Functions/Virtualization/VirtualizationCluster/Get-NBVirtualizationClusterGroup.ps1
@@ -28,6 +28,9 @@ function Get-NBVirtualizationClusterGroup {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [string]$Name,
 
         [string]$Slug,

--- a/Functions/Virtualization/VirtualizationClusterType/Get-NBVirtualizationClusterType.ps1
+++ b/Functions/Virtualization/VirtualizationClusterType/Get-NBVirtualizationClusterType.ps1
@@ -62,6 +62,9 @@ function Get-NBVirtualizationClusterType {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ValueFromPipelineByPropertyName = $true)]
         [uint64[]]$Id,
 

--- a/Functions/Wireless/WirelessLAN/Get-NBWirelessLAN.ps1
+++ b/Functions/Wireless/WirelessLAN/Get-NBWirelessLAN.ps1
@@ -27,6 +27,9 @@ function Get-NBWirelessLAN {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'ByID', ValueFromPipelineByPropertyName = $true)][uint64[]]$Id,
         [Parameter(ParameterSetName = 'Query')][string]$SSID,[Parameter(ParameterSetName = 'Query')][uint64]$Group_Id,
         [Parameter(ParameterSetName = 'Query')][string]$Status,[Parameter(ParameterSetName = 'Query')][uint64]$VLAN_Id,

--- a/Functions/Wireless/WirelessLANGroup/Get-NBWirelessLANGroup.ps1
+++ b/Functions/Wireless/WirelessLANGroup/Get-NBWirelessLANGroup.ps1
@@ -27,6 +27,9 @@ function Get-NBWirelessLANGroup {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'ByID', ValueFromPipelineByPropertyName = $true)][uint64[]]$Id,
         [Parameter(ParameterSetName = 'Query')][string]$Name,[Parameter(ParameterSetName = 'Query')][string]$Slug,
         [Parameter(ParameterSetName = 'Query')][uint64]$Parent_Id,[ValidateRange(1, 1000)]

--- a/Functions/Wireless/WirelessLink/Get-NBWirelessLink.ps1
+++ b/Functions/Wireless/WirelessLink/Get-NBWirelessLink.ps1
@@ -27,6 +27,9 @@ function Get-NBWirelessLink {
 
         [string[]]$Fields,
 
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'ByID', ValueFromPipelineByPropertyName = $true)][uint64[]]$Id,
         [Parameter(ParameterSetName = 'Query')][string]$SSID,[Parameter(ParameterSetName = 'Query')][string]$Status,
         [ValidateRange(1, 1000)]

--- a/scripts/Add-OmitParameter.Tests.ps1
+++ b/scripts/Add-OmitParameter.Tests.ps1
@@ -1,0 +1,481 @@
+<#
+.SYNOPSIS
+    Tests for Add-OmitParameter.ps1 script
+
+.DESCRIPTION
+    Comprehensive tests to ensure the Add-OmitParameter script:
+    1. Correctly identifies files needing updates
+    2. Skips files that already have -Omit
+    3. Makes syntactically correct modifications
+    4. Preserves file integrity
+    5. Modified files still parse correctly
+#>
+
+BeforeAll {
+    $ScriptPath = Join-Path $PSScriptRoot "Add-OmitParameter.ps1"
+
+    # Create test directory (cross-platform temp path)
+    $tempBase = if ($env:TEMP) { $env:TEMP } elseif ($env:TMPDIR) { $env:TMPDIR } else { "/tmp" }
+    $script:TestDir = Join-Path $tempBase "OmitParameterTests_$(Get-Random)"
+    New-Item -ItemType Directory -Path $script:TestDir -Force | Out-Null
+}
+
+AfterAll {
+    # Cleanup test directory
+    if ($script:TestDir -and (Test-Path $script:TestDir)) {
+        Remove-Item -Path $script:TestDir -Recurse -Force
+    }
+}
+
+Describe "Add-OmitParameter Script Tests" {
+
+    Context "File Detection" {
+
+        It "Should identify files that need -Omit parameter" {
+            # Create test file WITH $Fields but WITHOUT $Omit
+            $testFile = Join-Path $script:TestDir "Get-NBTestFunction.ps1"
+            @'
+function Get-NBTestFunction {
+    param(
+        [string[]]$Fields,
+        [switch]$Raw
+    )
+}
+'@ | Set-Content -Path $testFile
+
+            . $ScriptPath
+            $files = Get-FilesNeedingOmit -Path $script:TestDir
+
+            $files | Should -Contain $testFile
+        }
+
+        It "Should skip files that already have -Omit parameter" {
+            $testFile = Join-Path $script:TestDir "Get-NBAlreadyHasOmit.ps1"
+            @'
+function Get-NBAlreadyHasOmit {
+    param(
+        [string[]]$Fields,
+        [string[]]$Omit,
+        [switch]$Raw
+    )
+}
+'@ | Set-Content -Path $testFile
+
+            . $ScriptPath
+            $files = Get-FilesNeedingOmit -Path $script:TestDir
+
+            $files | Should -Not -Contain $testFile
+        }
+
+        It "Should skip files without -Fields parameter" {
+            $testFile = Join-Path $script:TestDir "Get-NBNoFields.ps1"
+            @'
+function Get-NBNoFields {
+    param(
+        [switch]$Raw
+    )
+}
+'@ | Set-Content -Path $testFile
+
+            . $ScriptPath
+            $files = Get-FilesNeedingOmit -Path $script:TestDir
+
+            $files | Should -Not -Contain $testFile
+        }
+
+        It "Should only process Get-NB*.ps1 files" {
+            $testFile = Join-Path $script:TestDir "Set-NBTestFunction.ps1"
+            @'
+function Set-NBTestFunction {
+    param(
+        [string[]]$Fields,
+        [switch]$Raw
+    )
+}
+'@ | Set-Content -Path $testFile
+
+            . $ScriptPath
+            $files = Get-FilesNeedingOmit -Path $script:TestDir
+
+            $files | Should -Not -Contain $testFile
+        }
+    }
+
+    Context "Parameter Insertion" {
+
+        It "Should insert -Omit parameter after -Fields parameter" {
+            $testFile = Join-Path $script:TestDir "Get-NBInsertTest.ps1"
+            $originalContent = @'
+function Get-NBInsertTest {
+    param(
+        [string[]]$Fields,
+
+        [switch]$Raw
+    )
+}
+'@
+            $originalContent | Set-Content -Path $testFile
+
+            . $ScriptPath
+            Add-OmitParameter -FilePath $testFile
+
+            $newContent = Get-Content -Path $testFile -Raw
+
+            # Verify -Omit is present
+            $newContent | Should -Match '\[string\[\]\]\$Omit'
+
+            # Verify -Omit comes after -Fields
+            $fieldsIndex = $newContent.IndexOf('$Fields')
+            $omitIndex = $newContent.IndexOf('$Omit')
+            $omitIndex | Should -BeGreaterThan $fieldsIndex
+        }
+
+        It "Should handle param block with trailing comma after Fields" {
+            $testFile = Join-Path $script:TestDir "Get-NBTrailingComma.ps1"
+            @'
+function Get-NBTrailingComma {
+    param(
+        [string[]]$Fields,
+        [switch]$Raw
+    )
+}
+'@ | Set-Content -Path $testFile
+
+            . $ScriptPath
+            Add-OmitParameter -FilePath $testFile
+
+            $newContent = Get-Content -Path $testFile -Raw
+            $newContent | Should -Match '\[string\[\]\]\$Omit'
+        }
+
+        It "Should preserve original indentation" {
+            $testFile = Join-Path $script:TestDir "Get-NBIndentation.ps1"
+            @'
+function Get-NBIndentation {
+    param(
+        [string[]]$Fields,
+
+        [switch]$Raw
+    )
+}
+'@ | Set-Content -Path $testFile
+
+            . $ScriptPath
+            Add-OmitParameter -FilePath $testFile
+
+            $lines = Get-Content -Path $testFile
+            $omitLine = $lines | Where-Object { $_ -match '\$Omit' }
+
+            # Should have same indentation as $Fields line (8 spaces)
+            $omitLine | Should -Match '^\s{8}\[string\[\]\]\$Omit'
+        }
+    }
+
+    Context "Documentation Insertion" {
+
+        It "Should add .PARAMETER Omit documentation" {
+            $testFile = Join-Path $script:TestDir "Get-NBDocTest.ps1"
+            @'
+<#
+.SYNOPSIS
+    Test function
+
+.PARAMETER Fields
+    Field selection.
+
+.PARAMETER Raw
+    Return raw response.
+#>
+function Get-NBDocTest {
+    param(
+        [string[]]$Fields,
+        [switch]$Raw
+    )
+}
+'@ | Set-Content -Path $testFile
+
+            . $ScriptPath
+            Add-OmitParameter -FilePath $testFile
+
+            $newContent = Get-Content -Path $testFile -Raw
+            $newContent | Should -Match '\.PARAMETER Omit'
+            $newContent | Should -Match 'Netbox 4\.5'
+        }
+
+        It "Should add .PARAMETER Omit after .PARAMETER Fields" {
+            $testFile = Join-Path $script:TestDir "Get-NBDocOrder.ps1"
+            @'
+<#
+.PARAMETER Fields
+    Field selection.
+
+.PARAMETER Raw
+    Return raw response.
+#>
+function Get-NBDocOrder {
+    param(
+        [string[]]$Fields,
+        [switch]$Raw
+    )
+}
+'@ | Set-Content -Path $testFile
+
+            . $ScriptPath
+            Add-OmitParameter -FilePath $testFile
+
+            $newContent = Get-Content -Path $testFile -Raw
+            $fieldsDocIndex = $newContent.IndexOf('.PARAMETER Fields')
+            $omitDocIndex = $newContent.IndexOf('.PARAMETER Omit')
+            $rawDocIndex = $newContent.IndexOf('.PARAMETER Raw')
+
+            $omitDocIndex | Should -BeGreaterThan $fieldsDocIndex
+            $omitDocIndex | Should -BeLessThan $rawDocIndex
+        }
+    }
+
+    Context "File Integrity" {
+
+        It "Should produce valid PowerShell syntax" {
+            $testFile = Join-Path $script:TestDir "Get-NBSyntaxTest.ps1"
+            @'
+<#
+.SYNOPSIS
+    Test function
+.PARAMETER Fields
+    Fields to include.
+.PARAMETER Raw
+    Raw output.
+#>
+function Get-NBSyntaxTest {
+    [CmdletBinding()]
+    param(
+        [string[]]$Fields,
+        [switch]$Raw
+    )
+    process {
+        Write-Output "Test"
+    }
+}
+'@ | Set-Content -Path $testFile
+
+            . $ScriptPath
+            Add-OmitParameter -FilePath $testFile
+
+            # Parse the file - should not throw
+            $errors = $null
+            $tokens = $null
+            $ast = [System.Management.Automation.Language.Parser]::ParseFile(
+                $testFile,
+                [ref]$tokens,
+                [ref]$errors
+            )
+
+            $errors | Should -BeNullOrEmpty
+        }
+
+        It "Should not corrupt files with special characters" {
+            $testFile = Join-Path $script:TestDir "Get-NBSpecialChars.ps1"
+            @'
+<#
+.SYNOPSIS
+    Test with special chars: é, ñ, ü
+.PARAMETER Fields
+    Fields to include.
+#>
+function Get-NBSpecialChars {
+    param(
+        [string[]]$Fields,
+        [switch]$Raw
+    )
+    # Comment with special: © ® ™
+}
+'@ | Set-Content -Path $testFile -Encoding UTF8
+
+            . $ScriptPath
+            Add-OmitParameter -FilePath $testFile
+
+            $newContent = Get-Content -Path $testFile -Raw
+            $newContent | Should -Match 'é, ñ, ü'
+            $newContent | Should -Match '© ® ™'
+        }
+
+        It "Should preserve BOM if present" {
+            $testFile = Join-Path $script:TestDir "Get-NBBOM.ps1"
+            $content = @'
+function Get-NBBOM {
+    param(
+        [string[]]$Fields,
+        [switch]$Raw
+    )
+}
+'@
+            # Write with BOM
+            [System.IO.File]::WriteAllText($testFile, $content, [System.Text.UTF8Encoding]::new($true))
+
+            $originalBytes = [System.IO.File]::ReadAllBytes($testFile)
+            $hadBOM = ($originalBytes[0] -eq 0xEF -and $originalBytes[1] -eq 0xBB -and $originalBytes[2] -eq 0xBF)
+
+            . $ScriptPath
+            Add-OmitParameter -FilePath $testFile
+
+            $newBytes = [System.IO.File]::ReadAllBytes($testFile)
+            $hasBOM = ($newBytes[0] -eq 0xEF -and $newBytes[1] -eq 0xBB -and $newBytes[2] -eq 0xBF)
+
+            $hasBOM | Should -Be $hadBOM
+        }
+    }
+
+    Context "Idempotency" {
+
+        It "Should not modify file if run twice" {
+            $testFile = Join-Path $script:TestDir "Get-NBIdempotent.ps1"
+            @'
+function Get-NBIdempotent {
+    param(
+        [string[]]$Fields,
+        [switch]$Raw
+    )
+}
+'@ | Set-Content -Path $testFile
+
+            . $ScriptPath
+            Add-OmitParameter -FilePath $testFile
+            $firstContent = Get-Content -Path $testFile -Raw
+
+            Add-OmitParameter -FilePath $testFile
+            $secondContent = Get-Content -Path $testFile -Raw
+
+            $secondContent | Should -BeExactly $firstContent
+        }
+    }
+
+    Context "Edge Cases" {
+
+        It "Should handle files with multiple param blocks (nested functions)" {
+            $testFile = Join-Path $script:TestDir "Get-NBNestedFunctions.ps1"
+            @'
+function Get-NBNestedFunctions {
+    param(
+        [string[]]$Fields,
+        [switch]$Raw
+    )
+
+    # Helper function inside
+    function InnerHelper {
+        param([string]$Value)
+    }
+}
+'@ | Set-Content -Path $testFile
+
+            . $ScriptPath
+            Add-OmitParameter -FilePath $testFile
+
+            $newContent = Get-Content -Path $testFile -Raw
+
+            # Should only have ONE $Omit
+            $omitCount = ([regex]::Matches($newContent, '\$Omit')).Count
+            $omitCount | Should -Be 1
+        }
+
+        It "Should handle different line endings (CRLF vs LF)" {
+            $testFile = Join-Path $script:TestDir "Get-NBLineEndings.ps1"
+            $content = "function Get-NBLineEndings {`r`n    param(`r`n        [string[]]`$Fields,`r`n        [switch]`$Raw`r`n    )`r`n}"
+            [System.IO.File]::WriteAllText($testFile, $content)
+
+            . $ScriptPath
+            Add-OmitParameter -FilePath $testFile
+
+            $newContent = Get-Content -Path $testFile -Raw
+            $newContent | Should -Match '\[string\[\]\]\$Omit'
+
+            # Should preserve CRLF
+            $newContent | Should -Match "`r`n"
+        }
+    }
+
+    Context "Real-World Sample" {
+
+        It "Should correctly modify a real Get function pattern" {
+            $testFile = Join-Path $script:TestDir "Get-NBDCIMSite.ps1"
+            @'
+<#
+.SYNOPSIS
+    Retrieves Site objects from Netbox DCIM module.
+
+.DESCRIPTION
+    Retrieves Site objects from Netbox DCIM module.
+
+.PARAMETER All
+    Automatically fetch all pages of results.
+
+.PARAMETER Brief
+    Return minimal representation.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+
+.PARAMETER Raw
+    Return the raw API response.
+
+.EXAMPLE
+    Get-NBDCIMSite
+
+.LINK
+    https://netbox.readthedocs.io/en/stable/rest-api/overview/
+#>
+function Get-NBDCIMSite {
+    [CmdletBinding(DefaultParameterSetName = 'Query')]
+    [OutputType([PSCustomObject])]
+    param (
+        [switch]$All,
+
+        [ValidateRange(1, 1000)]
+        [int]$PageSize = 100,
+
+        [switch]$Brief,
+
+        [string[]]$Fields,
+
+        [Parameter(ParameterSetName = 'ByID', ValueFromPipelineByPropertyName = $true)]
+        [uint64[]]$Id,
+
+        [switch]$Raw
+    )
+
+    process {
+        Write-Verbose "Retrieving DCIM Site"
+        # ... implementation
+    }
+}
+'@ | Set-Content -Path $testFile
+
+            . $ScriptPath
+            Add-OmitParameter -FilePath $testFile
+
+            $newContent = Get-Content -Path $testFile -Raw
+
+            # Verify all requirements
+            $newContent | Should -Match '\[string\[\]\]\$Omit'
+            $newContent | Should -Match '\.PARAMETER Omit'
+            $newContent | Should -Match 'Netbox 4\.5'
+
+            # Parse check
+            $errors = $null
+            $ast = [System.Management.Automation.Language.Parser]::ParseFile(
+                $testFile,
+                [ref]$null,
+                [ref]$errors
+            )
+            $errors | Should -BeNullOrEmpty
+
+            # Verify parameter order in AST
+            $funcDef = $ast.FindAll({ $args[0] -is [System.Management.Automation.Language.FunctionDefinitionAst] }, $true)[0]
+            $params = $funcDef.Body.ParamBlock.Parameters.Name.VariablePath.UserPath
+
+            $fieldsIndex = [array]::IndexOf($params, 'Fields')
+            $omitIndex = [array]::IndexOf($params, 'Omit')
+
+            $omitIndex | Should -Be ($fieldsIndex + 1)
+        }
+    }
+}

--- a/scripts/Add-OmitParameter.ps1
+++ b/scripts/Add-OmitParameter.ps1
@@ -1,0 +1,182 @@
+<#
+.SYNOPSIS
+    Adds -Omit parameter to Get-NB* functions that have -Fields but not -Omit.
+
+.DESCRIPTION
+    This script automates adding the -Omit parameter to PowerNetbox Get functions.
+    It identifies files that have the -Fields parameter but are missing -Omit,
+    then adds the parameter and documentation in the correct locations.
+
+    Can be dot-sourced to import functions, or run directly to process files.
+
+.EXAMPLE
+    .\Add-OmitParameter.ps1 -WhatIf
+    Shows which files would be modified.
+
+.EXAMPLE
+    .\Add-OmitParameter.ps1
+    Modifies all applicable files.
+
+.EXAMPLE
+    . .\Add-OmitParameter.ps1
+    Get-FilesNeedingOmit -Path ./Functions
+    Dot-source to use functions directly.
+#>
+
+function Get-FilesNeedingOmit {
+    <#
+    .SYNOPSIS
+        Returns files that need the -Omit parameter added.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Path
+    )
+
+    $files = Get-ChildItem -Path $Path -Filter "Get-NB*.ps1" -Recurse -File
+
+    $needsOmit = @()
+
+    foreach ($file in $files) {
+        $content = Get-Content -Path $file.FullName -Raw
+
+        # Must have $Fields parameter
+        $hasFields = $content -match '\[string\[\]\]\$Fields'
+
+        # Must NOT already have $Omit parameter
+        $hasOmit = $content -match '\[string\[\]\]\$Omit'
+
+        if ($hasFields -and -not $hasOmit) {
+            $needsOmit += $file.FullName
+        }
+    }
+
+    return $needsOmit
+}
+
+function Add-OmitParameter {
+    <#
+    .SYNOPSIS
+        Adds -Omit parameter to a single file.
+    #>
+    [CmdletBinding(SupportsShouldProcess)]
+    param(
+        [Parameter(Mandatory)]
+        [string]$FilePath
+    )
+
+    # Read file preserving encoding
+    $originalBytes = [System.IO.File]::ReadAllBytes($FilePath)
+    $hasBOM = ($originalBytes.Length -ge 3 -and
+               $originalBytes[0] -eq 0xEF -and
+               $originalBytes[1] -eq 0xBB -and
+               $originalBytes[2] -eq 0xBF)
+
+    $content = Get-Content -Path $FilePath -Raw
+
+    # Check if already has -Omit
+    if ($content -match '\[string\[\]\]\$Omit') {
+        Write-Verbose "File already has -Omit parameter: $FilePath"
+        return
+    }
+
+    # Check if has -Fields
+    if ($content -notmatch '\[string\[\]\]\$Fields') {
+        Write-Verbose "File does not have -Fields parameter: $FilePath"
+        return
+    }
+
+    # Detect line ending style
+    $lineEnding = if ($content -match "`r`n") { "`r`n" } else { "`n" }
+
+    # 1. Add parameter after $Fields in param block
+    # Pattern: Find [string[]]$Fields, followed by comma and possible whitespace/newline
+    $paramPattern = '(\[string\[\]\]\$Fields)(,?)(\s*)'
+
+    # Determine indentation by looking at the $Fields line
+    $fieldsMatch = [regex]::Match($content, '(?m)^(\s*)\[string\[\]\]\$Fields')
+    $indent = if ($fieldsMatch.Success) { $fieldsMatch.Groups[1].Value } else { "        " }
+
+    # Replace: Add $Omit after $Fields
+    $paramReplacement = '$1,' + $lineEnding + $lineEnding + $indent + '[string[]]$Omit$2$3'
+    $newContent = $content -replace $paramPattern, $paramReplacement
+
+    # 2. Add .PARAMETER Omit documentation after .PARAMETER Fields
+    $docPattern = '(\.PARAMETER Fields\s*\r?\n(?:.*?\r?\n)*?)(\s*\.PARAMETER|\s*\.EXAMPLE|\s*\.LINK|\s*#>)'
+
+    $omitDoc = @"
+`$1
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+`$2
+"@
+
+    # Only add doc if .PARAMETER Fields exists
+    if ($newContent -match '\.PARAMETER Fields') {
+        $newContent = $newContent -replace $docPattern, $omitDoc
+    }
+
+    # Verify syntax before writing
+    $errors = $null
+    $null = [System.Management.Automation.Language.Parser]::ParseInput(
+        $newContent,
+        [ref]$null,
+        [ref]$errors
+    )
+
+    if ($errors) {
+        Write-Error "Syntax errors would be introduced in $FilePath. Aborting."
+        Write-Error ($errors | Out-String)
+        return
+    }
+
+    # Write file with original encoding
+    if ($PSCmdlet.ShouldProcess($FilePath, "Add -Omit parameter")) {
+        $encoding = if ($hasBOM) {
+            [System.Text.UTF8Encoding]::new($true)
+        } else {
+            [System.Text.UTF8Encoding]::new($false)
+        }
+
+        [System.IO.File]::WriteAllText($FilePath, $newContent, $encoding)
+        Write-Verbose "Updated: $FilePath"
+    }
+}
+
+function Invoke-AddOmitParameter {
+    <#
+    .SYNOPSIS
+        Main entry point - processes all files needing -Omit parameter.
+    #>
+    [CmdletBinding(SupportsShouldProcess)]
+    param(
+        [string]$Path = (Join-Path $PSScriptRoot ".." "Functions")
+    )
+
+    $files = Get-FilesNeedingOmit -Path $Path
+
+    Write-Host "Found $($files.Count) files needing -Omit parameter" -ForegroundColor Cyan
+
+    if ($files.Count -eq 0) {
+        Write-Host "No files need modification." -ForegroundColor Green
+        return
+    }
+
+    $modified = 0
+    foreach ($file in $files) {
+        if ($PSCmdlet.ShouldProcess($file, "Add -Omit parameter")) {
+            Add-OmitParameter -FilePath $file -Confirm:$false
+            $modified++
+        }
+    }
+
+    Write-Host "Done! Modified $modified files." -ForegroundColor Green
+}
+
+# Main execution when run directly (not dot-sourced)
+if ($MyInvocation.InvocationName -ne '.') {
+    Invoke-AddOmitParameter @args
+}


### PR DESCRIPTION
## Summary

Completes the addition of `-Omit` parameter to **all 123 Get functions** that have the `-Fields` parameter. This enables users to exclude specific fields from API responses (Netbox 4.5.0+).

## Approach

Used a **test-driven scripted approach**:
1. Created comprehensive Pester tests (`Scripts/Add-OmitParameter.Tests.ps1`) - 16 test cases
2. Created automation script (`Scripts/Add-OmitParameter.ps1`)
3. Ran tests to verify script correctness
4. Executed script to modify all 121 remaining files

## Test Coverage

The script was validated against:
- File detection (skip files with -Omit, skip files without -Fields)
- Parameter insertion (correct placement, indentation preservation)
- Documentation insertion (.PARAMETER Omit after .PARAMETER Fields)
- File integrity (valid PowerShell syntax, special characters, BOM preservation)
- Idempotency (safe to run multiple times)
- Edge cases (nested functions, CRLF vs LF)
- Real-world sample (full Get function pattern)

## Changes

| Category | Count |
|----------|-------|
| Get functions modified | 121 |
| Total Get functions with -Omit | 123 |
| New script files | 2 |
| Test cases | 16 |

## Usage

```powershell
# Exclude specific fields from response
Get-NBDCIMSite -Omit 'description','comments'

# Works with any Get function
Get-NBIPAMPrefix -Omit 'custom_fields'
Get-NBVirtualMachine -Omit 'config_context','local_context_data'
```

## Test plan
- [x] Script tests pass (16/16)
- [x] All 137 Get-NB*.ps1 files have valid PowerShell syntax
- [x] Module builds successfully
- [ ] CI unit tests
- [ ] CI integration tests

Closes #256

---
🤖 Generated with [Claude Code](https://claude.ai/code)
