### PR TITLE
fix: Tenancy Set-* ConfirmImpact, $Force, and PATCH casing

### DIFF
--- a/Functions/Tenancy/ContactAssignment/Set-NBContactAssignment.ps1
+++ b/Functions/Tenancy/ContactAssignment/Set-NBContactAssignment.ps1
@@ -33,7 +33,7 @@ function Set-NBContactAssignment {
         Valid content types: https://docs.netbox.dev/en/stable/features/contacts/#contacts_1
 #>
 
-    [CmdletBinding(ConfirmImpact = 'Low',
+    [CmdletBinding(ConfirmImpact = 'Medium',
                    SupportsShouldProcess = $true)]
     [OutputType([pscustomobject])]
     param
@@ -59,7 +59,7 @@ function Set-NBContactAssignment {
     )
 
     begin {
-        $Method = 'Patch'
+        $Method = 'PATCH'
     }
 
     process {
@@ -67,7 +67,7 @@ function Set-NBContactAssignment {
         foreach ($ContactAssignmentId in $Id) {
             $Segments = [System.Collections.ArrayList]::new(@('tenancy', 'contact-assignments', $ContactAssignmentId))
 
-            $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw', 'Force'
+            $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw'
 
             $URI = BuildNewURI -Segments $URIComponents.Segments
 

--- a/Functions/Tenancy/ContactRoles/Set-NBContactRole.ps1
+++ b/Functions/Tenancy/ContactRoles/Set-NBContactRole.ps1
@@ -26,7 +26,7 @@ function Set-NBContactRole {
         PS C:\> Set-NBContactRole -Id 1 -Name 'Updated Role Name'
 #>
 
-    [CmdletBinding(ConfirmImpact = 'Low',
+    [CmdletBinding(ConfirmImpact = 'Medium',
                    SupportsShouldProcess = $true)]
     [OutputType([pscustomobject])]
     param
@@ -60,11 +60,11 @@ function Set-NBContactRole {
         foreach ($ContactRoleId in $Id) {
             $Segments = [System.Collections.ArrayList]::new(@('tenancy', 'contact-roles', $ContactRoleId))
 
-            $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw', 'Force'
+            $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw'
 
             $URI = BuildNewURI -Segments $URIComponents.Segments
 
-            if ($Force -or $PSCmdlet.ShouldProcess("ID $ContactRoleId", 'Update contact role')) {
+            if ($PSCmdlet.ShouldProcess("ID $ContactRoleId", 'Update contact role')) {
                 InvokeNetboxRequest -URI $URI -Method $Method -Body $URIComponents.Parameters -Raw:$Raw
             }
         }

--- a/Functions/Tenancy/Contacts/Set-NBContact.ps1
+++ b/Functions/Tenancy/Contacts/Set-NBContact.ps1
@@ -51,7 +51,7 @@ function Set-NBContact {
 
 #>
 
-    [CmdletBinding(ConfirmImpact = 'Low',
+    [CmdletBinding(ConfirmImpact = 'Medium',
                    SupportsShouldProcess = $true)]
     [OutputType([pscustomobject])]
     param


### PR DESCRIPTION
## Summary\n- Change `ConfirmImpact` from `'Low'` to `'Medium'` on `Set-NBContactAssignment`, `Set-NBContactRole`, and `Set-NBContact` (standard for remote API-modifying functions)\n- Remove undeclared `$Force` reference from `Set-NBContactRole` ShouldProcess conditional\n- Remove phantom `'Force'` from `SkipParameterByName` in `Set-NBContactAssignment` and `Set-NBContactRole`\n- Fix `$Method` casing from `'Patch'` to `'PATCH'` in `Set-NBContactAssignment`\n\nFixes #264, fixes #273\n\n## Test plan\n- [ ] Unit tests pass for Tenancy module\n- [ ] `Set-NBContactAssignment`, `Set-NBContactRole`, `Set-NBContact` prompt at correct ConfirmImpact level\n- [ ] No `$Force` variable warnings in `Set-NBContactRole`