### PR TITLE
Fix ByID parameter passthrough in 18 Get functions

### DIFF
--- a/Functions/IPAM/FHRPGroup/Get-NBIPAMFHRPGroup.ps1
+++ b/Functions/IPAM/FHRPGroup/Get-NBIPAMFHRPGroup.ps1
@@ -44,7 +44,14 @@ function Get-NBIPAMFHRPGroup {
     process {
         Write-Verbose "Retrieving IPAM FHRP Group"
         switch ($PSCmdlet.ParameterSetName) {
-            'ByID' { foreach ($i in $Id) { InvokeNetboxRequest -URI (BuildNewURI -Segments @('ipam','fhrp-groups',$i)) -Raw:$Raw } }
+            'ByID' {
+                foreach ($i in $Id) {
+                    $Segments = [System.Collections.ArrayList]::new(@('ipam', 'fhrp-groups', $i))
+                    $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw', 'All', 'PageSize'
+                    $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
+                    InvokeNetboxRequest -URI $URI -Raw:$Raw
+                }
+            }
             default {
                 $Segments = [System.Collections.ArrayList]::new(@('ipam','fhrp-groups'))
                 $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'All', 'PageSize'

--- a/Functions/IPAM/FHRPGroupAssignment/Get-NBIPAMFHRPGroupAssignment.ps1
+++ b/Functions/IPAM/FHRPGroupAssignment/Get-NBIPAMFHRPGroupAssignment.ps1
@@ -44,7 +44,14 @@ function Get-NBIPAMFHRPGroupAssignment {
     process {
         Write-Verbose "Retrieving IPAM FHRP Group Assignment"
         switch ($PSCmdlet.ParameterSetName) {
-            'ByID' { foreach ($i in $Id) { InvokeNetboxRequest -URI (BuildNewURI -Segments @('ipam','fhrp-group-assignments',$i)) -Raw:$Raw } }
+            'ByID' {
+                foreach ($i in $Id) {
+                    $Segments = [System.Collections.ArrayList]::new(@('ipam', 'fhrp-group-assignments', $i))
+                    $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw', 'All', 'PageSize'
+                    $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
+                    InvokeNetboxRequest -URI $URI -Raw:$Raw
+                }
+            }
             default {
                 $Segments = [System.Collections.ArrayList]::new(@('ipam','fhrp-group-assignments'))
                 $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'All', 'PageSize'

--- a/Functions/IPAM/RIR/Get-NBIPAMRIR.ps1
+++ b/Functions/IPAM/RIR/Get-NBIPAMRIR.ps1
@@ -44,7 +44,14 @@ function Get-NBIPAMRIR {
     process {
         Write-Verbose "Retrieving IPAM RIR"
         switch ($PSCmdlet.ParameterSetName) {
-            'ByID' { foreach ($i in $Id) { InvokeNetboxRequest -URI (BuildNewURI -Segments @('ipam','rirs',$i)) -Raw:$Raw } }
+            'ByID' {
+                foreach ($i in $Id) {
+                    $Segments = [System.Collections.ArrayList]::new(@('ipam', 'rirs', $i))
+                    $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw', 'All', 'PageSize'
+                    $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
+                    InvokeNetboxRequest -URI $URI -Raw:$Raw
+                }
+            }
             default {
                 $Segments = [System.Collections.ArrayList]::new(@('ipam','rirs'))
                 $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'All', 'PageSize'

--- a/Functions/IPAM/VLANGroup/Get-NBIPAMVLANGroup.ps1
+++ b/Functions/IPAM/VLANGroup/Get-NBIPAMVLANGroup.ps1
@@ -47,7 +47,14 @@ function Get-NBIPAMVLANGroup {
     process {
         Write-Verbose "Retrieving IPAM VLAN Group"
         switch ($PSCmdlet.ParameterSetName) {
-            'ByID' { foreach ($i in $Id) { InvokeNetboxRequest -URI (BuildNewURI -Segments @('ipam','vlan-groups',$i)) -Raw:$Raw } }
+            'ByID' {
+                foreach ($i in $Id) {
+                    $Segments = [System.Collections.ArrayList]::new(@('ipam', 'vlan-groups', $i))
+                    $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw', 'All', 'PageSize'
+                    $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
+                    InvokeNetboxRequest -URI $URI -Raw:$Raw
+                }
+            }
             default {
                 $Segments = [System.Collections.ArrayList]::new(@('ipam','vlan-groups'))
                 $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'All', 'PageSize'

--- a/Functions/IPAM/VLANTranslationPolicy/Get-NBIPAMVLANTranslationPolicy.ps1
+++ b/Functions/IPAM/VLANTranslationPolicy/Get-NBIPAMVLANTranslationPolicy.ps1
@@ -42,7 +42,14 @@ function Get-NBIPAMVLANTranslationPolicy {
     process {
         Write-Verbose "Retrieving IPAM VLAN Translation Policy"
         switch ($PSCmdlet.ParameterSetName) {
-            'ByID' { foreach ($i in $Id) { InvokeNetboxRequest -URI (BuildNewURI -Segments @('ipam','vlan-translation-policies',$i)) -Raw:$Raw } }
+            'ByID' {
+                foreach ($i in $Id) {
+                    $Segments = [System.Collections.ArrayList]::new(@('ipam', 'vlan-translation-policies', $i))
+                    $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw', 'All', 'PageSize'
+                    $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
+                    InvokeNetboxRequest -URI $URI -Raw:$Raw
+                }
+            }
             default {
                 $Segments = [System.Collections.ArrayList]::new(@('ipam','vlan-translation-policies'))
                 $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'All', 'PageSize'

--- a/Functions/IPAM/VLANTranslationRule/Get-NBIPAMVLANTranslationRule.ps1
+++ b/Functions/IPAM/VLANTranslationRule/Get-NBIPAMVLANTranslationRule.ps1
@@ -43,7 +43,14 @@ function Get-NBIPAMVLANTranslationRule {
     process {
         Write-Verbose "Retrieving IPAM VLAN Translation Rule"
         switch ($PSCmdlet.ParameterSetName) {
-            'ByID' { foreach ($i in $Id) { InvokeNetboxRequest -URI (BuildNewURI -Segments @('ipam','vlan-translation-rules',$i)) -Raw:$Raw } }
+            'ByID' {
+                foreach ($i in $Id) {
+                    $Segments = [System.Collections.ArrayList]::new(@('ipam', 'vlan-translation-rules', $i))
+                    $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw', 'All', 'PageSize'
+                    $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
+                    InvokeNetboxRequest -URI $URI -Raw:$Raw
+                }
+            }
             default {
                 $Segments = [System.Collections.ArrayList]::new(@('ipam','vlan-translation-rules'))
                 $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'All', 'PageSize'

--- a/Functions/VPN/IKEPolicy/Get-NBVPNIKEPolicy.ps1
+++ b/Functions/VPN/IKEPolicy/Get-NBVPNIKEPolicy.ps1
@@ -64,7 +64,10 @@ function Get-NBVPNIKEPolicy {
         switch ($PSCmdlet.ParameterSetName) {
             'ByID' {
                 foreach ($i in $Id) {
-                    InvokeNetboxRequest -URI (BuildNewURI -Segments @('vpn', 'ike-policies', $i)) -Raw:$Raw
+                    $Segments = [System.Collections.ArrayList]::new(@('vpn', 'ike-policies', $i))
+                    $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw', 'All', 'PageSize'
+                    $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
+                    InvokeNetboxRequest -URI $URI -Raw:$Raw
                 }
             }
             default {

--- a/Functions/VPN/IKEProposal/Get-NBVPNIKEProposal.ps1
+++ b/Functions/VPN/IKEProposal/Get-NBVPNIKEProposal.ps1
@@ -64,7 +64,10 @@ function Get-NBVPNIKEProposal {
         switch ($PSCmdlet.ParameterSetName) {
             'ByID' {
                 foreach ($i in $Id) {
-                    InvokeNetboxRequest -URI (BuildNewURI -Segments @('vpn', 'ike-proposals', $i)) -Raw:$Raw
+                    $Segments = [System.Collections.ArrayList]::new(@('vpn', 'ike-proposals', $i))
+                    $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw', 'All', 'PageSize'
+                    $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
+                    InvokeNetboxRequest -URI $URI -Raw:$Raw
                 }
             }
             default {

--- a/Functions/VPN/IPSecPolicy/Get-NBVPNIPSecPolicy.ps1
+++ b/Functions/VPN/IPSecPolicy/Get-NBVPNIPSecPolicy.ps1
@@ -64,7 +64,10 @@ function Get-NBVPNIPSecPolicy {
         switch ($PSCmdlet.ParameterSetName) {
             'ByID' {
                 foreach ($i in $Id) {
-                    InvokeNetboxRequest -URI (BuildNewURI -Segments @('vpn', 'ipsec-policies', $i)) -Raw:$Raw
+                    $Segments = [System.Collections.ArrayList]::new(@('vpn', 'ipsec-policies', $i))
+                    $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw', 'All', 'PageSize'
+                    $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
+                    InvokeNetboxRequest -URI $URI -Raw:$Raw
                 }
             }
             default {

--- a/Functions/VPN/IPSecProfile/Get-NBVPNIPSecProfile.ps1
+++ b/Functions/VPN/IPSecProfile/Get-NBVPNIPSecProfile.ps1
@@ -64,7 +64,10 @@ function Get-NBVPNIPSecProfile {
         switch ($PSCmdlet.ParameterSetName) {
             'ByID' {
                 foreach ($i in $Id) {
-                    InvokeNetboxRequest -URI (BuildNewURI -Segments @('vpn', 'ipsec-profiles', $i)) -Raw:$Raw
+                    $Segments = [System.Collections.ArrayList]::new(@('vpn', 'ipsec-profiles', $i))
+                    $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw', 'All', 'PageSize'
+                    $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
+                    InvokeNetboxRequest -URI $URI -Raw:$Raw
                 }
             }
             default {

--- a/Functions/VPN/IPSecProposal/Get-NBVPNIPSecProposal.ps1
+++ b/Functions/VPN/IPSecProposal/Get-NBVPNIPSecProposal.ps1
@@ -64,7 +64,10 @@ function Get-NBVPNIPSecProposal {
         switch ($PSCmdlet.ParameterSetName) {
             'ByID' {
                 foreach ($i in $Id) {
-                    InvokeNetboxRequest -URI (BuildNewURI -Segments @('vpn', 'ipsec-proposals', $i)) -Raw:$Raw
+                    $Segments = [System.Collections.ArrayList]::new(@('vpn', 'ipsec-proposals', $i))
+                    $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw', 'All', 'PageSize'
+                    $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
+                    InvokeNetboxRequest -URI $URI -Raw:$Raw
                 }
             }
             default {

--- a/Functions/VPN/L2VPN/Get-NBVPNL2VPN.ps1
+++ b/Functions/VPN/L2VPN/Get-NBVPNL2VPN.ps1
@@ -73,7 +73,10 @@ function Get-NBVPNL2VPN {
         switch ($PSCmdlet.ParameterSetName) {
             'ByID' {
                 foreach ($i in $Id) {
-                    InvokeNetboxRequest -URI (BuildNewURI -Segments @('vpn', 'l2vpns', $i)) -Raw:$Raw
+                    $Segments = [System.Collections.ArrayList]::new(@('vpn', 'l2vpns', $i))
+                    $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw', 'All', 'PageSize'
+                    $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
+                    InvokeNetboxRequest -URI $URI -Raw:$Raw
                 }
             }
             default {

--- a/Functions/VPN/L2VPNTermination/Get-NBVPNL2VPNTermination.ps1
+++ b/Functions/VPN/L2VPNTermination/Get-NBVPNL2VPNTermination.ps1
@@ -64,7 +64,10 @@ function Get-NBVPNL2VPNTermination {
         switch ($PSCmdlet.ParameterSetName) {
             'ByID' {
                 foreach ($i in $Id) {
-                    InvokeNetboxRequest -URI (BuildNewURI -Segments @('vpn', 'l2vpn-terminations', $i)) -Raw:$Raw
+                    $Segments = [System.Collections.ArrayList]::new(@('vpn', 'l2vpn-terminations', $i))
+                    $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw', 'All', 'PageSize'
+                    $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
+                    InvokeNetboxRequest -URI $URI -Raw:$Raw
                 }
             }
             default {

--- a/Functions/VPN/TunnelGroup/Get-NBVPNTunnelGroup.ps1
+++ b/Functions/VPN/TunnelGroup/Get-NBVPNTunnelGroup.ps1
@@ -67,7 +67,10 @@ function Get-NBVPNTunnelGroup {
         switch ($PSCmdlet.ParameterSetName) {
             'ByID' {
                 foreach ($i in $Id) {
-                    InvokeNetboxRequest -URI (BuildNewURI -Segments @('vpn', 'tunnel-groups', $i)) -Raw:$Raw
+                    $Segments = [System.Collections.ArrayList]::new(@('vpn', 'tunnel-groups', $i))
+                    $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw', 'All', 'PageSize'
+                    $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
+                    InvokeNetboxRequest -URI $URI -Raw:$Raw
                 }
             }
             default {

--- a/Functions/VPN/TunnelTermination/Get-NBVPNTunnelTermination.ps1
+++ b/Functions/VPN/TunnelTermination/Get-NBVPNTunnelTermination.ps1
@@ -67,7 +67,10 @@ function Get-NBVPNTunnelTermination {
         switch ($PSCmdlet.ParameterSetName) {
             'ByID' {
                 foreach ($i in $Id) {
-                    InvokeNetboxRequest -URI (BuildNewURI -Segments @('vpn', 'tunnel-terminations', $i)) -Raw:$Raw
+                    $Segments = [System.Collections.ArrayList]::new(@('vpn', 'tunnel-terminations', $i))
+                    $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw', 'All', 'PageSize'
+                    $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
+                    InvokeNetboxRequest -URI $URI -Raw:$Raw
                 }
             }
             default {

--- a/Functions/Wireless/WirelessLAN/Get-NBWirelessLAN.ps1
+++ b/Functions/Wireless/WirelessLAN/Get-NBWirelessLAN.ps1
@@ -39,7 +39,14 @@ function Get-NBWirelessLAN {
     process {
         Write-Verbose "Retrieving Wireless LAN"
         switch ($PSCmdlet.ParameterSetName) {
-            'ByID' { foreach ($i in $Id) { InvokeNetboxRequest -URI (BuildNewURI -Segments @('wireless','wireless-lans',$i)) -Raw:$Raw } }
+            'ByID' {
+                foreach ($i in $Id) {
+                    $Segments = [System.Collections.ArrayList]::new(@('wireless', 'wireless-lans', $i))
+                    $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw', 'All', 'PageSize'
+                    $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
+                    InvokeNetboxRequest -URI $URI -Raw:$Raw
+                }
+            }
             default { $s = [System.Collections.ArrayList]::new(@('wireless','wireless-lans')); $u = BuildURIComponents -URISegments $s.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'All', 'PageSize'; InvokeNetboxRequest -URI (BuildNewURI -Segments $u.Segments -Parameters $u.Parameters) -Raw:$Raw -All:$All -PageSize $PageSize }
         }
     }

--- a/Functions/Wireless/WirelessLANGroup/Get-NBWirelessLANGroup.ps1
+++ b/Functions/Wireless/WirelessLANGroup/Get-NBWirelessLANGroup.ps1
@@ -38,7 +38,14 @@ function Get-NBWirelessLANGroup {
     process {
         Write-Verbose "Retrieving Wireless LAN Group"
         switch ($PSCmdlet.ParameterSetName) {
-            'ByID' { foreach ($i in $Id) { InvokeNetboxRequest -URI (BuildNewURI -Segments @('wireless','wireless-lan-groups',$i)) -Raw:$Raw } }
+            'ByID' {
+                foreach ($i in $Id) {
+                    $Segments = [System.Collections.ArrayList]::new(@('wireless', 'wireless-lan-groups', $i))
+                    $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw', 'All', 'PageSize'
+                    $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
+                    InvokeNetboxRequest -URI $URI -Raw:$Raw
+                }
+            }
             default { $s = [System.Collections.ArrayList]::new(@('wireless','wireless-lan-groups')); $u = BuildURIComponents -URISegments $s.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'All', 'PageSize'; InvokeNetboxRequest -URI (BuildNewURI -Segments $u.Segments -Parameters $u.Parameters) -Raw:$Raw -All:$All -PageSize $PageSize }
         }
     }

--- a/Functions/Wireless/WirelessLink/Get-NBWirelessLink.ps1
+++ b/Functions/Wireless/WirelessLink/Get-NBWirelessLink.ps1
@@ -38,7 +38,14 @@ function Get-NBWirelessLink {
     process {
         Write-Verbose "Retrieving Wireless Link"
         switch ($PSCmdlet.ParameterSetName) {
-            'ByID' { foreach ($i in $Id) { InvokeNetboxRequest -URI (BuildNewURI -Segments @('wireless','wireless-links',$i)) -Raw:$Raw } }
+            'ByID' {
+                foreach ($i in $Id) {
+                    $Segments = [System.Collections.ArrayList]::new(@('wireless', 'wireless-links', $i))
+                    $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw', 'All', 'PageSize'
+                    $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
+                    InvokeNetboxRequest -URI $URI -Raw:$Raw
+                }
+            }
             default { $s = [System.Collections.ArrayList]::new(@('wireless','wireless-links')); $u = BuildURIComponents -URISegments $s.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'All', 'PageSize'; InvokeNetboxRequest -URI (BuildNewURI -Segments $u.Segments -Parameters $u.Parameters) -Raw:$Raw -All:$All -PageSize $PageSize }
         }
     }


### PR DESCRIPTION
## Summary
- Fixes ByID path in 18 Get functions that bypassed `BuildURIComponents`, silently ignoring `-Brief`, `-Fields`, and `-Omit` query parameters
- **VPN** (9): IKEPolicy, IKEProposal, IPSecPolicy, IPSecProfile, IPSecProposal, L2VPN, L2VPNTermination, TunnelGroup, TunnelTermination
- **Wireless** (3): WirelessLAN, WirelessLink, WirelessLANGroup
- **IPAM** (6): FHRPGroup, FHRPGroupAssignment, RIR, VLANGroup, VLANTranslationPolicy, VLANTranslationRule

Closes #300

## Test plan
- [x] All 216 VPN + Wireless + IPAM unit tests pass
- [x] Module builds successfully with `deploy.ps1`
- [ ] CI passes on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)