### PR TITLE
fix: Add All/PageSize to SkipParameterByName in 29 ByID branches

### DIFF
--- a/Functions/Circuits/CircuitGroupAssignments/Get-NBCircuitGroupAssignment.ps1
+++ b/Functions/Circuits/CircuitGroupAssignments/Get-NBCircuitGroupAssignment.ps1
@@ -75,7 +75,7 @@ function Get-NBCircuitGroupAssignment {
             'ById' {
                 foreach ($i in $Id) {
                     $Segments = [System.Collections.ArrayList]::new(@('circuits', 'circuit-group-assignments', $i))
-                    $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw'
+                    $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw', 'All', 'PageSize'
                     $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
                     InvokeNetboxRequest -URI $URI -Raw:$Raw -All:$All -PageSize $PageSize
                 }

--- a/Functions/Circuits/CircuitGroups/Get-NBCircuitGroup.ps1
+++ b/Functions/Circuits/CircuitGroups/Get-NBCircuitGroup.ps1
@@ -78,7 +78,7 @@ function Get-NBCircuitGroup {
             'ById' {
                 foreach ($i in $Id) {
                     $Segments = [System.Collections.ArrayList]::new(@('circuits', 'circuit-groups', $i))
-                    $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw'
+                    $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw', 'All', 'PageSize'
                     $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
                     InvokeNetboxRequest -URI $URI -Raw:$Raw -All:$All -PageSize $PageSize
                 }

--- a/Functions/Circuits/ProviderAccounts/Get-NBCircuitProviderAccount.ps1
+++ b/Functions/Circuits/ProviderAccounts/Get-NBCircuitProviderAccount.ps1
@@ -81,7 +81,7 @@ function Get-NBCircuitProviderAccount {
             'ById' {
                 foreach ($i in $Id) {
                     $Segments = [System.Collections.ArrayList]::new(@('circuits', 'provider-accounts', $i))
-                    $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw'
+                    $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw', 'All', 'PageSize'
                     $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
                     InvokeNetboxRequest -URI $URI -Raw:$Raw -All:$All -PageSize $PageSize
                 }

--- a/Functions/Circuits/ProviderNetworks/Get-NBCircuitProviderNetwork.ps1
+++ b/Functions/Circuits/ProviderNetworks/Get-NBCircuitProviderNetwork.ps1
@@ -75,7 +75,7 @@ function Get-NBCircuitProviderNetwork {
             'ById' {
                 foreach ($i in $Id) {
                     $Segments = [System.Collections.ArrayList]::new(@('circuits', 'provider-networks', $i))
-                    $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw'
+                    $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw', 'All', 'PageSize'
                     $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
                     InvokeNetboxRequest -URI $URI -Raw:$Raw -All:$All -PageSize $PageSize
                 }

--- a/Functions/Circuits/VirtualCircuitTerminations/Get-NBVirtualCircuitTermination.ps1
+++ b/Functions/Circuits/VirtualCircuitTerminations/Get-NBVirtualCircuitTermination.ps1
@@ -82,7 +82,7 @@ function Get-NBVirtualCircuitTermination {
             'ById' {
                 foreach ($i in $Id) {
                     $Segments = [System.Collections.ArrayList]::new(@('circuits', 'virtual-circuit-terminations', $i))
-                    $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw'
+                    $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw', 'All', 'PageSize'
                     $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
                     InvokeNetboxRequest -URI $URI -Raw:$Raw -All:$All -PageSize $PageSize
                 }

--- a/Functions/Circuits/VirtualCircuitTypes/Get-NBVirtualCircuitType.ps1
+++ b/Functions/Circuits/VirtualCircuitTypes/Get-NBVirtualCircuitType.ps1
@@ -75,7 +75,7 @@ function Get-NBVirtualCircuitType {
             'ById' {
                 foreach ($i in $Id) {
                     $Segments = [System.Collections.ArrayList]::new(@('circuits', 'virtual-circuit-types', $i))
-                    $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw'
+                    $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw', 'All', 'PageSize'
                     $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
                     InvokeNetboxRequest -URI $URI -Raw:$Raw -All:$All -PageSize $PageSize
                 }

--- a/Functions/Circuits/VirtualCircuits/Get-NBVirtualCircuit.ps1
+++ b/Functions/Circuits/VirtualCircuits/Get-NBVirtualCircuit.ps1
@@ -105,7 +105,7 @@ function Get-NBVirtualCircuit {
             'ById' {
                 foreach ($i in $Id) {
                     $Segments = [System.Collections.ArrayList]::new(@('circuits', 'virtual-circuits', $i))
-                    $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw'
+                    $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw', 'All', 'PageSize'
                     $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
                     InvokeNetboxRequest -URI $URI -Raw:$Raw -All:$All -PageSize $PageSize
                 }

--- a/Functions/Core/DataFiles/Get-NBDataFile.ps1
+++ b/Functions/Core/DataFiles/Get-NBDataFile.ps1
@@ -75,7 +75,7 @@ function Get-NBDataFile {
             'ById' {
                 foreach ($i in $Id) {
                     $Segments = [System.Collections.ArrayList]::new(@('core', 'data-files', $i))
-                    $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw'
+                    $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw', 'All', 'PageSize'
                     $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
                     InvokeNetboxRequest -URI $URI -Raw:$Raw -All:$All -PageSize $PageSize
                 }

--- a/Functions/Core/DataSources/Get-NBDataSource.ps1
+++ b/Functions/Core/DataSources/Get-NBDataSource.ps1
@@ -82,7 +82,7 @@ function Get-NBDataSource {
             'ById' {
                 foreach ($i in $Id) {
                     $Segments = [System.Collections.ArrayList]::new(@('core', 'data-sources', $i))
-                    $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw'
+                    $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw', 'All', 'PageSize'
                     $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
                     InvokeNetboxRequest -URI $URI -Raw:$Raw -All:$All -PageSize $PageSize
                 }

--- a/Functions/Core/Jobs/Get-NBJob.ps1
+++ b/Functions/Core/Jobs/Get-NBJob.ps1
@@ -97,7 +97,7 @@ function Get-NBJob {
             'ById' {
                 foreach ($i in $Id) {
                     $Segments = [System.Collections.ArrayList]::new(@('core', 'jobs', $i))
-                    $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw'
+                    $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw', 'All', 'PageSize'
                     $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
                     InvokeNetboxRequest -URI $URI -Raw:$Raw -All:$All -PageSize $PageSize
                 }

--- a/Functions/Core/ObjectChanges/Get-NBObjectChange.ps1
+++ b/Functions/Core/ObjectChanges/Get-NBObjectChange.ps1
@@ -97,7 +97,7 @@ function Get-NBObjectChange {
             'ById' {
                 foreach ($i in $Id) {
                     $Segments = [System.Collections.ArrayList]::new(@('core', 'object-changes', $i))
-                    $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw'
+                    $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw', 'All', 'PageSize'
                     $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
                     InvokeNetboxRequest -URI $URI -Raw:$Raw -All:$All -PageSize $PageSize
                 }

--- a/Functions/Core/ObjectTypes/Get-NBObjectType.ps1
+++ b/Functions/Core/ObjectTypes/Get-NBObjectType.ps1
@@ -78,7 +78,7 @@ function Get-NBObjectType {
             'ById' {
                 foreach ($i in $Id) {
                     $Segments = [System.Collections.ArrayList]::new(@('core', 'object-types', $i))
-                    $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw'
+                    $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw', 'All', 'PageSize'
                     $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
                     InvokeNetboxRequest -URI $URI -Raw:$Raw -All:$All -PageSize $PageSize
                 }

--- a/Functions/DCIM/Devices/Get-NBDCIMDeviceRole.ps1
+++ b/Functions/DCIM/Devices/Get-NBDCIMDeviceRole.ps1
@@ -58,7 +58,7 @@ function Get-NBDCIMDeviceRole {
             foreach ($DRId in $Id) {
                 $Segments = [System.Collections.ArrayList]::new(@('dcim', 'device-roles', $DRId))
 
-                $URIComponents = BuildURIComponents -URISegments $Segments -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw'
+                $URIComponents = BuildURIComponents -URISegments $Segments -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw', 'All', 'PageSize'
 
                 $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
 

--- a/Functions/DCIM/Platforms/Get-NBDCIMPlatform.ps1
+++ b/Functions/DCIM/Platforms/Get-NBDCIMPlatform.ps1
@@ -58,7 +58,7 @@ function Get-NBDCIMPlatform {
             foreach ($PlatformID in $Id) {
                 $Segments = [System.Collections.ArrayList]::new(@('dcim', 'platforms', $PlatformID))
 
-                $URIComponents = BuildURIComponents -URISegments $Segments -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw'
+                $URIComponents = BuildURIComponents -URISegments $Segments -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw', 'All', 'PageSize'
 
                 $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
 

--- a/Functions/Extras/Bookmarks/Get-NBBookmark.ps1
+++ b/Functions/Extras/Bookmarks/Get-NBBookmark.ps1
@@ -75,7 +75,7 @@ function Get-NBBookmark {
             'ById' {
                 foreach ($i in $Id) {
                     $Segments = [System.Collections.ArrayList]::new(@('extras', 'bookmarks', $i))
-                    $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw'
+                    $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw', 'All', 'PageSize'
                     $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
                     InvokeNetboxRequest -URI $URI -Raw:$Raw -All:$All -PageSize $PageSize
                 }

--- a/Functions/Extras/ConfigContexts/Get-NBConfigContext.ps1
+++ b/Functions/Extras/ConfigContexts/Get-NBConfigContext.ps1
@@ -75,7 +75,7 @@ function Get-NBConfigContext {
             'ById' {
                 foreach ($i in $Id) {
                     $Segments = [System.Collections.ArrayList]::new(@('extras', 'config-contexts', $i))
-                    $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw'
+                    $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw', 'All', 'PageSize'
                     $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
                     InvokeNetboxRequest -URI $URI -Raw:$Raw -All:$All -PageSize $PageSize
                 }

--- a/Functions/Extras/CustomFieldChoiceSets/Get-NBCustomFieldChoiceSet.ps1
+++ b/Functions/Extras/CustomFieldChoiceSets/Get-NBCustomFieldChoiceSet.ps1
@@ -69,7 +69,7 @@ function Get-NBCustomFieldChoiceSet {
             'ById' {
                 foreach ($i in $Id) {
                     $Segments = [System.Collections.ArrayList]::new(@('extras', 'custom-field-choice-sets', $i))
-                    $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw'
+                    $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw', 'All', 'PageSize'
                     $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
                     InvokeNetboxRequest -URI $URI -Raw:$Raw -All:$All -PageSize $PageSize
                 }

--- a/Functions/Extras/CustomFields/Get-NBCustomField.ps1
+++ b/Functions/Extras/CustomFields/Get-NBCustomField.ps1
@@ -81,7 +81,7 @@ function Get-NBCustomField {
             'ById' {
                 foreach ($i in $Id) {
                     $Segments = [System.Collections.ArrayList]::new(@('extras', 'custom-fields', $i))
-                    $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw'
+                    $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw', 'All', 'PageSize'
                     $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
                     InvokeNetboxRequest -URI $URI -Raw:$Raw -All:$All -PageSize $PageSize
                 }

--- a/Functions/Extras/CustomLinks/Get-NBCustomLink.ps1
+++ b/Functions/Extras/CustomLinks/Get-NBCustomLink.ps1
@@ -75,7 +75,7 @@ function Get-NBCustomLink {
             'ById' {
                 foreach ($i in $Id) {
                     $Segments = [System.Collections.ArrayList]::new(@('extras', 'custom-links', $i))
-                    $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw'
+                    $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw', 'All', 'PageSize'
                     $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
                     InvokeNetboxRequest -URI $URI -Raw:$Raw -All:$All -PageSize $PageSize
                 }

--- a/Functions/Extras/EventRules/Get-NBEventRule.ps1
+++ b/Functions/Extras/EventRules/Get-NBEventRule.ps1
@@ -93,7 +93,7 @@ function Get-NBEventRule {
             'ById' {
                 foreach ($i in $Id) {
                     $Segments = [System.Collections.ArrayList]::new(@('extras', 'event-rules', $i))
-                    $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw'
+                    $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw', 'All', 'PageSize'
                     $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
                     InvokeNetboxRequest -URI $URI -Raw:$Raw -All:$All -PageSize $PageSize
                 }

--- a/Functions/Extras/ExportTemplates/Get-NBExportTemplate.ps1
+++ b/Functions/Extras/ExportTemplates/Get-NBExportTemplate.ps1
@@ -75,7 +75,7 @@ function Get-NBExportTemplate {
             'ById' {
                 foreach ($i in $Id) {
                     $Segments = [System.Collections.ArrayList]::new(@('extras', 'export-templates', $i))
-                    $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw'
+                    $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw', 'All', 'PageSize'
                     $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
                     InvokeNetboxRequest -URI $URI -Raw:$Raw -All:$All -PageSize $PageSize
                 }

--- a/Functions/Extras/ImageAttachments/Get-NBImageAttachment.ps1
+++ b/Functions/Extras/ImageAttachments/Get-NBImageAttachment.ps1
@@ -81,7 +81,7 @@ function Get-NBImageAttachment {
             'ById' {
                 foreach ($i in $Id) {
                     $Segments = [System.Collections.ArrayList]::new(@('extras', 'image-attachments', $i))
-                    $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw'
+                    $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw', 'All', 'PageSize'
                     $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
                     InvokeNetboxRequest -URI $URI -Raw:$Raw -All:$All -PageSize $PageSize
                 }

--- a/Functions/Extras/JournalEntries/Get-NBJournalEntry.ps1
+++ b/Functions/Extras/JournalEntries/Get-NBJournalEntry.ps1
@@ -88,7 +88,7 @@ function Get-NBJournalEntry {
             'ById' {
                 foreach ($i in $Id) {
                     $Segments = [System.Collections.ArrayList]::new(@('extras', 'journal-entries', $i))
-                    $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw'
+                    $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw', 'All', 'PageSize'
                     $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
                     InvokeNetboxRequest -URI $URI -Raw:$Raw -All:$All -PageSize $PageSize
                 }

--- a/Functions/Extras/SavedFilters/Get-NBSavedFilter.ps1
+++ b/Functions/Extras/SavedFilters/Get-NBSavedFilter.ps1
@@ -99,7 +99,7 @@ function Get-NBSavedFilter {
             'ById' {
                 foreach ($i in $Id) {
                     $Segments = [System.Collections.ArrayList]::new(@('extras', 'saved-filters', $i))
-                    $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw'
+                    $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw', 'All', 'PageSize'
                     $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
                     InvokeNetboxRequest -URI $URI -Raw:$Raw -All:$All -PageSize $PageSize
                 }

--- a/Functions/Extras/Webhooks/Get-NBWebhook.ps1
+++ b/Functions/Extras/Webhooks/Get-NBWebhook.ps1
@@ -75,7 +75,7 @@ function Get-NBWebhook {
             'ById' {
                 foreach ($i in $Id) {
                     $Segments = [System.Collections.ArrayList]::new(@('extras', 'webhooks', $i))
-                    $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw'
+                    $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw', 'All', 'PageSize'
                     $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
                     InvokeNetboxRequest -URI $URI -Raw:$Raw -All:$All -PageSize $PageSize
                 }

--- a/Functions/Users/Groups/Get-NBGroup.ps1
+++ b/Functions/Users/Groups/Get-NBGroup.ps1
@@ -69,7 +69,7 @@ function Get-NBGroup {
             'ById' {
                 foreach ($i in $Id) {
                     $Segments = [System.Collections.ArrayList]::new(@('users', 'groups', $i))
-                    $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw'
+                    $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw', 'All', 'PageSize'
                     $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
                     InvokeNetboxRequest -URI $URI -Raw:$Raw -All:$All -PageSize $PageSize
                 }

--- a/Functions/Users/Permissions/Get-NBPermission.ps1
+++ b/Functions/Users/Permissions/Get-NBPermission.ps1
@@ -93,7 +93,7 @@ function Get-NBPermission {
             'ById' {
                 foreach ($i in $Id) {
                     $Segments = [System.Collections.ArrayList]::new(@('users', 'permissions', $i))
-                    $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw'
+                    $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw', 'All', 'PageSize'
                     $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
                     InvokeNetboxRequest -URI $URI -Raw:$Raw -All:$All -PageSize $PageSize
                 }

--- a/Functions/Users/Tokens/Get-NBToken.ps1
+++ b/Functions/Users/Tokens/Get-NBToken.ps1
@@ -81,7 +81,7 @@ function Get-NBToken {
             'ById' {
                 foreach ($i in $Id) {
                     $Segments = [System.Collections.ArrayList]::new(@('users', 'tokens', $i))
-                    $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw'
+                    $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw', 'All', 'PageSize'
                     $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
                     InvokeNetboxRequest -URI $URI -Raw:$Raw -All:$All -PageSize $PageSize
                 }

--- a/Functions/Users/Users/Get-NBUser.ps1
+++ b/Functions/Users/Users/Get-NBUser.ps1
@@ -114,7 +114,7 @@ function Get-NBUser {
             'ById' {
                 foreach ($i in $Id) {
                     $Segments = [System.Collections.ArrayList]::new(@('users', 'users', $i))
-                    $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw'
+                    $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw', 'All', 'PageSize'
                     $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
                     InvokeNetboxRequest -URI $URI -Raw:$Raw -All:$All -PageSize $PageSize
                 }


### PR DESCRIPTION
## Summary\n- 29 Get-* functions had their ByID parameter set branch missing `'All'` and `'PageSize'` in the `SkipParameterByName` list\n- This caused `BuildURIComponents` to leak these parameters as query strings (`?all=True&pagesize=100`) when fetching single objects by ID\n- While harmless (Netbox ignores unknown query params), it adds unnecessary data to the URL\n\n**Modules affected:** Core (5), Circuits (7), DCIM (2), Users (4), Extras (11)\n\nFixes #262\n\n## Test plan\n- [ ] Unit tests pass\n- [ ] `Get-NBWebhook -Id 1 -Verbose` no longer shows `all` or `pagesize` in URI\n- [ ] All 29 affected functions work correctly with `-Id` parameter