### PR TITLE
fix: Parameter types, missing -Raw, and unnecessary GET call

### DIFF
--- a/Functions/DCIM/FrontPorts/New-NBDCIMFrontPort.ps1
+++ b/Functions/DCIM/FrontPorts/New-NBDCIMFrontPort.ps1
@@ -124,7 +124,9 @@ function New-NBDCIMFrontPort {
 
         [bool]$Mark_Connected,
 
-        [uint64[]]$Tags
+        [uint64[]]$Tags,
+
+        [switch]$Raw
     )
 
     process {
@@ -138,7 +140,7 @@ function New-NBDCIMFrontPort {
         $Segments = [System.Collections.ArrayList]::new(@('dcim', 'front-ports'))
 
         # Use BuildURIComponents but skip port mapping params (handled separately)
-        $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Rear_Ports', 'Rear_Port', 'Rear_Port_Position'
+        $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Rear_Ports', 'Rear_Port', 'Rear_Port_Position', 'Raw'
 
         $URI = BuildNewURI -Segments $URIComponents.Segments
 
@@ -174,7 +176,7 @@ function New-NBDCIMFrontPort {
         }
 
         if ($PSCmdlet.ShouldProcess("Device $Device", "Create front port '$Name'")) {
-            InvokeNetboxRequest -URI $URI -Body $URIComponents.Parameters -Method POST
+            InvokeNetboxRequest -URI $URI -Body $URIComponents.Parameters -Method POST -Raw:$Raw
         }
     }
 }

--- a/Functions/DCIM/Racks/Get-NBDCIMRackElevation.ps1
+++ b/Functions/DCIM/Racks/Get-NBDCIMRackElevation.ps1
@@ -90,8 +90,8 @@ function Get-NBDCIMRackElevation {
         [ValidateRange(1, 1000)]
         [uint16]$Limit,
 
-        [ValidateRange(0, [uint32]::MaxValue)]
-        [uint32]$Offset,
+        [ValidateRange(0, [int]::MaxValue)]
+        [uint16]$Offset,
 
         [switch]$All,
 

--- a/Functions/DCIM/Racks/Get-NBDCIMRackElevation.ps1
+++ b/Functions/DCIM/Racks/Get-NBDCIMRackElevation.ps1
@@ -90,7 +90,7 @@ function Get-NBDCIMRackElevation {
         [ValidateRange(1, 1000)]
         [uint16]$Limit,
 
-        [ValidateRange(0, [int]::MaxValue)]
+        [ValidateRange(0, [uint16]::MaxValue)]
         [uint16]$Offset,
 
         [switch]$All,

--- a/Functions/DCIM/RearPorts/New-NBDCIMRearPort.ps1
+++ b/Functions/DCIM/RearPorts/New-NBDCIMRearPort.ps1
@@ -117,7 +117,9 @@ function New-NBDCIMRearPort {
 
         [bool]$Mark_Connected,
 
-        [uint64[]]$Tags
+        [uint64[]]$Tags,
+
+        [switch]$Raw
     )
 
     process {
@@ -125,7 +127,7 @@ function New-NBDCIMRearPort {
         $Segments = [System.Collections.ArrayList]::new(@('dcim', 'rear-ports'))
 
         # Use BuildURIComponents but skip Front_Ports (handled separately)
-        $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Front_Ports'
+        $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Front_Ports', 'Raw'
 
         $URI = BuildNewURI -Segments $URIComponents.Segments
 
@@ -144,7 +146,7 @@ function New-NBDCIMRearPort {
         }
 
         if ($PSCmdlet.ShouldProcess("Device $Device", "Create rear port '$Name'")) {
-            InvokeNetboxRequest -URI $URI -Body $URIComponents.Parameters -Method POST
+            InvokeNetboxRequest -URI $URI -Body $URIComponents.Parameters -Method POST -Raw:$Raw
         }
     }
 }

--- a/Functions/IPAM/Address/Get-NBIPAMAvailableIP.ps1
+++ b/Functions/IPAM/Address/Get-NBIPAMAvailableIP.ps1
@@ -54,7 +54,7 @@ function Get-NBIPAMAvailableIP {
         [uint64]$Prefix_ID,
 
         [Alias('NumberOfIPs')]
-        [uint64]$Limit,
+        [uint16]$Limit,
 
         [switch]$Raw
     )

--- a/Functions/IPAM/Range/Set-NBIPAMAddressRange.ps1
+++ b/Functions/IPAM/Range/Set-NBIPAMAddressRange.ps1
@@ -64,10 +64,9 @@ function Set-NBIPAMAddressRange {
         foreach ($RangeID in $Id) {
             $Segments = [System.Collections.ArrayList]::new(@('ipam', 'ip-ranges', $RangeID))
 
-            Write-Verbose "Obtaining IP range from ID $RangeID"
-            $CurrentRange = Get-NBIPAMAddressRange -Id $RangeID -ErrorAction Stop
+            Write-Verbose "Updating IP range ID $RangeID"
 
-            if ($Force -or $PSCmdlet.ShouldProcess("$($CurrentRange.Start_Address) - $($CurrentRange.End_Address)", 'Set')) {
+            if ($Force -or $PSCmdlet.ShouldProcess("ID $RangeID", 'Set IP Range')) {
                 $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw', 'Force'
 
                 $URI = BuildNewURI -Segments $URIComponents.Segments


### PR DESCRIPTION
## Summary\n- **#265**: Fix `$Offset` type from `[uint32]` to `[uint16]` in `Get-NBDCIMRackElevation` and `$Limit` from `[uint64]` to `[uint16]` in `Get-NBIPAMAvailableIP` for consistency with all other Get-* functions\n- **#274**: Remove unnecessary GET call before PATCH in `Set-NBIPAMAddressRange` (missed by PR #226 performance improvements). Reduces API calls by 50% for address range updates\n- **#275**: Add missing `[switch]$Raw` parameter to `New-NBDCIMFrontPort` and `New-NBDCIMRearPort`, and pass `-Raw:$Raw` to `InvokeNetboxRequest`\n\nFixes #265, fixes #274, fixes #275\n\n## Test plan\n- [ ] Unit tests pass\n- [ ] `New-NBDCIMFrontPort -Raw` returns raw API response\n- [ ] `New-NBDCIMRearPort -Raw` returns raw API response\n- [ ] `Set-NBIPAMAddressRange` no longer makes redundant GET call