### PR TITLE
Fix -All pagination silently ignored in 36 Get functions

### DIFF
--- a/Functions/DCIM/ConnectedDevice/Get-NBDCIMConnectedDevice.ps1
+++ b/Functions/DCIM/ConnectedDevice/Get-NBDCIMConnectedDevice.ps1
@@ -38,6 +38,6 @@ function Get-NBDCIMConnectedDevice {
         Write-Verbose "Retrieving DCIM Connected Device"
         $Segments = [System.Collections.ArrayList]::new(@('dcim','connected-device'))
         $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'All', 'PageSize'
-        InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters) -Raw:$Raw
+        InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters) -Raw:$Raw -All:$All -PageSize $PageSize
     }
 }

--- a/Functions/DCIM/ConsolePortTemplates/Get-NBDCIMConsolePortTemplate.ps1
+++ b/Functions/DCIM/ConsolePortTemplates/Get-NBDCIMConsolePortTemplate.ps1
@@ -49,7 +49,7 @@ function Get-NBDCIMConsolePortTemplate {
             default {
                 $Segments = [System.Collections.ArrayList]::new(@('dcim','console-port-templates'))
                 $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'All', 'PageSize'
-                InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters) -Raw:$Raw
+                InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters) -Raw:$Raw -All:$All -PageSize $PageSize
             }
         }
     }

--- a/Functions/DCIM/ConsolePorts/Get-NBDCIMConsolePort.ps1
+++ b/Functions/DCIM/ConsolePorts/Get-NBDCIMConsolePort.ps1
@@ -49,7 +49,7 @@ function Get-NBDCIMConsolePort {
             default {
                 $Segments = [System.Collections.ArrayList]::new(@('dcim','console-ports'))
                 $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'All', 'PageSize'
-                InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters) -Raw:$Raw
+                InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters) -Raw:$Raw -All:$All -PageSize $PageSize
             }
         }
     }

--- a/Functions/DCIM/ConsoleServerPortTemplates/Get-NBDCIMConsoleServerPortTemplate.ps1
+++ b/Functions/DCIM/ConsoleServerPortTemplates/Get-NBDCIMConsoleServerPortTemplate.ps1
@@ -49,7 +49,7 @@ function Get-NBDCIMConsoleServerPortTemplate {
             default {
                 $Segments = [System.Collections.ArrayList]::new(@('dcim','console-server-port-templates'))
                 $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'All', 'PageSize'
-                InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters) -Raw:$Raw
+                InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters) -Raw:$Raw -All:$All -PageSize $PageSize
             }
         }
     }

--- a/Functions/DCIM/ConsoleServerPorts/Get-NBDCIMConsoleServerPort.ps1
+++ b/Functions/DCIM/ConsoleServerPorts/Get-NBDCIMConsoleServerPort.ps1
@@ -49,7 +49,7 @@ function Get-NBDCIMConsoleServerPort {
             default {
                 $Segments = [System.Collections.ArrayList]::new(@('dcim','console-server-ports'))
                 $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'All', 'PageSize'
-                InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters) -Raw:$Raw
+                InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters) -Raw:$Raw -All:$All -PageSize $PageSize
             }
         }
     }

--- a/Functions/DCIM/DeviceBayTemplates/Get-NBDCIMDeviceBayTemplate.ps1
+++ b/Functions/DCIM/DeviceBayTemplates/Get-NBDCIMDeviceBayTemplate.ps1
@@ -47,7 +47,7 @@ function Get-NBDCIMDeviceBayTemplate {
             default {
                 $Segments = [System.Collections.ArrayList]::new(@('dcim','device-bay-templates'))
                 $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'All', 'PageSize'
-                InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters) -Raw:$Raw
+                InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters) -Raw:$Raw -All:$All -PageSize $PageSize
             }
         }
     }

--- a/Functions/DCIM/DeviceBays/Get-NBDCIMDeviceBay.ps1
+++ b/Functions/DCIM/DeviceBays/Get-NBDCIMDeviceBay.ps1
@@ -47,7 +47,7 @@ function Get-NBDCIMDeviceBay {
             default {
                 $Segments = [System.Collections.ArrayList]::new(@('dcim','device-bays'))
                 $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'All', 'PageSize'
-                InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters) -Raw:$Raw
+                InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters) -Raw:$Raw -All:$All -PageSize $PageSize
             }
         }
     }

