### PR TITLE
security: SecureString for Preshared_Key and Auth_PSK

### DIFF
--- a/Functions/VPN/IKEPolicy/New-NBVPNIKEPolicy.ps1
+++ b/Functions/VPN/IKEPolicy/New-NBVPNIKEPolicy.ps1
@@ -53,7 +53,7 @@ function New-NBVPNIKEPolicy {
 
         [uint64[]]$Proposals,
 
-        [string]$Preshared_Key,
+        [securestring]$Preshared_Key,
 
         [string]$Description,
 
@@ -67,8 +67,12 @@ function New-NBVPNIKEPolicy {
     process {
         Write-Verbose "Creating VPN IKE Policy"
         $Segments = [System.Collections.ArrayList]::new(@('vpn', 'ike-policies'))
-        $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw'
+        $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'Preshared_Key'
         $URI = BuildNewURI -Segments $URIComponents.Segments
+
+        if ($PSBoundParameters.ContainsKey('Preshared_Key')) {
+            $URIComponents.Parameters['preshared_key'] = [System.Net.NetworkCredential]::new('', $Preshared_Key).Password
+        }
 
         if ($PSCmdlet.ShouldProcess($Name, 'Create IKE policy')) {
             InvokeNetboxRequest -URI $URI -Method POST -Body $URIComponents.Parameters -Raw:$Raw

--- a/Functions/VPN/IKEPolicy/Set-NBVPNIKEPolicy.ps1
+++ b/Functions/VPN/IKEPolicy/Set-NBVPNIKEPolicy.ps1
@@ -21,10 +21,11 @@ function Set-NBVPNIKEPolicy {
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
     [OutputType([PSCustomObject])]
     param([Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)][uint64]$Id,
-        [string]$Name,[uint16]$Version,[string]$Mode,[uint64[]]$Proposals,[string]$Preshared_Key,[string]$Description,[string]$Comments,[hashtable]$Custom_Fields,[switch]$Raw)
+        [string]$Name,[uint16]$Version,[string]$Mode,[uint64[]]$Proposals,[securestring]$Preshared_Key,[string]$Description,[string]$Comments,[hashtable]$Custom_Fields,[switch]$Raw)
     process {
         Write-Verbose "Updating VPN IKE Policy"
-        $s = [System.Collections.ArrayList]::new(@('vpn','ike-policies',$Id)); $u = BuildURIComponents -URISegments $s.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id','Raw'
+        $s = [System.Collections.ArrayList]::new(@('vpn','ike-policies',$Id)); $u = BuildURIComponents -URISegments $s.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id','Raw','Preshared_Key'
+        if ($PSBoundParameters.ContainsKey('Preshared_Key')) { $u.Parameters['preshared_key'] = [System.Net.NetworkCredential]::new('', $Preshared_Key).Password }
         if ($PSCmdlet.ShouldProcess($Id, 'Update IKE policy')) { InvokeNetboxRequest -URI (BuildNewURI -Segments $u.Segments) -Method PATCH -Body $u.Parameters -Raw:$Raw }
     }
 }

--- a/Functions/Wireless/WirelessLAN/New-NBWirelessLAN.ps1
+++ b/Functions/Wireless/WirelessLAN/New-NBWirelessLAN.ps1
@@ -68,7 +68,7 @@ function New-NBWirelessLAN {
 
         [string]$Auth_Cipher,
 
-        [string]$Auth_PSK,
+        [securestring]$Auth_PSK,
 
         [string]$Description,
 
@@ -82,8 +82,12 @@ function New-NBWirelessLAN {
     process {
         Write-Verbose "Creating Wireless LAN"
         $Segments = [System.Collections.ArrayList]::new(@('wireless', 'wireless-lans'))
-        $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw'
+        $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'Auth_PSK'
         $URI = BuildNewURI -Segments $URIComponents.Segments
+
+        if ($PSBoundParameters.ContainsKey('Auth_PSK')) {
+            $URIComponents.Parameters['auth_psk'] = [System.Net.NetworkCredential]::new('', $Auth_PSK).Password
+        }
 
         if ($PSCmdlet.ShouldProcess($SSID, 'Create wireless LAN')) {
             InvokeNetboxRequest -URI $URI -Method POST -Body $URIComponents.Parameters -Raw:$Raw

--- a/Functions/Wireless/WirelessLAN/Set-NBWirelessLAN.ps1
+++ b/Functions/Wireless/WirelessLAN/Set-NBWirelessLAN.ps1
@@ -21,10 +21,11 @@ function Set-NBWirelessLAN {
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
     [OutputType([PSCustomObject])]
     param([Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)][uint64]$Id,[string]$SSID,[uint64]$Group,[string]$Status,[uint64]$VLAN,[uint64]$Tenant,
-        [string]$Auth_Type,[string]$Auth_Cipher,[string]$Auth_PSK,[string]$Description,[string]$Comments,[hashtable]$Custom_Fields,[switch]$Raw)
+        [string]$Auth_Type,[string]$Auth_Cipher,[securestring]$Auth_PSK,[string]$Description,[string]$Comments,[hashtable]$Custom_Fields,[switch]$Raw)
     process {
         Write-Verbose "Updating Wireless LAN"
-        $s = [System.Collections.ArrayList]::new(@('wireless','wireless-lans',$Id)); $u = BuildURIComponents -URISegments $s.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id','Raw'
+        $s = [System.Collections.ArrayList]::new(@('wireless','wireless-lans',$Id)); $u = BuildURIComponents -URISegments $s.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id','Raw','Auth_PSK'
+        if ($PSBoundParameters.ContainsKey('Auth_PSK')) { $u.Parameters['auth_psk'] = [System.Net.NetworkCredential]::new('', $Auth_PSK).Password }
         if ($PSCmdlet.ShouldProcess($Id, 'Update wireless LAN')) { InvokeNetboxRequest -URI (BuildNewURI -Segments $u.Segments) -Method PATCH -Body $u.Parameters -Raw:$Raw }
     }
 }

--- a/Functions/Wireless/WirelessLink/New-NBWirelessLink.ps1
+++ b/Functions/Wireless/WirelessLink/New-NBWirelessLink.ps1
@@ -69,7 +69,7 @@ function New-NBWirelessLink {
 
         [string]$Auth_Cipher,
 
-        [string]$Auth_PSK,
+        [securestring]$Auth_PSK,
 
         [string]$Description,
 
@@ -83,8 +83,12 @@ function New-NBWirelessLink {
     process {
         Write-Verbose "Creating Wireless Link"
         $Segments = [System.Collections.ArrayList]::new(@('wireless', 'wireless-links'))
-        $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw'
+        $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'Auth_PSK'
         $URI = BuildNewURI -Segments $URIComponents.Segments
+
+        if ($PSBoundParameters.ContainsKey('Auth_PSK')) {
+            $URIComponents.Parameters['auth_psk'] = [System.Net.NetworkCredential]::new('', $Auth_PSK).Password
+        }
 
         if ($PSCmdlet.ShouldProcess("$Interface_A to $Interface_B", 'Create wireless link')) {
             InvokeNetboxRequest -URI $URI -Method POST -Body $URIComponents.Parameters -Raw:$Raw

--- a/Functions/Wireless/WirelessLink/Set-NBWirelessLink.ps1
+++ b/Functions/Wireless/WirelessLink/Set-NBWirelessLink.ps1
@@ -21,11 +21,12 @@ function Set-NBWirelessLink {
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
     [OutputType([PSCustomObject])]
     param([Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)][uint64]$Id,[uint64]$Interface_A,[uint64]$Interface_B,
-        [string]$SSID,[string]$Status,[uint64]$Tenant,[string]$Auth_Type,[string]$Auth_Cipher,[string]$Auth_PSK,
+        [string]$SSID,[string]$Status,[uint64]$Tenant,[string]$Auth_Type,[string]$Auth_Cipher,[securestring]$Auth_PSK,
         [string]$Description,[string]$Comments,[hashtable]$Custom_Fields,[switch]$Raw)
     process {
         Write-Verbose "Updating Wireless Link"
-        $s = [System.Collections.ArrayList]::new(@('wireless','wireless-links',$Id)); $u = BuildURIComponents -URISegments $s.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id','Raw'
+        $s = [System.Collections.ArrayList]::new(@('wireless','wireless-links',$Id)); $u = BuildURIComponents -URISegments $s.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id','Raw','Auth_PSK'
+        if ($PSBoundParameters.ContainsKey('Auth_PSK')) { $u.Parameters['auth_psk'] = [System.Net.NetworkCredential]::new('', $Auth_PSK).Password }
         if ($PSCmdlet.ShouldProcess($Id, 'Update wireless link')) { InvokeNetboxRequest -URI (BuildNewURI -Segments $u.Segments) -Method PATCH -Body $u.Parameters -Raw:$Raw }
     }
 }


### PR DESCRIPTION
## Summary
- Change `Preshared_Key` and `Auth_PSK` parameters from `[string]` to `[securestring]` in 6 VPN/Wireless functions
- Follows the same pattern established by PR #234 for webhook `Secret` parameters
- Each function skips the SecureString param in `BuildURIComponents` and converts via `NetworkCredential` before adding to the API body

**Functions changed:**
- `New-NBVPNIKEPolicy` / `Set-NBVPNIKEPolicy`: `Preshared_Key`
- `New-NBWirelessLAN` / `Set-NBWirelessLAN`: `Auth_PSK`
- `New-NBWirelessLink` / `Set-NBWirelessLink`: `Auth_PSK`

**Note:** This is a breaking change for users passing plain strings. They will need to use `ConvertTo-SecureString` or `Read-Host -AsSecureString`. This aligns with PowerShell security best practices.

Closes #302

## Test plan
- [x] All 111 VPN and Wireless tests pass
- [ ] CI passes on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)