### PR TITLE
Standardize Get functions with ByID/Query parameter sets

### DIFF
--- a/Functions/DCIM/Cables/Get-NBDCIMCable.ps1
+++ b/Functions/DCIM/Cables/Get-NBDCIMCable.ps1
@@ -70,7 +70,7 @@
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>
 function Get-NBDCIMCable {
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName = 'Query')]
     [OutputType([PSCustomObject])]
     #region Parameters
     param
@@ -93,25 +93,34 @@ function Get-NBDCIMCable {
         [ValidateRange(0, [int]::MaxValue)]
         [uint16]$Offset,
 
-        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [Parameter(ParameterSetName = 'ByID', ValueFromPipelineByPropertyName = $true)]
         [uint64[]]$Id,
 
+        [Parameter(ParameterSetName = 'Query')]
         [string]$Label,
 
+        [Parameter(ParameterSetName = 'Query')]
         [string]$Termination_A_Type,
 
+        [Parameter(ParameterSetName = 'Query')]
         [uint64]$Termination_A_ID,
 
+        [Parameter(ParameterSetName = 'Query')]
         [string]$Termination_B_Type,
 
+        [Parameter(ParameterSetName = 'Query')]
         [uint64]$Termination_B_ID,
 
+        [Parameter(ParameterSetName = 'Query')]
         [string]$Type,
 
+        [Parameter(ParameterSetName = 'Query')]
         [string]$Status,
 
+        [Parameter(ParameterSetName = 'Query')]
         [string]$Color,
 
+        [Parameter(ParameterSetName = 'Query')]
         [ValidateSet('1c1p', '1c2p', '1c4p', '1c6p', '1c8p', '1c12p', '1c16p',
                      '2c1p', '2c2p', '2c4p', '2c4p-shuffle', '2c6p', '2c8p', '2c12p',
                      '4c1p', '4c2p', '4c4p', '4c4p-shuffle', '4c6p', '4c8p', '8c4p',
@@ -119,16 +128,22 @@ function Get-NBDCIMCable {
         [Alias('Profile')]
         [string]$Cable_Profile,
 
+        [Parameter(ParameterSetName = 'Query')]
         [uint64]$Device_ID,
 
+        [Parameter(ParameterSetName = 'Query')]
         [string]$Device,
 
+        [Parameter(ParameterSetName = 'Query')]
         [uint64]$Rack_Id,
 
+        [Parameter(ParameterSetName = 'Query')]
         [string]$Rack,
 
+        [Parameter(ParameterSetName = 'Query')]
         [uint64]$Location_ID,
 
+        [Parameter(ParameterSetName = 'Query')]
         [string]$Location,
 
         [switch]$Raw
@@ -138,23 +153,28 @@ function Get-NBDCIMCable {
 
     process {
         Write-Verbose "Retrieving DCIM Cable"
-        $Segments = [System.Collections.ArrayList]::new(@('dcim', 'cables'))
+        switch ($PSCmdlet.ParameterSetName) {
+            'ByID' { foreach ($i in $Id) { InvokeNetboxRequest -URI (BuildNewURI -Segments @('dcim', 'cables', $i)) -Raw:$Raw } }
+            default {
+                $Segments = [System.Collections.ArrayList]::new(@('dcim', 'cables'))
 
-        # Check for version-specific parameters
-        $excludeProfile = Test-NBMinimumVersion -ParameterName 'Cable_Profile' -MinimumVersion '4.5.0' -BoundParameters $PSBoundParameters -FeatureName 'Cable Profiles'
+                # Check for version-specific parameters
+                $excludeProfile = Test-NBMinimumVersion -ParameterName 'Cable_Profile' -MinimumVersion '4.5.0' -BoundParameters $PSBoundParameters -FeatureName 'Cable Profiles'
 
-        # Build skip parameters list (always skip Cable_Profile, we'll add it manually as 'profile')
-        $skipParams = @('Raw', 'All', 'PageSize', 'Cable_Profile')
+                # Build skip parameters list (always skip Cable_Profile, we'll add it manually as 'profile')
+                $skipParams = @('Raw', 'All', 'PageSize', 'Cable_Profile')
 
-        $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName $skipParams
+                $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName $skipParams
 
-        # Add Cable_Profile as 'profile' in query params (API uses 'profile')
-        if ($PSBoundParameters.ContainsKey('Cable_Profile') -and -not $excludeProfile) {
-            $URIComponents.Parameters['profile'] = $Cable_Profile
+                # Add Cable_Profile as 'profile' in query params (API uses 'profile')
+                if ($PSBoundParameters.ContainsKey('Cable_Profile') -and -not $excludeProfile) {
+                    $URIComponents.Parameters['profile'] = $Cable_Profile
+                }
+
+                $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
+
+                InvokeNetboxRequest -URI $URI -Raw:$Raw -All:$All -PageSize $PageSize
+            }
         }
-
-        $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
-
-        InvokeNetboxRequest -URI $URI -Raw:$Raw -All:$All -PageSize $PageSize
     }
 }

--- a/Functions/DCIM/Devices/Get-NBDCIMDeviceType.ps1
+++ b/Functions/DCIM/Devices/Get-NBDCIMDeviceType.ps1
@@ -15,7 +15,7 @@
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>
 function Get-NBDCIMDeviceType {
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName = 'Query')]
     [OutputType([PSCustomObject])]
     #region Parameters
     param
@@ -38,46 +38,60 @@ function Get-NBDCIMDeviceType {
         [ValidateRange(1, 1000)]
         [uint16]$Limit,
 
-        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [Parameter(ParameterSetName = 'ByID', ValueFromPipelineByPropertyName = $true)]
         [uint64[]]$Id,
 
+        [Parameter(ParameterSetName = 'Query')]
         [string]$Query,
 
+        [Parameter(ParameterSetName = 'Query')]
         [string]$Slug,
 
+        [Parameter(ParameterSetName = 'Query')]
         [string]$Manufacturer,
 
+        [Parameter(ParameterSetName = 'Query')]
         [uint64]$Manufacturer_Id,
 
+        [Parameter(ParameterSetName = 'Query')]
         [string]$Model,
 
+        [Parameter(ParameterSetName = 'Query')]
         [string]$Part_Number,
 
+        [Parameter(ParameterSetName = 'Query')]
         [uint16]$U_Height,
 
+        [Parameter(ParameterSetName = 'Query')]
         [bool]$Is_Full_Depth,
 
+        [Parameter(ParameterSetName = 'Query')]
         [bool]$Is_Console_Server,
 
+        [Parameter(ParameterSetName = 'Query')]
         [bool]$Is_PDU,
 
+        [Parameter(ParameterSetName = 'Query')]
         [bool]$Is_Network_Device,
 
+        [Parameter(ParameterSetName = 'Query')]
         [uint16]$Subdevice_Role,
 
         [switch]$Raw
     )
 
+    #endregion Parameters
+
     process {
         Write-Verbose "Retrieving DCIM Device Type"
-        #endregion Parameters
-
-        $Segments = [System.Collections.ArrayList]::new(@('dcim', 'device-types'))
-
-        $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'All', 'PageSize'
-
-        $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
-
-        InvokeNetboxRequest -URI $URI -Raw:$Raw -All:$All -PageSize $PageSize
+        switch ($PSCmdlet.ParameterSetName) {
+            'ByID' { foreach ($i in $Id) { InvokeNetboxRequest -URI (BuildNewURI -Segments @('dcim', 'device-types', $i)) -Raw:$Raw } }
+            default {
+                $Segments = [System.Collections.ArrayList]::new(@('dcim', 'device-types'))
+                $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'All', 'PageSize'
+                $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
+                InvokeNetboxRequest -URI $URI -Raw:$Raw -All:$All -PageSize $PageSize
+            }
+        }
     }
 }

--- a/Functions/DCIM/FrontPorts/Get-NBDCIMFrontPort.ps1
+++ b/Functions/DCIM/FrontPorts/Get-NBDCIMFrontPort.ps1
@@ -15,7 +15,7 @@
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>
 function Get-NBDCIMFrontPort {
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName = 'Query')]
     [OutputType([pscustomobject])]
     param
     (
@@ -37,15 +37,19 @@ function Get-NBDCIMFrontPort {
         [ValidateRange(0, [int]::MaxValue)]
         [uint16]$Offset,
 
-        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [Parameter(ParameterSetName = 'ByID', ValueFromPipelineByPropertyName = $true)]
         [uint64[]]$Id,
 
+        [Parameter(ParameterSetName = 'Query')]
         [string]$Name,
 
+        [Parameter(ParameterSetName = 'Query')]
         [string]$Device,
 
+        [Parameter(ParameterSetName = 'Query')]
         [uint64]$Device_Id,
 
+        [Parameter(ParameterSetName = 'Query')]
         [string]$Type,
 
         [switch]$Raw
@@ -53,13 +57,14 @@ function Get-NBDCIMFrontPort {
 
     process {
         Write-Verbose "Retrieving DCIM Front Port"
-
-        $Segments = [System.Collections.ArrayList]::new(@('dcim', 'front-ports'))
-
-        $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'All', 'PageSize'
-
-        $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
-
-        InvokeNetboxRequest -URI $URI -Raw:$Raw -All:$All -PageSize $PageSize
+        switch ($PSCmdlet.ParameterSetName) {
+            'ByID' { foreach ($i in $Id) { InvokeNetboxRequest -URI (BuildNewURI -Segments @('dcim', 'front-ports', $i)) -Raw:$Raw } }
+            default {
+                $Segments = [System.Collections.ArrayList]::new(@('dcim', 'front-ports'))
+                $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'All', 'PageSize'
+                $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
+                InvokeNetboxRequest -URI $URI -Raw:$Raw -All:$All -PageSize $PageSize
+            }
+        }
     }
 }

--- a/Functions/DCIM/Interfaces/Get-NBDCIMInterface.ps1
+++ b/Functions/DCIM/Interfaces/Get-NBDCIMInterface.ps1
@@ -23,7 +23,7 @@
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>
 function Get-NBDCIMInterface {
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName = 'Query')]
     [OutputType([pscustomobject])]
     param
     (
@@ -44,26 +44,35 @@ function Get-NBDCIMInterface {
         [ValidateRange(0, [int]::MaxValue)]
         [uint16]$Offset,
 
-        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [Parameter(ParameterSetName = 'ByID', ValueFromPipelineByPropertyName = $true)]
         [uint64[]]$Id,
 
+        [Parameter(ParameterSetName = 'Query')]
         [string]$Name,
 
+        [Parameter(ParameterSetName = 'Query')]
         [bool]$Enabled,
 
+        [Parameter(ParameterSetName = 'Query')]
         [uint16]$MTU,
 
+        [Parameter(ParameterSetName = 'Query')]
         [bool]$MGMT_Only,
 
+        [Parameter(ParameterSetName = 'Query')]
         [string]$Device,
 
+        [Parameter(ParameterSetName = 'Query')]
         [uint64]$Device_Id,
 
+        [Parameter(ParameterSetName = 'Query')]
         [ValidateSet('virtual', 'bridge', 'lag', '100base-tx', '1000base-t', '2.5gbase-t', '5gbase-t', '10gbase-t', '10gbase-cx4', '1000base-x-gbic', '1000base-x-sfp', '10gbase-x-sfpp', '10gbase-x-xfp', '10gbase-x-xenpak', '10gbase-x-x2', '25gbase-x-sfp28', '50gbase-x-sfp56', '40gbase-x-qsfpp', '50gbase-x-sfp28', '100gbase-x-cfp', '100gbase-x-cfp2', '200gbase-x-cfp2', '100gbase-x-cfp4', '100gbase-x-cpak', '100gbase-x-qsfp28', '200gbase-x-qsfp56', '400gbase-x-qsfpdd', '400gbase-x-osfp', '1000base-kx', '10gbase-kr', '10gbase-kx4', '25gbase-kr', '40gbase-kr4', '50gbase-kr', '100gbase-kp4', '100gbase-kr2', '100gbase-kr4', 'ieee802.11a', 'ieee802.11g', 'ieee802.11n', 'ieee802.11ac', 'ieee802.11ad', 'ieee802.11ax', 'ieee802.11ay', 'ieee802.15.1', 'other-wireless', 'gsm', 'cdma', 'lte', 'sonet-oc3', 'sonet-oc12', 'sonet-oc48', 'sonet-oc192', 'sonet-oc768', 'sonet-oc1920', 'sonet-oc3840', '1gfc-sfp', '2gfc-sfp', '4gfc-sfp', '8gfc-sfpp', '16gfc-sfpp', '32gfc-sfp28', '64gfc-qsfpp', '128gfc-qsfp28', 'infiniband-sdr', 'infiniband-ddr', 'infiniband-qdr', 'infiniband-fdr10', 'infiniband-fdr', 'infiniband-edr', 'infiniband-hdr', 'infiniband-ndr', 'infiniband-xdr', 't1', 'e1', 't3', 'e3', 'xdsl', 'docsis', 'gpon', 'xg-pon', 'xgs-pon', 'ng-pon2', 'epon', '10g-epon', 'cisco-stackwise', 'cisco-stackwise-plus', 'cisco-flexstack', 'cisco-flexstack-plus', 'cisco-stackwise-80', 'cisco-stackwise-160', 'cisco-stackwise-320', 'cisco-stackwise-480', 'juniper-vcp', 'extreme-summitstack', 'extreme-summitstack-128', 'extreme-summitstack-256', 'extreme-summitstack-512', 'other', IgnoreCase = $true)]
         [string]$Type,
 
+        [Parameter(ParameterSetName = 'Query')]
         [uint64]$LAG_Id,
 
+        [Parameter(ParameterSetName = 'Query')]
         [string]$MAC_Address,
 
         [switch]$Raw
@@ -71,12 +80,14 @@ function Get-NBDCIMInterface {
 
     process {
         Write-Verbose "Retrieving DCIM Interface"
-        $Segments = [System.Collections.ArrayList]::new(@('dcim', 'interfaces'))
-
-        $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'All', 'PageSize'
-
-        $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
-
-        InvokeNetboxRequest -URI $URI -Raw:$Raw -All:$All -PageSize $PageSize
+        switch ($PSCmdlet.ParameterSetName) {
+            'ByID' { foreach ($i in $Id) { InvokeNetboxRequest -URI (BuildNewURI -Segments @('dcim', 'interfaces', $i)) -Raw:$Raw } }
+            default {
+                $Segments = [System.Collections.ArrayList]::new(@('dcim', 'interfaces'))
+                $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'All', 'PageSize'
+                $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
+                InvokeNetboxRequest -URI $URI -Raw:$Raw -All:$All -PageSize $PageSize
+            }
+        }
     }
 }

--- a/Functions/DCIM/RearPorts/Get-NBDCIMRearPort.ps1
+++ b/Functions/DCIM/RearPorts/Get-NBDCIMRearPort.ps1
@@ -15,7 +15,7 @@
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>
 function Get-NBDCIMRearPort {
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName = 'Query')]
     [OutputType([pscustomobject])]
     param
     (
@@ -37,15 +37,19 @@ function Get-NBDCIMRearPort {
         [ValidateRange(0, [int]::MaxValue)]
         [uint16]$Offset,
 
-        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [Parameter(ParameterSetName = 'ByID', ValueFromPipelineByPropertyName = $true)]
         [uint64[]]$Id,
 
+        [Parameter(ParameterSetName = 'Query')]
         [string]$Name,
 
+        [Parameter(ParameterSetName = 'Query')]
         [string]$Device,
 
+        [Parameter(ParameterSetName = 'Query')]
         [uint64]$Device_Id,
 
+        [Parameter(ParameterSetName = 'Query')]
         [string]$Type,
 
         [switch]$Raw
@@ -53,13 +57,14 @@ function Get-NBDCIMRearPort {
 
     process {
         Write-Verbose "Retrieving DCIM Rear Port"
-
-        $Segments = [System.Collections.ArrayList]::new(@('dcim', 'rear-ports'))
-
-        $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'All', 'PageSize'
-
-        $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
-
-        InvokeNetboxRequest -URI $URI -Raw:$Raw -All:$All -PageSize $PageSize
+        switch ($PSCmdlet.ParameterSetName) {
+            'ByID' { foreach ($i in $Id) { InvokeNetboxRequest -URI (BuildNewURI -Segments @('dcim', 'rear-ports', $i)) -Raw:$Raw } }
+            default {
+                $Segments = [System.Collections.ArrayList]::new(@('dcim', 'rear-ports'))
+                $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'All', 'PageSize'
+                $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
+                InvokeNetboxRequest -URI $URI -Raw:$Raw -All:$All -PageSize $PageSize
+            }
+        }
     }
 }

--- a/Functions/Virtualization/VirtualMachineInterface/Get-NBVirtualMachineInterface.ps1
+++ b/Functions/Virtualization/VirtualMachineInterface/Get-NBVirtualMachineInterface.ps1
@@ -41,7 +41,7 @@ function Get-NBVirtualMachineInterface {
         PS C:\> Get-NBVirtualMachineInterface
 #>
 
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName = 'Query')]
     [OutputType([PSCustomObject])]
     param
     (
@@ -57,21 +57,28 @@ function Get-NBVirtualMachineInterface {
 
         [string[]]$Omit,
 
-        [Parameter(ValueFromPipeline = $true)]
+        [Parameter(ParameterSetName = 'ByID', ValueFromPipelineByPropertyName = $true)]
         [uint64[]]$Id,
 
+        [Parameter(ParameterSetName = 'Query')]
         [string]$Name,
 
+        [Parameter(ParameterSetName = 'Query')]
         [string]$Query,
 
+        [Parameter(ParameterSetName = 'Query')]
         [boolean]$Enabled,
 
+        [Parameter(ParameterSetName = 'Query')]
         [uint16]$MTU,
 
+        [Parameter(ParameterSetName = 'Query')]
         [uint64]$Virtual_Machine_Id,
 
+        [Parameter(ParameterSetName = 'Query')]
         [string]$Virtual_Machine,
 
+        [Parameter(ParameterSetName = 'Query')]
         [string]$MAC_Address,
 
         [ValidateRange(1, 1000)]
@@ -85,12 +92,14 @@ function Get-NBVirtualMachineInterface {
 
     process {
         Write-Verbose "Retrieving Virtual Machine Interface"
-        $Segments = [System.Collections.ArrayList]::new(@('virtualization', 'interfaces'))
-
-        $URIComponents = BuildURIComponents -URISegments $Segments -ParametersDictionary $PSBoundParameters -SkipParameterByName 'All', 'PageSize'
-
-        $uri = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
-
-        InvokeNetboxRequest -URI $uri -Raw:$Raw -All:$All -PageSize $PageSize
+        switch ($PSCmdlet.ParameterSetName) {
+            'ByID' { foreach ($i in $Id) { InvokeNetboxRequest -URI (BuildNewURI -Segments @('virtualization', 'interfaces', $i)) -Raw:$Raw } }
+            default {
+                $Segments = [System.Collections.ArrayList]::new(@('virtualization', 'interfaces'))
+                $URIComponents = BuildURIComponents -URISegments $Segments -ParametersDictionary $PSBoundParameters -SkipParameterByName 'All', 'PageSize'
+                $uri = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
+                InvokeNetboxRequest -URI $uri -Raw:$Raw -All:$All -PageSize $PageSize
+            }
+        }
     }
 }

--- a/Functions/Virtualization/VirtualizationCluster/Get-NBVirtualizationCluster.ps1
+++ b/Functions/Virtualization/VirtualizationCluster/Get-NBVirtualizationCluster.ps1
@@ -47,7 +47,7 @@ function Get-NBVirtualizationCluster {
         PS C:\> Get-NBVirtualizationCluster
 #>
 
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName = 'Query')]
     [OutputType([PSCustomObject])]
     param
     (
@@ -63,24 +63,32 @@ function Get-NBVirtualizationCluster {
 
         [string[]]$Omit,
 
+        [Parameter(ParameterSetName = 'Query')]
         [string]$Name,
 
+        [Parameter(ParameterSetName = 'Query')]
         [Alias('q')]
         [string]$Query,
 
-        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [Parameter(ParameterSetName = 'ByID', ValueFromPipelineByPropertyName = $true)]
         [uint64[]]$Id,
 
+        [Parameter(ParameterSetName = 'Query')]
         [string]$Group,
 
+        [Parameter(ParameterSetName = 'Query')]
         [uint64]$Group_Id,
 
+        [Parameter(ParameterSetName = 'Query')]
         [string]$Type,
 
+        [Parameter(ParameterSetName = 'Query')]
         [uint64]$Type_Id,
 
+        [Parameter(ParameterSetName = 'Query')]
         [string]$Site,
 
+        [Parameter(ParameterSetName = 'Query')]
         [uint64]$Site_Id,
 
         [ValidateRange(1, 1000)]
@@ -94,12 +102,14 @@ function Get-NBVirtualizationCluster {
 
     process {
         Write-Verbose "Retrieving Virtualization Cluster"
-        $Segments = [System.Collections.ArrayList]::new(@('virtualization', 'clusters'))
-
-        $URIComponents = BuildURIComponents -URISegments $Segments -ParametersDictionary $PSBoundParameters -SkipParameterByName 'All', 'PageSize'
-
-        $uri = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
-
-        InvokeNetboxRequest -URI $uri -Raw:$Raw -All:$All -PageSize $PageSize
+        switch ($PSCmdlet.ParameterSetName) {
+            'ByID' { foreach ($i in $Id) { InvokeNetboxRequest -URI (BuildNewURI -Segments @('virtualization', 'clusters', $i)) -Raw:$Raw } }
+            default {
+                $Segments = [System.Collections.ArrayList]::new(@('virtualization', 'clusters'))
+                $URIComponents = BuildURIComponents -URISegments $Segments -ParametersDictionary $PSBoundParameters -SkipParameterByName 'All', 'PageSize'
+                $uri = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
+                InvokeNetboxRequest -URI $uri -Raw:$Raw -All:$All -PageSize $PageSize
+            }
+        }
     }
 }

--- a/Functions/Virtualization/VirtualizationCluster/Get-NBVirtualizationClusterGroup.ps1
+++ b/Functions/Virtualization/VirtualizationCluster/Get-NBVirtualizationClusterGroup.ps1
@@ -15,7 +15,7 @@
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>
 function Get-NBVirtualizationClusterGroup {
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName = 'Query')]
     [OutputType([PSCustomObject])]
     param
     (
@@ -31,15 +31,19 @@ function Get-NBVirtualizationClusterGroup {
 
         [string[]]$Omit,
 
+        [Parameter(ParameterSetName = 'Query')]
         [string]$Name,
 
+        [Parameter(ParameterSetName = 'Query')]
         [string]$Slug,
 
+        [Parameter(ParameterSetName = 'Query')]
         [string]$Description,
 
+        [Parameter(ParameterSetName = 'Query')]
         [string]$Query,
 
-        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [Parameter(ParameterSetName = 'ByID', ValueFromPipelineByPropertyName = $true)]
         [uint64[]]$Id,
 
         [ValidateRange(1, 1000)]
@@ -53,12 +57,14 @@ function Get-NBVirtualizationClusterGroup {
 
     process {
         Write-Verbose "Retrieving Virtualization Cluster Group"
-        $Segments = [System.Collections.ArrayList]::new(@('virtualization', 'cluster-groups'))
-
-        $URIComponents = BuildURIComponents -URISegments $Segments -ParametersDictionary $PSBoundParameters -SkipParameterByName 'All', 'PageSize'
-
-        $uri = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
-
-        InvokeNetboxRequest -URI $uri -Raw:$Raw -All:$All -PageSize $PageSize
+        switch ($PSCmdlet.ParameterSetName) {
+            'ByID' { foreach ($i in $Id) { InvokeNetboxRequest -URI (BuildNewURI -Segments @('virtualization', 'cluster-groups', $i)) -Raw:$Raw } }
+            default {
+                $Segments = [System.Collections.ArrayList]::new(@('virtualization', 'cluster-groups'))
+                $URIComponents = BuildURIComponents -URISegments $Segments -ParametersDictionary $PSBoundParameters -SkipParameterByName 'All', 'PageSize'
+                $uri = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
+                InvokeNetboxRequest -URI $uri -Raw:$Raw -All:$All -PageSize $PageSize
+            }
+        }
     }
 }

--- a/Functions/Virtualization/VirtualizationClusterType/Get-NBVirtualizationClusterType.ps1
+++ b/Functions/Virtualization/VirtualizationClusterType/Get-NBVirtualizationClusterType.ps1
@@ -49,7 +49,7 @@
     https://netbox.readthedocs.io/en/stable/models/virtualization/clustertype/
 #>
 function Get-NBVirtualizationClusterType {
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName = 'Query')]
     [OutputType([PSCustomObject])]
     param
     (
@@ -65,15 +65,19 @@ function Get-NBVirtualizationClusterType {
 
         [string[]]$Omit,
 
-        [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [Parameter(ParameterSetName = 'ByID', ValueFromPipelineByPropertyName = $true)]
         [uint64[]]$Id,
 
+        [Parameter(ParameterSetName = 'Query')]
         [string]$Name,
 
+        [Parameter(ParameterSetName = 'Query')]
         [string]$Slug,
 
+        [Parameter(ParameterSetName = 'Query')]
         [string]$Description,
 
+        [Parameter(ParameterSetName = 'Query')]
         [Alias('q')]
         [string]$Query,
 
@@ -88,12 +92,14 @@ function Get-NBVirtualizationClusterType {
 
     process {
         Write-Verbose "Retrieving Virtualization Cluster Type"
-        $Segments = [System.Collections.ArrayList]::new(@('virtualization', 'cluster-types'))
-
-        $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'All', 'PageSize'
-
-        $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
-
-        InvokeNetboxRequest -URI $URI -Raw:$Raw -All:$All -PageSize $PageSize
+        switch ($PSCmdlet.ParameterSetName) {
+            'ByID' { foreach ($i in $Id) { InvokeNetboxRequest -URI (BuildNewURI -Segments @('virtualization', 'cluster-types', $i)) -Raw:$Raw } }
+            default {
+                $Segments = [System.Collections.ArrayList]::new(@('virtualization', 'cluster-types'))
+                $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'All', 'PageSize'
+                $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
+                InvokeNetboxRequest -URI $URI -Raw:$Raw -All:$All -PageSize $PageSize
+            }
+        }
     }
 }

--- a/Tests/DCIM.Interfaces.Tests.ps1
+++ b/Tests/DCIM.Interfaces.Tests.ps1
@@ -73,6 +73,19 @@ Describe "DCIM Interfaces Tests" -Tag 'DCIM', 'Interfaces' {
             $Result.Uri | Should -BeExactly 'https://netbox.domain.com/api/dcim/interfaces/?name=eth0'
         }
 
+        It "Should request an interface by ID" {
+            $Result = Get-NBDCIMInterface -Id 10
+            $Result.Method | Should -Be 'GET'
+            $Result.Uri | Should -Match '/api/dcim/interfaces/10/'
+        }
+
+        It "Should request multiple interfaces by ID" {
+            $Result = Get-NBDCIMInterface -Id 10, 12
+            $Result | Should -HaveCount 2
+            $Result[0].Uri | Should -Match '/api/dcim/interfaces/10/'
+            $Result[1].Uri | Should -Match '/api/dcim/interfaces/12/'
+        }
+
         It "Should request an interface from the pipeline" {
             $Result = [pscustomobject]@{ 'Id' = 1234 } | Get-NBDCIMInterface
             $Result.Uri | Should -Be 'https://netbox.domain.com/api/dcim/interfaces/1234/'
@@ -212,6 +225,12 @@ Describe "DCIM Interfaces Tests" -Tag 'DCIM', 'Interfaces' {
             $validateSet = $param.Attributes | Where-Object { $_ -is [System.Management.Automation.ValidateSetAttribute] }
             $validateSet | Should -Not -BeNullOrEmpty
             $validateSet.ValidValues | Should -Contain 'connected'
+        }
+
+        It "Should request an interface connection by ID" {
+            $Result = Get-NBDCIMInterfaceConnection -Id 7
+            $Result.Method | Should -Be 'GET'
+            $Result.Uri | Should -Match '/api/dcim/interface-connections/7/'
         }
     }
 

--- a/Tests/Virtualization.Tests.ps1
+++ b/Tests/Virtualization.Tests.ps1
@@ -80,10 +80,13 @@ Describe "Virtualization tests" -Tag 'Virtualization' {
 
         It "Should request with multiple IDs" {
             $Result = Get-NBVirtualMachine -Id 10, 12, 15
-            $Result.Method | Should -Be 'GET'
-            # Commas may or may not be URL-encoded depending on PS version
-            $Result.Uri | Should -Match 'id__in=10(%2C|,)12(%2C|,)15'
-            $Result.Uri | Should -Match 'omit=config_context'
+
+            $Result | Should -HaveCount 3
+            $Result[0].Method | Should -Be 'GET'
+            $Result[0].Uri | Should -Match 'virtualization/virtual-machines/10/'
+            $Result[1].Uri | Should -Match 'virtualization/virtual-machines/12/'
+            $Result[2].Uri | Should -Match 'virtualization/virtual-machines/15/'
+            $Result | ForEach-Object { $_.Uri | Should -Match 'omit=config_context' }
         }
 
         It "Should request a status" {
@@ -210,9 +213,12 @@ Describe "Virtualization tests" -Tag 'Virtualization' {
 
         It "Should request with multiple IDs" {
             $Result = Get-NBVirtualizationCluster -Id 10, 12, 15
-            $Result.Method | Should -Be 'GET'
-            # Commas may or may not be URL-encoded depending on PS version
-            $Result.Uri | Should -Match 'id__in=10(%2C|,)12(%2C|,)15'
+
+            $Result | Should -HaveCount 3
+            $Result[0].Method | Should -Be 'GET'
+            $Result[0].Uri | Should -Match 'virtualization/clusters/10/'
+            $Result[1].Uri | Should -Match 'virtualization/clusters/12/'
+            $Result[2].Uri | Should -Match 'virtualization/clusters/15/'
         }
     }
 
@@ -241,6 +247,12 @@ Describe "Virtualization tests" -Tag 'Virtualization' {
             $Result = Get-NBVirtualizationClusterGroup -Slug 'test-cluster-group'
             $Result.Method | Should -Be 'GET'
             $Result.Uri | Should -Be 'https://netbox.domain.com/api/virtualization/cluster-groups/?slug=test-cluster-group'
+        }
+
+        It "Should request a cluster group by ID" {
+            $Result = Get-NBVirtualizationClusterGroup -Id 5
+            $Result.Method | Should -Be 'GET'
+            $Result.Uri | Should -Match '/api/virtualization/cluster-groups/5/'
         }
     }
 


### PR DESCRIPTION
## Summary

- Adds ByID/Query parameter set pattern to 13 Get functions across DCIM, Virtualization, Extras, and Tenancy modules
- When `-Id` is passed, functions now route to `/resource/ID/` (direct lookup) instead of sending `id` as a query parameter to the list endpoint
- Follows the same pattern already used by Get-NBDCIMDevice, Get-NBDCIMSite, and other standardized functions

### Functions updated (13):
| Module | Functions |
|--------|-----------|
| DCIM | Cable, DeviceType, FrontPort, Interface, InterfaceConnection, RearPort |
| Virtualization | VirtualMachine, VirtualMachineInterface, Cluster, ClusterGroup, ClusterType |
| Extras | Tag |
| Tenancy | TenantGroup |

### Additional fixes:
- `Get-NBDCIMInterfaceConnection`: Added missing `ValueFromPipelineByPropertyName` on `$Id`
- `Get-NBVirtualMachineInterface`: Changed `ValueFromPipeline` to `ValueFromPipelineByPropertyName` on `$Id`
- `Get-NBVirtualMachine`: ByID branch handles `config_context` exclusion (matches `Get-NBDCIMDevice` pattern)

### Tests:
- Updated existing multi-ID tests for Get-NBVirtualMachine and Get-NBVirtualizationCluster
- Added new ByID tests for Get-NBDCIMInterface, Get-NBDCIMInterfaceConnection, Get-NBVirtualizationClusterGroup
- All 1341 unit tests pass

Closes #290, #291, #293

🤖 Generated with [Claude Code](https://claude.com/claude-code)