### PR TITLE
cleanup: Remove dead code from Setup and IPAM files

### DIFF
--- a/Functions/IPAM/Aggregate/Get-NBIPAMAggregate.ps1
+++ b/Functions/IPAM/Aggregate/Get-NBIPAMAggregate.ps1
@@ -64,9 +64,6 @@ function Get-NBIPAMAggregate {
 
 process {
         Write-Verbose "Retrieving IPAM Aggregate"
-        #    if ($null -ne $Family) {
-        #        $PSBoundParameters.Family = ValidateIPAMChoice -ProvidedValue $Family -AggregateFamily
-        #    }
 
         switch ($PSCmdlet.ParameterSetName) {
         'ById' {

--- a/Functions/IPAM/Prefix/Get-NBIPAMPrefix.ps1
+++ b/Functions/IPAM/Prefix/Get-NBIPAMPrefix.ps1
@@ -177,13 +177,6 @@ function Get-NBIPAMPrefix {
 
     process {
         Write-Verbose "Retrieving IPAM Prefix"
-        #    if ($null -ne $Family) {
-        #        $PSBoundParameters.Family = ValidateIPAMChoice -ProvidedValue $Family -PrefixFamily
-        #    }
-        #
-        #    if ($null -ne $Status) {
-        #        $PSBoundParameters.Status = ValidateIPAMChoice -ProvidedValue $Status -PrefixStatus
-        #    }
 
         switch ($PSCmdlet.ParameterSetName) {
         'ById' {

--- a/Functions/IPAM/Prefix/Set-NBIPAMPrefix.ps1
+++ b/Functions/IPAM/Prefix/Set-NBIPAMPrefix.ps1
@@ -55,27 +55,6 @@ function Set-NBIPAMPrefix {
         [switch]$Raw
     )
 
-    begin {
-        #        Write-Verbose "Validating enum properties"
-        #        $Segments = [System.Collections.ArrayList]::new(@('ipam', 'ip-addresses', 0))
-        $Method = 'PATCH'
-        #
-        #        # Value validation
-        #        $ModelDefinition = GetModelDefinitionFromURIPath -Segments $Segments -Method $Method
-        #        $EnumProperties = GetModelEnumProperties -ModelDefinition $ModelDefinition
-        #
-        #        foreach ($Property in $EnumProperties.Keys) {
-        #            if ($PSBoundParameters.ContainsKey($Property)) {
-        #                Write-Verbose "Validating property [$Property] with value [$($PSBoundParameters.$Property)]"
-        #                $PSBoundParameters.$Property = ValidateValue -ModelDefinition $ModelDefinition -Property $Property -ProvidedValue $PSBoundParameters.$Property
-        #            } else {
-        #                Write-Verbose "User did not provide a value for [$Property]"
-        #            }
-        #        }
-        #
-        #        Write-Verbose "Finished enum validation"
-    }
-
     process {
         foreach ($PrefixId in $Id) {
             $Segments = [System.Collections.ArrayList]::new(@('ipam', 'prefixes', $PrefixId))
@@ -87,13 +66,11 @@ function Set-NBIPAMPrefix {
 
                 $URI = BuildNewURI -Segments $URIComponents.Segments
 
-                InvokeNetboxRequest -URI $URI -Body $URIComponents.Parameters -Method $Method -Raw:$Raw
+                InvokeNetboxRequest -URI $URI -Body $URIComponents.Parameters -Method PATCH -Raw:$Raw
             }
         }
     }
 }
-
-
 
 
 

--- a/Functions/Setup/Support/VerifyAPIConnectivity.ps1
+++ b/Functions/Setup/Support/VerifyAPIConnectivity.ps1
@@ -31,9 +31,6 @@ function VerifyAPIConnectivity {
         # Validate we got a proper response
         if ($status.'netbox-version') {
             Write-Verbose "Successfully connected to Netbox $($status.'netbox-version')"
-
-            # Store version in module scope for later compatibility checks
-            $script:NetboxVersion = $status.'netbox-version'
         }
         else {
             Write-Warning "Connected to API but received unexpected response format"


### PR DESCRIPTION
## Summary
- Remove dead `$script:NetboxVersion` variable from `VerifyAPIConnectivity` (set but never read) — fixes #271
- Remove 28 lines of commented-out enum validation code from 3 IPAM files referencing non-existent functions (`ValidateIPAMChoice`, `GetModelDefinitionFromURIPath`, etc.) — fixes #276
- Inline `PATCH` method string in `Set-NBIPAMPrefix` (was using `$Method` variable only needed by the removed dead code)

## Files Changed (4)
- `Functions/Setup/Support/VerifyAPIConnectivity.ps1`
- `Functions/IPAM/Prefix/Set-NBIPAMPrefix.ps1`
- `Functions/IPAM/Aggregate/Get-NBIPAMAggregate.ps1`
- `Functions/IPAM/Prefix/Get-NBIPAMPrefix.ps1`

## Test plan
- [ ] PSScriptAnalyzer passes
- [ ] All unit tests pass (Ubuntu, macOS, Windows PS7, Windows PS5.1)
- [ ] Integration tests pass (Netbox 4.3.7, 4.4.10, 4.5.2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)