--- a/Functions/DCIM/FrontPortTemplates/Get-NBDCIMFrontPortTemplate.ps1
+++ b/Functions/DCIM/FrontPortTemplates/Get-NBDCIMFrontPortTemplate.ps1
@@ -49,7 +49,7 @@ function Get-NBDCIMFrontPortTemplate {
             default {
                 $Segments = [System.Collections.ArrayList]::new(@('dcim','front-port-templates'))
                 $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'All', 'PageSize'
-                InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters) -Raw:$Raw
+                InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters) -Raw:$Raw -All:$All -PageSize $PageSize
             }
         }
     }

--- a/Functions/DCIM/InterfaceTemplates/Get-NBDCIMInterfaceTemplate.ps1
+++ b/Functions/DCIM/InterfaceTemplates/Get-NBDCIMInterfaceTemplate.ps1
@@ -49,7 +49,7 @@ function Get-NBDCIMInterfaceTemplate {
             default {
                 $Segments = [System.Collections.ArrayList]::new(@('dcim','interface-templates'))
                 $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'All', 'PageSize'
-                InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters) -Raw:$Raw
+                InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters) -Raw:$Raw -All:$All -PageSize $PageSize
             }
         }
     }

--- a/Functions/DCIM/InventoryItemRoles/Get-NBDCIMInventoryItemRole.ps1
+++ b/Functions/DCIM/InventoryItemRoles/Get-NBDCIMInventoryItemRole.ps1
@@ -47,7 +47,7 @@ function Get-NBDCIMInventoryItemRole {
             default {
                 $Segments = [System.Collections.ArrayList]::new(@('dcim','inventory-item-roles'))
                 $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'All', 'PageSize'
-                InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters) -Raw:$Raw
+                InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters) -Raw:$Raw -All:$All -PageSize $PageSize
             }
         }
     }

--- a/Functions/DCIM/InventoryItemTemplates/Get-NBDCIMInventoryItemTemplate.ps1
+++ b/Functions/DCIM/InventoryItemTemplates/Get-NBDCIMInventoryItemTemplate.ps1
@@ -48,7 +48,7 @@ function Get-NBDCIMInventoryItemTemplate {
             default {
                 $Segments = [System.Collections.ArrayList]::new(@('dcim','inventory-item-templates'))
                 $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'All', 'PageSize'
-                InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters) -Raw:$Raw
+                InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters) -Raw:$Raw -All:$All -PageSize $PageSize
             }
         }
     }

--- a/Functions/DCIM/InventoryItems/Get-NBDCIMInventoryItem.ps1
+++ b/Functions/DCIM/InventoryItems/Get-NBDCIMInventoryItem.ps1
@@ -51,7 +51,7 @@ function Get-NBDCIMInventoryItem {
             default {
                 $Segments = [System.Collections.ArrayList]::new(@('dcim','inventory-items'))
                 $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'All', 'PageSize'
-                InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters) -Raw:$Raw
+                InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters) -Raw:$Raw -All:$All -PageSize $PageSize
             }
         }
     }

--- a/Functions/DCIM/MACAddresses/Get-NBDCIMMACAddress.ps1
+++ b/Functions/DCIM/MACAddresses/Get-NBDCIMMACAddress.ps1
@@ -50,7 +50,7 @@ function Get-NBDCIMMACAddress {
             default {
                 $Segments = [System.Collections.ArrayList]::new(@('dcim','mac-addresses'))
                 $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'All', 'PageSize'
-                InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters) -Raw:$Raw
+                InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters) -Raw:$Raw -All:$All -PageSize $PageSize
             }
         }
     }

--- a/Functions/DCIM/ModuleBayTemplates/Get-NBDCIMModuleBayTemplate.ps1
+++ b/Functions/DCIM/ModuleBayTemplates/Get-NBDCIMModuleBayTemplate.ps1
@@ -47,7 +47,7 @@ function Get-NBDCIMModuleBayTemplate {
             default {
                 $Segments = [System.Collections.ArrayList]::new(@('dcim','module-bay-templates'))
                 $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'All', 'PageSize'
-                InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters) -Raw:$Raw
+                InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters) -Raw:$Raw -All:$All -PageSize $PageSize
             }
         }
     }

--- a/Functions/DCIM/ModuleBays/Get-NBDCIMModuleBay.ps1
+++ b/Functions/DCIM/ModuleBays/Get-NBDCIMModuleBay.ps1
@@ -47,7 +47,7 @@ function Get-NBDCIMModuleBay {
             default {
                 $Segments = [System.Collections.ArrayList]::new(@('dcim','module-bays'))
                 $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'All', 'PageSize'
-                InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters) -Raw:$Raw
+                InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters) -Raw:$Raw -All:$All -PageSize $PageSize
             }
         }
     }

