### PR TITLE
fix: Resolve parameter validation and type bugs

### DIFF
--- a/Functions/Circuits/Circuits/New-NBCircuit.ps1
+++ b/Functions/Circuits/Circuits/New-NBCircuit.ps1
@@ -65,7 +65,7 @@ function New-NBCircuit {
         $Segments = [System.Collections.ArrayList]::new(@('circuits', 'circuits'))
         $Method = 'POST'
 
-        $URIComponents = BuildURIComponents -URISegments $Segments -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw'
+        $URIComponents = BuildURIComponents -URISegments $Segments -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'Force'
 
         $URI = BuildNewURI -Segments $URIComponents.Segments
 

--- a/Functions/Circuits/Types/Get-NBCircuitType.ps1
+++ b/Functions/Circuits/Types/Get-NBCircuitType.ps1
@@ -57,7 +57,7 @@ function Get-NBCircuitType {
         switch ($PSCmdlet.ParameterSetName) {
         'ById' {
             foreach ($i in $ID) {
-                $Segments = [System.Collections.ArrayList]::new(@('circuits', 'circuit_types', $i))
+                $Segments = [System.Collections.ArrayList]::new(@('circuits', 'circuit-types', $i))
 
                 $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'All', 'PageSize'
 

--- a/Functions/Helpers/CheckNetboxIsConnected.ps1
+++ b/Functions/Helpers/CheckNetboxIsConnected.ps1
@@ -1,7 +1,7 @@
 
 function CheckNetboxIsConnected {
     [CmdletBinding()]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param ()
 
     Write-Verbose "Checking connection status"

--- a/Functions/IPAM/Prefix/Set-NBIPAMPrefix.ps1
+++ b/Functions/IPAM/Prefix/Set-NBIPAMPrefix.ps1
@@ -46,7 +46,7 @@ function Set-NBIPAMPrefix {
 
         [string]$Description,
 
-        [switch]$Is_Pool,
+        [bool]$Is_Pool,
 
         [uint64]$Owner,
 

--- a/Functions/IPAM/Role/Get-NBIPAMRole.ps1
+++ b/Functions/IPAM/Role/Get-NBIPAMRole.ps1
@@ -45,6 +45,12 @@ function Get-NBIPAMRole {
         [ValidateRange(1, 1000)]
         [int]$PageSize = 100,
 
+        [switch]$Brief,
+
+        [string[]]$Fields,
+
+        [string[]]$Omit,
+
         [Parameter(ParameterSetName = 'Query',
                    Position = 0)]
         [string]$Name,
@@ -58,21 +64,12 @@ function Get-NBIPAMRole {
         [Parameter(ParameterSetName = 'Query')]
         [string]$Slug,
 
-        [Parameter(ParameterSetName = 'Query')]
-        [switch]$Brief,
-
-        [Parameter(ParameterSetName = 'Query')]
-        [Parameter(ParameterSetName = 'ByID')]
         [ValidateRange(1, 1000)]
         [uint16]$Limit,
 
-        [Parameter(ParameterSetName = 'Query')]
-        [Parameter(ParameterSetName = 'ByID')]
         [ValidateRange(0, [int]::MaxValue)]
         [uint16]$Offset,
 
-        [Parameter(ParameterSetName = 'Query')]
-        [Parameter(ParameterSetName = 'ByID')]
         [switch]$Raw
     )
 

--- a/Functions/IPAM/VLAN/Get-NBIPAMVLAN.ps1
+++ b/Functions/IPAM/VLAN/Get-NBIPAMVLAN.ps1
@@ -33,7 +33,7 @@ function Get-NBIPAMVLAN {
 
         [Parameter(ParameterSetName = 'Query',
                    Position = 0)]
-        [ValidateRange(1, 4096)]
+        [ValidateRange(1, 4094)]
         [uint16]$VID,
 
         [Parameter(ParameterSetName = 'ByID', ValueFromPipelineByPropertyName = $true)]

--- a/Functions/IPAM/VLAN/Set-NBIPAMVLAN.ps1
+++ b/Functions/IPAM/VLAN/Set-NBIPAMVLAN.ps1
@@ -22,7 +22,7 @@ function Set-NBIPAMVLAN {
     [OutputType([PSCustomObject])]
     param(
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)][uint64]$Id,
-        [ValidateRange(1, 4096)][uint16]$VID,
+        [ValidateRange(1, 4094)][uint16]$VID,
         [string]$Name,
         [string]$Status,
         [uint64]$Site,

--- a/Functions/VPN/IKEPolicy/New-NBVPNIKEPolicy.ps1
+++ b/Functions/VPN/IKEPolicy/New-NBVPNIKEPolicy.ps1
@@ -59,7 +59,7 @@ function New-NBVPNIKEPolicy {
 
         [string]$Comments,
 
-        [hashtable]$CustomFields,
+        [hashtable]$Custom_Fields,
 
         [switch]$Raw
     )

--- a/Functions/VPN/TunnelGroup/New-NBVPNTunnelGroup.ps1
+++ b/Functions/VPN/TunnelGroup/New-NBVPNTunnelGroup.ps1
@@ -39,7 +39,7 @@ function New-NBVPNTunnelGroup {
 
         [string]$Description,
 
-        [hashtable]$CustomFields,
+        [hashtable]$Custom_Fields,
 
         [switch]$Raw
     )

--- a/Functions/Virtualization/VirtualMachine/Set-NBVirtualMachine.ps1
+++ b/Functions/Virtualization/VirtualMachine/Set-NBVirtualMachine.ps1
@@ -126,7 +126,7 @@ function Set-NBVirtualMachine {
         [uint64]$Primary_IP6,
 
         [Parameter(ParameterSetName = 'Single')]
-        [byte]$VCPUs,
+        [uint16]$VCPUs,
 
         [Parameter(ParameterSetName = 'Single')]
         [uint64]$Memory,

--- a/Tests/Circuits.Tests.ps1
+++ b/Tests/Circuits.Tests.ps1
@@ -123,8 +123,7 @@ Describe "Circuits Module Tests" -Tag 'Circuits' {
 
         It "Should request a circuit type by ID" {
             $Result = Get-NBCircuitType -Id 3
-            # Bug: uses circuit_types (underscore) for ID lookup
-            $Result.Uri | Should -Be 'https://netbox.domain.com/api/circuits/circuit_types/3/'
+            $Result.Uri | Should -Be 'https://netbox.domain.com/api/circuits/circuit-types/3/'
         }
 
         It "Should request a circuit type by name" {


### PR DESCRIPTION
## Summary
- **Get-NBCircuitType**: Fix ByID URL segment (`circuit_types` -> `circuit-types`) - was returning 404 for ID lookups
- **Set-NBVirtualMachine**: Fix VCPUs type (`[byte]` max 255 -> `[uint16]` max 65535) to match New-NBVirtualMachine
- **Set-NBIPAMVLAN/Get-NBIPAMVLAN**: Fix VID ValidateRange (4096 -> 4094 per IEEE 802.1Q standard)
- **New-NBCircuit**: Add `Force` to SkipParameterByName (prevents switch leaking to API body)
- **Set-NBIPAMPrefix**: Change `Is_Pool` from `[switch]` to `[bool]` (allows explicitly setting to `$false`)
- **CheckNetboxIsConnected**: Fix OutputType (`[PSCustomObject]` -> `[void]`) - function returns nothing
- **New-NBVPNTunnelGroup/New-NBVPNIKEPolicy**: Fix `$CustomFields` -> `$Custom_Fields` (API key mismatch)
- **Get-NBIPAMRole**: Add missing `Fields`/`Omit` parameters, fix `Brief` param set scope

Closes #301

## Test plan
- [x] All 309 tests pass in Circuits, IPAM, VPN, and Virtualization test files
- [x] Circuit type test updated to expect corrected URL
- [ ] CI passes on all platforms (Ubuntu PS7, Windows PS5.1, Windows PS7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)