### PR TITLE
fix: Helper function bugs (verbose, error handler, 500 matching)

### DIFF
--- a/Functions/Extras/ImageAttachments/New-NBImageAttachment.ps1
+++ b/Functions/Extras/ImageAttachments/New-NBImageAttachment.ps1
@@ -117,7 +117,8 @@ function New-NBImageAttachment {
                     }
                 }
                 catch {
-                    $ErrorBody = GetNetboxAPIErrorBody -ErrorRecord $_
+                    $errorResponse = GetNetboxAPIErrorBody -Response $_.Exception.Response
+                    $ErrorBody = $errorResponse.Body
                     $PSCmdlet.ThrowTerminatingError(
                         [System.Management.Automation.ErrorRecord]::new(
                             [System.Exception]::new("Failed to upload image attachment: $ErrorBody"),

--- a/Functions/Extras/ImageAttachments/New-NBImageAttachment.ps1
+++ b/Functions/Extras/ImageAttachments/New-NBImageAttachment.ps1
@@ -117,8 +117,7 @@ function New-NBImageAttachment {
                     }
                 }
                 catch {
-                    $errorResponse = GetNetboxAPIErrorBody -Response $_.Exception.Response
-                    $ErrorBody = $errorResponse.Body
+                    $ErrorBody = (GetNetboxAPIErrorBody -Response $_.Exception.Response).Body
                     $PSCmdlet.ThrowTerminatingError(
                         [System.Management.Automation.ErrorRecord]::new(
                             [System.Exception]::new("Failed to upload image attachment: $ErrorBody"),

--- a/Functions/Helpers/Send-NBBulkRequest.ps1
+++ b/Functions/Helpers/Send-NBBulkRequest.ps1
@@ -130,7 +130,7 @@ function Send-NBBulkRequest {
 
             # Check if this is a 500 Internal Server Error
             # This can occur due to Redis cache inconsistency when referencing newly created objects
-            if ($errorMessage -like "*500 Internal Server Error*" -or $errorMessage -like "*500*") {
+            if ($errorMessage -like "*500 Internal Server Error*") {
                 Write-Warning "Batch $currentBatch failed with 500 Server Error. Retrying $($batch.Count) items sequentially with exponential backoff..."
 
                 # Wait before retrying to allow Redis cache to sync (longer initial delay)

--- a/Functions/Setup/Support/SetupNetboxConfigVariable.ps1
+++ b/Functions/Setup/Support/SetupNetboxConfigVariable.ps1
@@ -7,7 +7,7 @@ function SetupNetboxConfigVariable {
 
     Write-Verbose "Checking for NetboxConfig hashtable"
     if ((-not ($script:NetboxConfig)) -or $Overwrite) {
-        Write-Verbose "Creating Netbox Confighashtable"
+        Write-Verbose "Creating Netbox Config hashtable"
         $script:NetboxConfig = @{
             'Connected'     = $false
             'Choices'       = @{
@@ -17,6 +17,7 @@ function SetupNetboxConfigVariable {
             'BranchStack'   = [System.Collections.Generic.Stack[object]]::new()
         }
     }
-
-    Write-Verbose "NetboxConfig hashtable already exists"
+    else {
+        Write-Verbose "NetboxConfig hashtable already exists"
+    }
 }


### PR DESCRIPTION
## Summary\n- **SetupNetboxConfigVariable** (#267): Move \"already exists\" verbose message into `else` block so it only prints when config was NOT just created\n- **New-NBImageAttachment** (#269): Fix `GetNetboxAPIErrorBody` call — wrong parameter name (`-ErrorRecord` → `-Response`) and wrong value (`$_` → `$_.Exception.Response`)\n- **Send-NBBulkRequest** (#270): Remove overly broad `\"*500*\"` pattern that could match any error containing \"500\"; keep only the specific `\"*500 Internal Server Error*\"` match\n\nFixes #267, fixes #269, fixes #270\n\n## Test plan\n- [ ] Unit tests pass\n- [ ] `New-NBImageAttachment` error messages show API error details on failure\n- [ ] `Send-NBBulkRequest` only retries on actual 500 errors, not other errors containing \"500\"