--- a/Functions/DCIM/ModuleTypeProfiles/Get-NBDCIMModuleTypeProfile.ps1
+++ b/Functions/DCIM/ModuleTypeProfiles/Get-NBDCIMModuleTypeProfile.ps1
@@ -46,7 +46,7 @@ function Get-NBDCIMModuleTypeProfile {
             default {
                 $Segments = [System.Collections.ArrayList]::new(@('dcim','module-type-profiles'))
                 $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'All', 'PageSize'
-                InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters) -Raw:$Raw
+                InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters) -Raw:$Raw -All:$All -PageSize $PageSize
             }
         }
     }

--- a/Functions/DCIM/ModuleTypes/Get-NBDCIMModuleType.ps1
+++ b/Functions/DCIM/ModuleTypes/Get-NBDCIMModuleType.ps1
@@ -48,7 +48,7 @@ function Get-NBDCIMModuleType {
             default {
                 $Segments = [System.Collections.ArrayList]::new(@('dcim','module-types'))
                 $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'All', 'PageSize'
-                InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters) -Raw:$Raw
+                InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters) -Raw:$Raw -All:$All -PageSize $PageSize
             }
         }
     }

--- a/Functions/DCIM/Modules/Get-NBDCIMModule.ps1
+++ b/Functions/DCIM/Modules/Get-NBDCIMModule.ps1
@@ -51,7 +51,7 @@ function Get-NBDCIMModule {
             default {
                 $Segments = [System.Collections.ArrayList]::new(@('dcim','modules'))
                 $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'All', 'PageSize'
-                InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters) -Raw:$Raw
+                InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters) -Raw:$Raw -All:$All -PageSize $PageSize
             }
         }
     }

--- a/Functions/DCIM/PowerFeeds/Get-NBDCIMPowerFeed.ps1
+++ b/Functions/DCIM/PowerFeeds/Get-NBDCIMPowerFeed.ps1
@@ -50,7 +50,7 @@ function Get-NBDCIMPowerFeed {
             default {
                 $Segments = [System.Collections.ArrayList]::new(@('dcim','power-feeds'))
                 $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'All', 'PageSize'
-                InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters) -Raw:$Raw
+                InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters) -Raw:$Raw -All:$All -PageSize $PageSize
             }
         }
     }

--- a/Functions/DCIM/PowerOutletTemplates/Get-NBDCIMPowerOutletTemplate.ps1
+++ b/Functions/DCIM/PowerOutletTemplates/Get-NBDCIMPowerOutletTemplate.ps1
@@ -49,7 +49,7 @@ function Get-NBDCIMPowerOutletTemplate {
             default {
                 $Segments = [System.Collections.ArrayList]::new(@('dcim','power-outlet-templates'))
                 $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'All', 'PageSize'
-                InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters) -Raw:$Raw
+                InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters) -Raw:$Raw -All:$All -PageSize $PageSize
             }
         }
     }

--- a/Functions/DCIM/PowerOutlets/Get-NBDCIMPowerOutlet.ps1
+++ b/Functions/DCIM/PowerOutlets/Get-NBDCIMPowerOutlet.ps1
@@ -49,7 +49,7 @@ function Get-NBDCIMPowerOutlet {
             default {
                 $Segments = [System.Collections.ArrayList]::new(@('dcim','power-outlets'))
                 $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'All', 'PageSize'
-                InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters) -Raw:$Raw
+                InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters) -Raw:$Raw -All:$All -PageSize $PageSize
             }
         }
     }

--- a/Functions/DCIM/PowerPanels/Get-NBDCIMPowerPanel.ps1
+++ b/Functions/DCIM/PowerPanels/Get-NBDCIMPowerPanel.ps1
@@ -48,7 +48,7 @@ function Get-NBDCIMPowerPanel {
             default {
                 $Segments = [System.Collections.ArrayList]::new(@('dcim','power-panels'))
                 $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'All', 'PageSize'
-                InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters) -Raw:$Raw
+                InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters) -Raw:$Raw -All:$All -PageSize $PageSize
             }
         }
     }

