### PR TITLE
fix: Fix truncated docs in Wireless module functions

### DIFF
--- a/Functions/Wireless/WirelessLAN/New-NBWirelessLAN.ps1
+++ b/Functions/Wireless/WirelessLAN/New-NBWirelessLAN.ps1
@@ -1,9 +1,9 @@
 <#
 .SYNOPSIS
-    Creates a new irelessLAN in Netbox W module.
+    Creates a new Wireless LAN in Netbox Wireless module.
 
 .DESCRIPTION
-    Creates a new irelessLAN in Netbox W module.
+    Creates a new Wireless LAN in Netbox Wireless module.
     Supports pipeline input for Id parameter where applicable.
 
 .PARAMETER Raw

--- a/Functions/Wireless/WirelessLAN/Remove-NBWirelessLAN.ps1
+++ b/Functions/Wireless/WirelessLAN/Remove-NBWirelessLAN.ps1
@@ -1,9 +1,9 @@
 <#
 .SYNOPSIS
-    Removes a irelessLAN from Netbox W module.
+    Removes a Wireless LAN from Netbox Wireless module.
 
 .DESCRIPTION
-    Removes a irelessLAN from Netbox W module.
+    Removes a Wireless LAN from Netbox Wireless module.
     Supports pipeline input for Id parameter where applicable.
 
 .PARAMETER Raw

--- a/Functions/Wireless/WirelessLAN/Set-NBWirelessLAN.ps1
+++ b/Functions/Wireless/WirelessLAN/Set-NBWirelessLAN.ps1
@@ -1,9 +1,9 @@
 <#
 .SYNOPSIS
-    Updates an existing WirelessLAN in Netbox W module.
+    Updates an existing Wireless LAN in Netbox Wireless module.
 
 .DESCRIPTION
-    Updates an existing WirelessLAN in Netbox W module.
+    Updates an existing Wireless LAN in Netbox Wireless module.
     Supports pipeline input for Id parameter where applicable.
 
 .PARAMETER Raw

--- a/Functions/Wireless/WirelessLANGroup/Get-NBWirelessLANGroup.ps1
+++ b/Functions/Wireless/WirelessLANGroup/Get-NBWirelessLANGroup.ps1
@@ -1,9 +1,9 @@
 <#
 .SYNOPSIS
-    Retrieves Wireless LANGroup objects from Netbox Wireless module.
+    Retrieves Wireless LAN Group objects from Netbox Wireless module.
 
 .DESCRIPTION
-    Retrieves Wireless LANGroup objects from Netbox Wireless module.
+    Retrieves Wireless LAN Group objects from Netbox Wireless module.
 
 .PARAMETER Raw
     Return the raw API response instead of the results array.
