### PR TITLE
enhancement: Standardize DCIM Get function patterns

### DIFF
--- a/Tests/DCIM.Devices.Tests.ps1
+++ b/Tests/DCIM.Devices.Tests.ps1
@@ -121,10 +121,12 @@ Describe "DCIM Devices Tests" -Tag 'DCIM', 'Devices' {
         It "Should request with multiple IDs" {
             $Result = Get-NBDCIMDevice -Id 10, 12, 15
 
-            $Result.Method | Should -Be 'GET'
-            # Commas may or may not be URL-encoded depending on PS version
-            $Result.Uri | Should -Match 'id__in=10(%2C|,)12(%2C|,)15'
-            $Result.Uri | Should -Match 'omit=config_context'
+            $Result | Should -HaveCount 3
+            $Result[0].Method | Should -Be 'GET'
+            $Result[0].Uri | Should -Match 'dcim/devices/10/'
+            $Result[1].Uri | Should -Match 'dcim/devices/12/'
+            $Result[2].Uri | Should -Match 'dcim/devices/15/'
+            $Result | ForEach-Object { $_.Uri | Should -Match 'omit=config_context' }
         }
 
         It "Should request a status" {

--- a/Tests/DCIM.RackElevation.Tests.ps1
+++ b/Tests/DCIM.RackElevation.Tests.ps1
@@ -90,14 +90,6 @@ Describe "DCIM Rack Elevation Tests" -Tag 'DCIM', 'Racks', 'RackElevation' {
             $Result.Uri | Should -Match 'offset=50'
         }
 
-        It "Should throw when -All used with -Limit" {
-            { Get-NBDCIMRackElevation -Id 24 -All -Limit 100 } | Should -Throw "*cannot be used with*"
-        }
-
-        It "Should throw when -All used with -Offset" {
-            { Get-NBDCIMRackElevation -Id 24 -All -Offset 50 } | Should -Throw "*cannot be used with*"
-        }
-
         It "Should accept pipeline input from Get-NBDCIMRack" {
             $mockRack = [PSCustomObject]@{ Id = 42 }
             $Result = $mockRack | Get-NBDCIMRackElevation


### PR DESCRIPTION
## Summary
- **Get-NBDCIMDevice**: Add ByID/Query parameter sets so `-Id` uses direct URL path `/api/dcim/devices/{id}/` instead of query parameter `?id=` — fixes #272
- **Get-NBDCIMRackElevation**: Replace 30-line custom pagination loop with centralized `InvokeNetboxRequest -All -PageSize`, add missing `$PageSize` parameter — fixes #277

## Details

### Get-NBDCIMDevice
- Added `DefaultParameterSetName = 'Query'` to CmdletBinding
- `$Id` now scoped to `ByID` parameter set
- All query-specific params (`$Name`, `$Status`, etc.) scoped to `Query` parameter set
- ByID branch still applies `config_context` exclusion via `?omit=config_context`
- Common params (`$Brief`, `$Fields`, `$Omit`, `$Limit`, `$Offset`, `$Raw`) remain in both sets

### Get-NBDCIMRackElevation
- Added `$All` and `$PageSize` to param block (standardized position)
- Removed `begin{}` block with manual `-All` vs `-Limit`/`-Offset` validation
- Replaced custom pagination loop (lines 166-196) with single `InvokeNetboxRequest -URI $URI -Raw:$Raw -All:$All -PageSize $PageSize`
- SVG rendering path unchanged (still uses direct `Invoke-WebRequest`)

## Test plan
- [ ] PSScriptAnalyzer passes
- [ ] All unit tests pass
- [ ] Integration tests pass (Netbox 4.3.7, 4.4.10, 4.5.2)
- [ ] `Get-NBDCIMDevice -Id 1` uses direct URL path
- [ ] `Get-NBDCIMDevice -Name "test"` uses query path
- [ ] `Get-NBDCIMRackElevation -Id 1 -All` paginates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)