--- a/Functions/DCIM/PowerPortTemplates/Get-NBDCIMPowerPortTemplate.ps1
+++ b/Functions/DCIM/PowerPortTemplates/Get-NBDCIMPowerPortTemplate.ps1
@@ -49,7 +49,7 @@ function Get-NBDCIMPowerPortTemplate {
             default {
                 $Segments = [System.Collections.ArrayList]::new(@('dcim','power-port-templates'))
                 $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'All', 'PageSize'
-                InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters) -Raw:$Raw
+                InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters) -Raw:$Raw -All:$All -PageSize $PageSize
             }
         }
     }

--- a/Functions/DCIM/PowerPorts/Get-NBDCIMPowerPort.ps1
+++ b/Functions/DCIM/PowerPorts/Get-NBDCIMPowerPort.ps1
@@ -49,7 +49,7 @@ function Get-NBDCIMPowerPort {
             default {
                 $Segments = [System.Collections.ArrayList]::new(@('dcim','power-ports'))
                 $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'All', 'PageSize'
-                InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters) -Raw:$Raw
+                InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters) -Raw:$Raw -All:$All -PageSize $PageSize
             }
         }
     }

--- a/Functions/DCIM/RackReservations/Get-NBDCIMRackReservation.ps1
+++ b/Functions/DCIM/RackReservations/Get-NBDCIMRackReservation.ps1
@@ -49,7 +49,7 @@ function Get-NBDCIMRackReservation {
             default {
                 $Segments = [System.Collections.ArrayList]::new(@('dcim','rack-reservations'))
                 $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'All', 'PageSize'
-                InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters) -Raw:$Raw
+                InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters) -Raw:$Raw -All:$All -PageSize $PageSize
             }
         }
     }

--- a/Functions/DCIM/RackRoles/Get-NBDCIMRackRole.ps1
+++ b/Functions/DCIM/RackRoles/Get-NBDCIMRackRole.ps1
@@ -47,7 +47,7 @@ function Get-NBDCIMRackRole {
             default {
                 $Segments = [System.Collections.ArrayList]::new(@('dcim','rack-roles'))
                 $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'All', 'PageSize'
-                InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters) -Raw:$Raw
+                InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters) -Raw:$Raw -All:$All -PageSize $PageSize
             }
         }
     }

--- a/Functions/DCIM/RackTypes/Get-NBDCIMRackType.ps1
+++ b/Functions/DCIM/RackTypes/Get-NBDCIMRackType.ps1
@@ -48,7 +48,7 @@ function Get-NBDCIMRackType {
             default {
                 $Segments = [System.Collections.ArrayList]::new(@('dcim','rack-types'))
                 $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'All', 'PageSize'
-                InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters) -Raw:$Raw
+                InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters) -Raw:$Raw -All:$All -PageSize $PageSize
             }
         }
     }

--- a/Functions/DCIM/RearPortTemplates/Get-NBDCIMRearPortTemplate.ps1
+++ b/Functions/DCIM/RearPortTemplates/Get-NBDCIMRearPortTemplate.ps1
@@ -49,7 +49,7 @@ function Get-NBDCIMRearPortTemplate {
             default {
                 $Segments = [System.Collections.ArrayList]::new(@('dcim','rear-port-templates'))
                 $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'All', 'PageSize'
-                InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters) -Raw:$Raw
+                InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters) -Raw:$Raw -All:$All -PageSize $PageSize
             }
         }
     }

--- a/Functions/DCIM/VirtualChassis/Get-NBDCIMVirtualChassis.ps1
+++ b/Functions/DCIM/VirtualChassis/Get-NBDCIMVirtualChassis.ps1
@@ -51,7 +51,7 @@ function Get-NBDCIMVirtualChassis {
             default {
                 $Segments = [System.Collections.ArrayList]::new(@('dcim','virtual-chassis'))
                 $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'All', 'PageSize'
-                InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters) -Raw:$Raw
+                InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters) -Raw:$Raw -All:$All -PageSize $PageSize
             }
         }
     }

--- a/Functions/DCIM/VirtualDeviceContexts/Get-NBDCIMVirtualDeviceContext.ps1
+++ b/Functions/DCIM/VirtualDeviceContexts/Get-NBDCIMVirtualDeviceContext.ps1
@@ -51,7 +51,7 @@ function Get-NBDCIMVirtualDeviceContext {
             default {
                 $Segments = [System.Collections.ArrayList]::new(@('dcim','virtual-device-contexts'))
                 $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'All', 'PageSize'
-                InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters) -Raw:$Raw
+                InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters) -Raw:$Raw -All:$All -PageSize $PageSize
             }
         }
     }