@@ -36,7 +36,7 @@ function Get-NBWirelessLANGroup {
         [uint16]$Limit,[ValidateRange(0, [int]::MaxValue)]
         [uint16]$Offset,[switch]$Raw)
     process {
-        Write-Verbose "Retrieving Wireless LANGroup"
+        Write-Verbose "Retrieving Wireless LAN Group"
         switch ($PSCmdlet.ParameterSetName) {
             'ByID' { foreach ($i in $Id) { InvokeNetboxRequest -URI (BuildNewURI -Segments @('wireless','wireless-lan-groups',$i)) -Raw:$Raw } }
             default { $s = [System.Collections.ArrayList]::new(@('wireless','wireless-lan-groups')); $u = BuildURIComponents -URISegments $s.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'All', 'PageSize'; InvokeNetboxRequest -URI (BuildNewURI -Segments $u.Segments -Parameters $u.Parameters) -Raw:$Raw -All:$All -PageSize $PageSize }

--- a/Functions/Wireless/WirelessLANGroup/New-NBWirelessLANGroup.ps1
+++ b/Functions/Wireless/WirelessLANGroup/New-NBWirelessLANGroup.ps1
@@ -1,9 +1,9 @@
 <#
 .SYNOPSIS
-    Creates a new WirelessLANGroup in Netbox Wireless module.
+    Creates a new Wireless LAN Group in Netbox Wireless module.
 
 .DESCRIPTION
-    Creates a new WirelessLANGroup in Netbox Wireless module.
+    Creates a new Wireless LAN Group in Netbox Wireless module.
     Supports pipeline input for Id parameter where applicable.
 
 .PARAMETER Raw

--- a/Functions/Wireless/WirelessLANGroup/Remove-NBWirelessLANGroup.ps1
+++ b/Functions/Wireless/WirelessLANGroup/Remove-NBWirelessLANGroup.ps1
@@ -1,9 +1,9 @@
 <#
 .SYNOPSIS
-    Removes a irelessLANGroup from Netbox W module.
+    Removes a Wireless LAN Group from Netbox Wireless module.
 
 .DESCRIPTION
-    Removes a irelessLANGroup from Netbox W module.
+    Removes a Wireless LAN Group from Netbox Wireless module.
     Supports pipeline input for Id parameter where applicable.
 
 .PARAMETER Raw

--- a/Functions/Wireless/WirelessLANGroup/Set-NBWirelessLANGroup.ps1
+++ b/Functions/Wireless/WirelessLANGroup/Set-NBWirelessLANGroup.ps1
@@ -1,9 +1,9 @@
 <#
 .SYNOPSIS
-    Updates an existing irelessLANGroup in Netbox W module.
+    Updates an existing Wireless LAN Group in Netbox Wireless module.
 
 .DESCRIPTION
-    Updates an existing irelessLANGroup in Netbox W module.
+    Updates an existing Wireless LAN Group in Netbox Wireless module.
     Supports pipeline input for Id parameter where applicable.
 
 .PARAMETER Raw

--- a/Functions/Wireless/WirelessLink/New-NBWirelessLink.ps1
+++ b/Functions/Wireless/WirelessLink/New-NBWirelessLink.ps1
@@ -1,9 +1,9 @@
 <#
 .SYNOPSIS
-    Creates a new irelessLink in Netbox W module.
+    Creates a new Wireless Link in Netbox Wireless module.
 
 .DESCRIPTION
-    Creates a new irelessLink in Netbox W module.
+    Creates a new Wireless Link in Netbox Wireless module.
     Supports pipeline input for Id parameter where applicable.
 
 .PARAMETER Raw

--- a/Functions/Wireless/WirelessLink/Remove-NBWirelessLink.ps1
+++ b/Functions/Wireless/WirelessLink/Remove-NBWirelessLink.ps1
@@ -1,9 +1,9 @@
 <#
 .SYNOPSIS
-    Removes a irelessLink from Netbox W module.
+    Removes a Wireless Link from Netbox Wireless module.
 
 .DESCRIPTION
-    Removes a irelessLink from Netbox W module.
+    Removes a Wireless Link from Netbox Wireless module.
     Supports pipeline input for Id parameter where applicable.
 
 .PARAMETER Raw

--- a/Functions/Wireless/WirelessLink/Set-NBWirelessLink.ps1
+++ b/Functions/Wireless/WirelessLink/Set-NBWirelessLink.ps1
@@ -1,9 +1,9 @@
 <#
 .SYNOPSIS
-    Updates an existing irelessLink in Netbox W module.
+    Updates an existing Wireless Link in Netbox Wireless module.
 
 .DESCRIPTION
-    Updates an existing irelessLink in Netbox W module.
+    Updates an existing Wireless Link in Netbox Wireless module.
     Supports pipeline input for Id parameter where applicable.
 
 .PARAMETER Raw


### PR DESCRIPTION
## Summary\n- Fix synopsis/description text in 8 Wireless module functions where \"Wireless\" was truncated\n- \"irelessLAN\" → \"Wireless LAN\", \"irelessLink\" → \"Wireless Link\", \"Netbox W module\" → \"Netbox Wireless module\"\n- Affected: WirelessLAN (New, Set, Remove), WirelessLANGroup (Set, Remove), WirelessLink (New, Set, Remove)\n\nFixes #263\n\n## Test plan\n- [ ] `Get-Help New-NBWirelessLAN` shows correct synopsis\n- [ ] `Get-Help Set-NBWirelessLink` shows correct synopsis\n- [ ] Unit tests pass