--- a/Functions/IPAM/FHRPGroup/Get-NBIPAMFHRPGroup.ps1
+++ b/Functions/IPAM/FHRPGroup/Get-NBIPAMFHRPGroup.ps1
@@ -48,7 +48,7 @@ function Get-NBIPAMFHRPGroup {
             default {
                 $Segments = [System.Collections.ArrayList]::new(@('ipam','fhrp-groups'))
                 $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'All', 'PageSize'
-                InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters) -Raw:$Raw
+                InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters) -Raw:$Raw -All:$All -PageSize $PageSize
             }
         }
     }

--- a/Functions/IPAM/FHRPGroupAssignment/Get-NBIPAMFHRPGroupAssignment.ps1
+++ b/Functions/IPAM/FHRPGroupAssignment/Get-NBIPAMFHRPGroupAssignment.ps1
@@ -48,7 +48,7 @@ function Get-NBIPAMFHRPGroupAssignment {
             default {
                 $Segments = [System.Collections.ArrayList]::new(@('ipam','fhrp-group-assignments'))
                 $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'All', 'PageSize'
-                InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters) -Raw:$Raw
+                InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters) -Raw:$Raw -All:$All -PageSize $PageSize
             }
         }
     }

--- a/Functions/IPAM/RIR/Get-NBIPAMRIR.ps1
+++ b/Functions/IPAM/RIR/Get-NBIPAMRIR.ps1
@@ -48,7 +48,7 @@ function Get-NBIPAMRIR {
             default {
                 $Segments = [System.Collections.ArrayList]::new(@('ipam','rirs'))
                 $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'All', 'PageSize'
-                InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters) -Raw:$Raw
+                InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters) -Raw:$Raw -All:$All -PageSize $PageSize
             }
         }
     }

--- a/Functions/IPAM/VLANGroup/Get-NBIPAMVLANGroup.ps1
+++ b/Functions/IPAM/VLANGroup/Get-NBIPAMVLANGroup.ps1
@@ -51,7 +51,7 @@ function Get-NBIPAMVLANGroup {
             default {
                 $Segments = [System.Collections.ArrayList]::new(@('ipam','vlan-groups'))
                 $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'All', 'PageSize'
-                InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters) -Raw:$Raw
+                InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters) -Raw:$Raw -All:$All -PageSize $PageSize
             }
         }
     }

--- a/Functions/IPAM/VLANTranslationPolicy/Get-NBIPAMVLANTranslationPolicy.ps1
+++ b/Functions/IPAM/VLANTranslationPolicy/Get-NBIPAMVLANTranslationPolicy.ps1
@@ -46,7 +46,7 @@ function Get-NBIPAMVLANTranslationPolicy {
             default {
                 $Segments = [System.Collections.ArrayList]::new(@('ipam','vlan-translation-policies'))
                 $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'All', 'PageSize'
-                InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters) -Raw:$Raw
+                InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters) -Raw:$Raw -All:$All -PageSize $PageSize
             }
         }
     }

--- a/Functions/IPAM/VLANTranslationRule/Get-NBIPAMVLANTranslationRule.ps1
+++ b/Functions/IPAM/VLANTranslationRule/Get-NBIPAMVLANTranslationRule.ps1
@@ -47,7 +47,7 @@ function Get-NBIPAMVLANTranslationRule {
             default {
                 $Segments = [System.Collections.ArrayList]::new(@('ipam','vlan-translation-rules'))
                 $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'All', 'PageSize'
-                InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters) -Raw:$Raw
+                InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters) -Raw:$Raw -All:$All -PageSize $PageSize
             }
         }
     }


### PR DESCRIPTION
## Summary
- 36 Get functions declared `[switch]$All` and `[int]$PageSize` parameters but never passed them to `InvokeNetboxRequest`
- This caused `-All` to be **silently ignored** — users calling e.g. `Get-NBDCIMConsolePort -All` would only get the first page of results
- Fix: Add `-All:$All -PageSize $PageSize` to the `InvokeNetboxRequest` call in each function's Query branch
- Affected: 30 DCIM + 6 IPAM Get functions

## Test plan
- [x] All 1337 unit tests pass locally (0 failures)
- [ ] CI passes on all 4 platforms

Fixes #294, #295

🤖 Generated with [Claude Code](https://claude.com/claude-code)