### PR TITLE
Code quality: OutputType, SkipParam, style, dead code

### DIFF
--- a/Functions/Circuits/CircuitGroupAssignments/Remove-NBCircuitGroupAssignment.ps1
+++ b/Functions/Circuits/CircuitGroupAssignments/Remove-NBCircuitGroupAssignment.ps1
@@ -19,7 +19,7 @@
 #>
 function Remove-NBCircuitGroupAssignment {
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param (
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
         [uint64]$Id,

--- a/Functions/Circuits/CircuitGroups/Remove-NBCircuitGroup.ps1
+++ b/Functions/Circuits/CircuitGroups/Remove-NBCircuitGroup.ps1
@@ -19,7 +19,7 @@
 #>
 function Remove-NBCircuitGroup {
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param (
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
         [uint64]$Id,

--- a/Functions/Circuits/Circuits/Get-NBCircuit.ps1
+++ b/Functions/Circuits/Circuits/Get-NBCircuit.ps1
@@ -124,7 +124,7 @@ function Get-NBCircuit {
                 foreach ($i in $ID) {
                     $Segments = [System.Collections.ArrayList]::new(@('circuits', 'circuits', $i))
 
-                    $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'All', 'PageSize'
+                    $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw', 'All', 'PageSize'
 
                     $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
 
@@ -135,7 +135,7 @@ function Get-NBCircuit {
             default {
                 $Segments = [System.Collections.ArrayList]::new(@('circuits', 'circuits'))
 
-                $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'All', 'PageSize'
+                $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'All', 'PageSize'
 
                 $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
 

--- a/Functions/Circuits/Circuits/New-NBCircuit.ps1
+++ b/Functions/Circuits/Circuits/New-NBCircuit.ps1
@@ -63,14 +63,13 @@ function New-NBCircuit {
     process {
         Write-Verbose "Creating Circuit"
         $Segments = [System.Collections.ArrayList]::new(@('circuits', 'circuits'))
-        $Method = 'POST'
 
         $URIComponents = BuildURIComponents -URISegments $Segments -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'Force'
 
         $URI = BuildNewURI -Segments $URIComponents.Segments
 
         if ($Force -or $PSCmdlet.ShouldProcess($CID, 'Create new circuit')) {
-            InvokeNetboxRequest -URI $URI -Method $Method -Body $URIComponents.Parameters -Raw:$Raw
+            InvokeNetboxRequest -URI $URI -Method POST -Body $URIComponents.Parameters -Raw:$Raw
         }
     }
 }

--- a/Functions/Circuits/Circuits/Remove-NBCircuit.ps1
+++ b/Functions/Circuits/Circuits/Remove-NBCircuit.ps1
@@ -22,7 +22,7 @@
 #>
 function Remove-NBCircuit {
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param (
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
         [uint64]$Id,

--- a/Functions/Circuits/ProviderAccounts/Remove-NBCircuitProviderAccount.ps1
+++ b/Functions/Circuits/ProviderAccounts/Remove-NBCircuitProviderAccount.ps1
@@ -19,7 +19,7 @@
 #>
 function Remove-NBCircuitProviderAccount {
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param (
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
         [uint64]$Id,

--- a/Functions/Circuits/ProviderNetworks/Remove-NBCircuitProviderNetwork.ps1
+++ b/Functions/Circuits/ProviderNetworks/Remove-NBCircuitProviderNetwork.ps1
@@ -19,7 +19,7 @@
 #>
 function Remove-NBCircuitProviderNetwork {
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param (
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
         [uint64]$Id,

--- a/Functions/Circuits/Providers/Get-NBCircuitProvider.ps1
+++ b/Functions/Circuits/Providers/Get-NBCircuitProvider.ps1
@@ -68,7 +68,7 @@ function Get-NBCircuitProvider {
             foreach ($i in $ID) {
                 $Segments = [System.Collections.ArrayList]::new(@('circuits', 'providers', $i))
 
-                $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'All', 'PageSize'
+                $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw', 'All', 'PageSize'
 
                 $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
 
@@ -79,7 +79,7 @@ function Get-NBCircuitProvider {
         default {
             $Segments = [System.Collections.ArrayList]::new(@('circuits', 'providers'))
 
-            $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'All', 'PageSize'
+            $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'All', 'PageSize'
 
             $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
 

--- a/Functions/Circuits/Providers/Remove-NBCircuitProvider.ps1
+++ b/Functions/Circuits/Providers/Remove-NBCircuitProvider.ps1
@@ -19,7 +19,7 @@
 #>
 function Remove-NBCircuitProvider {
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param (
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
         [uint64]$Id,

--- a/Functions/Circuits/Terminations/Get-NBCircuitTermination.ps1
+++ b/Functions/Circuits/Terminations/Get-NBCircuitTermination.ps1
@@ -72,7 +72,7 @@ function Get-NBCircuitTermination {
                 foreach ($i in $ID) {
                     $Segments = [System.Collections.ArrayList]::new(@('circuits', 'circuit-terminations', $i))
 
-                    $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'All', 'PageSize'
+                    $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw', 'All', 'PageSize'
 
                     $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
 
@@ -83,7 +83,7 @@ function Get-NBCircuitTermination {
             default {
                 $Segments = [System.Collections.ArrayList]::new(@('circuits', 'circuit-terminations'))
 
-                $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'All', 'PageSize'
+                $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'All', 'PageSize'
 
                 $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
 

--- a/Functions/Circuits/Terminations/Remove-NBCircuitTermination.ps1
+++ b/Functions/Circuits/Terminations/Remove-NBCircuitTermination.ps1
@@ -19,7 +19,7 @@
 #>
 function Remove-NBCircuitTermination {
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param (
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
         [uint64]$Id,

--- a/Functions/Circuits/Types/Get-NBCircuitType.ps1
+++ b/Functions/Circuits/Types/Get-NBCircuitType.ps1
@@ -59,7 +59,7 @@ function Get-NBCircuitType {
             foreach ($i in $ID) {
                 $Segments = [System.Collections.ArrayList]::new(@('circuits', 'circuit-types', $i))
 
-                $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'All', 'PageSize'
+                $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw', 'All', 'PageSize'
 
                 $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
 
@@ -70,7 +70,7 @@ function Get-NBCircuitType {
         default {
             $Segments = [System.Collections.ArrayList]::new(@('circuits', 'circuit-types'))
 
-            $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'All', 'PageSize'
+            $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'All', 'PageSize'
 
             $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
 

--- a/Functions/Circuits/Types/Remove-NBCircuitType.ps1
+++ b/Functions/Circuits/Types/Remove-NBCircuitType.ps1
@@ -19,7 +19,7 @@
 #>
 function Remove-NBCircuitType {
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param (
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
         [uint64]$Id,

--- a/Functions/Circuits/VirtualCircuitTerminations/Remove-NBVirtualCircuitTermination.ps1
+++ b/Functions/Circuits/VirtualCircuitTerminations/Remove-NBVirtualCircuitTermination.ps1
@@ -19,7 +19,7 @@
 #>
 function Remove-NBVirtualCircuitTermination {
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param (
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
         [uint64]$Id,

--- a/Functions/Circuits/VirtualCircuitTypes/Remove-NBVirtualCircuitType.ps1
+++ b/Functions/Circuits/VirtualCircuitTypes/Remove-NBVirtualCircuitType.ps1
@@ -19,7 +19,7 @@
 #>
 function Remove-NBVirtualCircuitType {
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param (
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
         [uint64]$Id,

--- a/Functions/Circuits/VirtualCircuits/Remove-NBVirtualCircuit.ps1
+++ b/Functions/Circuits/VirtualCircuits/Remove-NBVirtualCircuit.ps1
@@ -19,7 +19,7 @@
 #>
 function Remove-NBVirtualCircuit {
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param (
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
         [uint64]$Id,

--- a/Functions/Core/DataSources/Remove-NBDataSource.ps1
+++ b/Functions/Core/DataSources/Remove-NBDataSource.ps1
@@ -19,7 +19,7 @@
 #>
 function Remove-NBDataSource {
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param (
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
         [uint64]$Id,

--- a/Functions/DCIM/Cable Terminations/Get-NBDCIMCableTermination.ps1
+++ b/Functions/DCIM/Cable Terminations/Get-NBDCIMCableTermination.ps1
@@ -15,7 +15,7 @@
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>
 function Get-NBDCIMCableTermination {
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName = 'Query')]
     [OutputType([PSCustomObject])]
     #region Parameters
     param
@@ -41,12 +41,16 @@ function Get-NBDCIMCableTermination {
         [Parameter(ValueFromPipelineByPropertyName = $true)]
         [uint64[]]$Id,
 
+        [Parameter(ParameterSetName = 'Query')]
         [uint64]$Cable,
 
+        [Parameter(ParameterSetName = 'Query')]
         [string]$Cable_End,
 
+        [Parameter(ParameterSetName = 'Query')]
         [string]$Termination_Type,
 
+        [Parameter(ParameterSetName = 'Query')]
         [uint64]$Termination_ID,
 
         [switch]$Raw

--- a/Functions/DCIM/Cables/Remove-NBDCIMCable.ps1
+++ b/Functions/DCIM/Cables/Remove-NBDCIMCable.ps1
@@ -19,7 +19,7 @@
 #>
 function Remove-NBDCIMCable {
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param(
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)][uint64]$Id,
         [switch]$Raw

--- a/Functions/DCIM/ConnectedDevice/Get-NBDCIMConnectedDevice.ps1
+++ b/Functions/DCIM/ConnectedDevice/Get-NBDCIMConnectedDevice.ps1
@@ -15,7 +15,7 @@
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>
 function Get-NBDCIMConnectedDevice {
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName = 'Query')]
     [OutputType([PSCustomObject])]
     param(
         [switch]$All,
@@ -30,8 +30,8 @@ function Get-NBDCIMConnectedDevice {
 
         [string[]]$Omit,
 
-        [Parameter(Mandatory = $true)][string]$Peer_Device,
-        [Parameter(Mandatory = $true)][string]$Peer_Interface,
+        [Parameter(ParameterSetName = 'Query', Mandatory = $true)][string]$Peer_Device,
+        [Parameter(ParameterSetName = 'Query', Mandatory = $true)][string]$Peer_Interface,
         [switch]$Raw
     )
     process {

--- a/Functions/DCIM/ConsolePortTemplates/Remove-NBDCIMConsolePortTemplate.ps1
+++ b/Functions/DCIM/ConsolePortTemplates/Remove-NBDCIMConsolePortTemplate.ps1
@@ -19,7 +19,7 @@
 #>
 function Remove-NBDCIMConsolePortTemplate {
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param(
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)][uint64]$Id,
         [switch]$Raw

--- a/Functions/DCIM/ConsolePorts/Remove-NBDCIMConsolePort.ps1
+++ b/Functions/DCIM/ConsolePorts/Remove-NBDCIMConsolePort.ps1
@@ -19,7 +19,7 @@
 #>
 function Remove-NBDCIMConsolePort {
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param(
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)][uint64]$Id,
         [switch]$Raw

--- a/Functions/DCIM/ConsoleServerPortTemplates/Remove-NBDCIMConsoleServerPortTemplate.ps1
+++ b/Functions/DCIM/ConsoleServerPortTemplates/Remove-NBDCIMConsoleServerPortTemplate.ps1
@@ -19,7 +19,7 @@
 #>
 function Remove-NBDCIMConsoleServerPortTemplate {
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param(
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)][uint64]$Id,
         [switch]$Raw

--- a/Functions/DCIM/ConsoleServerPorts/Remove-NBDCIMConsoleServerPort.ps1
+++ b/Functions/DCIM/ConsoleServerPorts/Remove-NBDCIMConsoleServerPort.ps1
@@ -19,7 +19,7 @@
 #>
 function Remove-NBDCIMConsoleServerPort {
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param(
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)][uint64]$Id,
         [switch]$Raw

--- a/Functions/DCIM/DeviceBayTemplates/Remove-NBDCIMDeviceBayTemplate.ps1
+++ b/Functions/DCIM/DeviceBayTemplates/Remove-NBDCIMDeviceBayTemplate.ps1
@@ -19,7 +19,7 @@
 #>
 function Remove-NBDCIMDeviceBayTemplate {
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param(
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)][uint64]$Id,
         [switch]$Raw

--- a/Functions/DCIM/DeviceBays/Remove-NBDCIMDeviceBay.ps1
+++ b/Functions/DCIM/DeviceBays/Remove-NBDCIMDeviceBay.ps1
@@ -19,7 +19,7 @@
 #>
 function Remove-NBDCIMDeviceBay {
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param(
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)][uint64]$Id,
         [switch]$Raw

--- a/Functions/DCIM/Devices/Get-NBDCIMDeviceRole.ps1
+++ b/Functions/DCIM/Devices/Get-NBDCIMDeviceRole.ps1
@@ -15,7 +15,7 @@
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>
 function Get-NBDCIMDeviceRole {
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName = 'Query')]
     [OutputType([PSCustomObject])]
     param
     (
@@ -40,12 +40,16 @@ function Get-NBDCIMDeviceRole {
         [Parameter(ParameterSetName = 'ById', ValueFromPipelineByPropertyName = $true)]
         [uint64[]]$Id,
 
+        [Parameter(ParameterSetName = 'Query')]
         [string]$Name,
 
+        [Parameter(ParameterSetName = 'Query')]
         [string]$Slug,
 
+        [Parameter(ParameterSetName = 'Query')]
         [string]$Color,
 
+        [Parameter(ParameterSetName = 'Query')]
         [bool]$VM_Role,
 
         [switch]$Raw

--- a/Functions/DCIM/Devices/Remove-NBDCIMDeviceRole.ps1
+++ b/Functions/DCIM/Devices/Remove-NBDCIMDeviceRole.ps1
@@ -19,7 +19,7 @@
 #>
 function Remove-NBDCIMDeviceRole {
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param(
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)][uint64]$Id,
         [switch]$Raw

--- a/Functions/DCIM/Devices/Remove-NBDCIMDeviceType.ps1
+++ b/Functions/DCIM/Devices/Remove-NBDCIMDeviceType.ps1
@@ -19,7 +19,7 @@
 #>
 function Remove-NBDCIMDeviceType {
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param(
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)][uint64]$Id,
         [switch]$Raw

--- a/Functions/DCIM/Devices/Set-NBDCIMDevice.ps1
+++ b/Functions/DCIM/Devices/Set-NBDCIMDevice.ps1
@@ -234,14 +234,6 @@ function Set-NBDCIMDevice {
                     # Handle property name mappings
                     switch ($key) {
                         'device_role' { $key = 'role' }
-                        'device_type' { $key = 'device_type' }
-                        'asset_tag' { $key = 'asset_tag' }
-                        'virtual_chassis' { $key = 'virtual_chassis' }
-                        'vc_priority' { $key = 'vc_priority' }
-                        'vc_position' { $key = 'vc_position' }
-                        'primary_ip4' { $key = 'primary_ip4' }
-                        'primary_ip6' { $key = 'primary_ip6' }
-                        'custom_fields' { $key = 'custom_fields' }
                     }
 
                     $item[$key] = $value

--- a/Functions/DCIM/FrontPortTemplates/Remove-NBDCIMFrontPortTemplate.ps1
+++ b/Functions/DCIM/FrontPortTemplates/Remove-NBDCIMFrontPortTemplate.ps1
@@ -19,7 +19,7 @@
 #>
 function Remove-NBDCIMFrontPortTemplate {
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param(
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)][uint64]$Id,
         [switch]$Raw

--- a/Functions/DCIM/FrontPorts/Get-NBDCIMFrontPort.ps1
+++ b/Functions/DCIM/FrontPorts/Get-NBDCIMFrontPort.ps1
@@ -16,7 +16,7 @@
 #>
 function Get-NBDCIMFrontPort {
     [CmdletBinding(DefaultParameterSetName = 'Query')]
-    [OutputType([pscustomobject])]
+    [OutputType([PSCustomObject])]
     param
     (
         [switch]$All,
@@ -61,7 +61,7 @@ function Get-NBDCIMFrontPort {
             'ByID' { foreach ($i in $Id) { InvokeNetboxRequest -URI (BuildNewURI -Segments @('dcim', 'front-ports', $i)) -Raw:$Raw } }
             default {
                 $Segments = [System.Collections.ArrayList]::new(@('dcim', 'front-ports'))
-                $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'All', 'PageSize'
+                $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'All', 'PageSize'
                 $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
                 InvokeNetboxRequest -URI $URI -Raw:$Raw -All:$All -PageSize $PageSize
             }

--- a/Functions/DCIM/FrontPorts/Remove-NBDCIMFrontPort.ps1
+++ b/Functions/DCIM/FrontPorts/Remove-NBDCIMFrontPort.ps1
@@ -21,7 +21,7 @@ function Remove-NBDCIMFrontPort {
 
     [CmdletBinding(ConfirmImpact = 'High',
         SupportsShouldProcess = $true)]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param
     (
         [Parameter(Mandatory = $true,
@@ -36,7 +36,7 @@ function Remove-NBDCIMFrontPort {
     process {
         Write-Verbose "Removing DCIM Front Port"
         foreach ($FrontPortID in $Id) {
-            if ($Force -or $pscmdlet.ShouldProcess("Front Port ID $FrontPortID", "Remove")) {
+            if ($Force -or $PSCmdlet.ShouldProcess("Front Port ID $FrontPortID", "Remove")) {
                 $Segments = [System.Collections.ArrayList]::new(@('dcim', 'front-ports', $FrontPortID))
 
                 $URI = BuildNewURI -Segments $Segments

--- a/Functions/DCIM/FrontPorts/Set-NBDCIMFrontPort.ps1
+++ b/Functions/DCIM/FrontPorts/Set-NBDCIMFrontPort.ps1
@@ -76,7 +76,7 @@
 function Set-NBDCIMFrontPort {
     [CmdletBinding(ConfirmImpact = 'Medium',
         SupportsShouldProcess = $true)]
-    [OutputType([pscustomobject])]
+    [OutputType([PSCustomObject])]
     param
     (
         [Parameter(Mandatory = $true,
@@ -161,7 +161,7 @@ function Set-NBDCIMFrontPort {
             }
         }
 
-        if ($Force -or $pscmdlet.ShouldProcess("Front Port ID $Id", "Set")) {
+        if ($Force -or $PSCmdlet.ShouldProcess("Front Port ID $Id", "Set")) {
             InvokeNetboxRequest -URI $URI -Body $URIComponents.Parameters -Method PATCH -Raw:$Raw
         }
     }

--- a/Functions/DCIM/InterfaceTemplates/Remove-NBDCIMInterfaceTemplate.ps1
+++ b/Functions/DCIM/InterfaceTemplates/Remove-NBDCIMInterfaceTemplate.ps1
@@ -19,7 +19,7 @@
 #>
 function Remove-NBDCIMInterfaceTemplate {
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param(
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)][uint64]$Id,
         [switch]$Raw

--- a/Functions/DCIM/Interfaces/Get-NBDCIMInterface.ps1
+++ b/Functions/DCIM/Interfaces/Get-NBDCIMInterface.ps1
@@ -24,7 +24,7 @@
 #>
 function Get-NBDCIMInterface {
     [CmdletBinding(DefaultParameterSetName = 'Query')]
-    [OutputType([pscustomobject])]
+    [OutputType([PSCustomObject])]
     param
     (
         [switch]$All,
@@ -84,7 +84,7 @@ function Get-NBDCIMInterface {
             'ByID' { foreach ($i in $Id) { InvokeNetboxRequest -URI (BuildNewURI -Segments @('dcim', 'interfaces', $i)) -Raw:$Raw } }
             default {
                 $Segments = [System.Collections.ArrayList]::new(@('dcim', 'interfaces'))
-                $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'All', 'PageSize'
+                $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'All', 'PageSize'
                 $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
                 InvokeNetboxRequest -URI $URI -Raw:$Raw -All:$All -PageSize $PageSize
             }

--- a/Functions/DCIM/Interfaces/Get-NBDCIMInterfaceConnection.ps1
+++ b/Functions/DCIM/Interfaces/Get-NBDCIMInterfaceConnection.ps1
@@ -16,7 +16,7 @@
 #>
 function Get-NBDCIMInterfaceConnection {
     [CmdletBinding(DefaultParameterSetName = 'Query')]
-    [OutputType([pscustomobject])]
+    [OutputType([PSCustomObject])]
     param
     (
         [switch]$All,

--- a/Functions/DCIM/Interfaces/Remove-NBDCIMInterface.ps1
+++ b/Functions/DCIM/Interfaces/Remove-NBDCIMInterface.ps1
@@ -34,7 +34,7 @@ function Remove-NBDCIMInterface {
         Write-Verbose "Removing DCIM Interface"
         foreach ($InterfaceId in $Id) {
 
-            if ($Force -or $pscmdlet.ShouldProcess("Name: $("ID $InterfaceId") | ID: $($InterfaceId)", "Remove")) {
+            if ($Force -or $PSCmdlet.ShouldProcess("ID $InterfaceId", "Remove")) {
                 $Segments = [System.Collections.ArrayList]::new(@('dcim', 'interfaces', $InterfaceId))
 
                 $URI = BuildNewURI -Segments $Segments

--- a/Functions/DCIM/Interfaces/Remove-NBDCIMInterfaceConnection.ps1
+++ b/Functions/DCIM/Interfaces/Remove-NBDCIMInterfaceConnection.ps1
@@ -36,7 +36,7 @@ function Remove-NBDCIMInterfaceConnection {
     process {
         Write-Verbose "Removing DCIM Interface Connection"
         foreach ($ConnectionID in $Id) {
-            if ($Force -or $pscmdlet.ShouldProcess("Interface Connection ID $ConnectionID", "REMOVE")) {
+            if ($Force -or $PSCmdlet.ShouldProcess("Interface Connection ID $ConnectionID", "REMOVE")) {
                 $Segments = [System.Collections.ArrayList]::new(@('dcim', 'interface-connections', $ConnectionID))
 
                 $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Force'

--- a/Functions/DCIM/Interfaces/Set-NBDCIMInterface.ps1
+++ b/Functions/DCIM/Interfaces/Set-NBDCIMInterface.ps1
@@ -20,7 +20,7 @@
 function Set-NBDCIMInterface {
     [CmdletBinding(ConfirmImpact = 'Medium',
         SupportsShouldProcess = $true)]
-    [OutputType([pscustomobject])]
+    [OutputType([PSCustomObject])]
     param
     (
         [Parameter(Mandatory = $true,
@@ -95,7 +95,7 @@ function Set-NBDCIMInterface {
 
             $URI = BuildNewURI -Segments $Segments
 
-            if ($Force -or $pscmdlet.ShouldProcess("Interface ID $InterfaceId", "Set")) {
+            if ($Force -or $PSCmdlet.ShouldProcess("Interface ID $InterfaceId", "Set")) {
                 InvokeNetboxRequest -URI $URI -Body $URIComponents.Parameters -Method PATCH -Raw:$Raw
             }
         }

--- a/Functions/DCIM/Interfaces/Set-NBDCIMInterfaceConnection.ps1
+++ b/Functions/DCIM/Interfaces/Set-NBDCIMInterfaceConnection.ps1
@@ -58,7 +58,7 @@ function Set-NBDCIMInterfaceConnection {
         foreach ($ConnectionID in $Id) {
             $Segments = [System.Collections.ArrayList]::new(@('dcim', 'interface-connections', $ConnectionID))
 
-            if ($Force -or $pscmdlet.ShouldProcess("Interface Connection ID $ConnectionID", "Set")) {
+            if ($Force -or $PSCmdlet.ShouldProcess("Interface Connection ID $ConnectionID", "Set")) {
 
                 $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw', 'Force'
 

--- a/Functions/DCIM/InventoryItemRoles/Remove-NBDCIMInventoryItemRole.ps1
+++ b/Functions/DCIM/InventoryItemRoles/Remove-NBDCIMInventoryItemRole.ps1
@@ -19,7 +19,7 @@
 #>
 function Remove-NBDCIMInventoryItemRole {
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param(
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)][uint64]$Id,
         [switch]$Raw

--- a/Functions/DCIM/InventoryItemTemplates/Remove-NBDCIMInventoryItemTemplate.ps1
+++ b/Functions/DCIM/InventoryItemTemplates/Remove-NBDCIMInventoryItemTemplate.ps1
@@ -19,7 +19,7 @@
 #>
 function Remove-NBDCIMInventoryItemTemplate {
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param(
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)][uint64]$Id,
         [switch]$Raw

--- a/Functions/DCIM/InventoryItems/Remove-NBDCIMInventoryItem.ps1
+++ b/Functions/DCIM/InventoryItems/Remove-NBDCIMInventoryItem.ps1
@@ -19,7 +19,7 @@
 #>
 function Remove-NBDCIMInventoryItem {
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param(
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)][uint64]$Id,
         [switch]$Raw

--- a/Functions/DCIM/Locations/Remove-NBDCIMLocation.ps1
+++ b/Functions/DCIM/Locations/Remove-NBDCIMLocation.ps1
@@ -24,7 +24,7 @@ function Remove-NBDCIMLocation {
 #>
 
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param
     (
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]

--- a/Functions/DCIM/MACAddresses/Remove-NBDCIMMACAddress.ps1
+++ b/Functions/DCIM/MACAddresses/Remove-NBDCIMMACAddress.ps1
@@ -19,7 +19,7 @@
 #>
 function Remove-NBDCIMMACAddress {
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param(
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)][uint64]$Id,
         [switch]$Raw

--- a/Functions/DCIM/Manufacturers/Remove-NBDCIMManufacturer.ps1
+++ b/Functions/DCIM/Manufacturers/Remove-NBDCIMManufacturer.ps1
@@ -48,7 +48,7 @@ function Remove-NBDCIMManufacturer {
         Write-Verbose "Removing DCIM Manufacturer"
         foreach ($ManufacturerId in $Id) {
 
-            if ($Force -or $PSCmdlet.ShouldProcess("$("ID $ManufacturerId")", "Delete manufacturer")) {
+            if ($Force -or $PSCmdlet.ShouldProcess("ID $ManufacturerId", "Delete manufacturer")) {
                 $Segments = [System.Collections.ArrayList]::new(@('dcim', 'manufacturers', $ManufacturerId))
 
                 $URI = BuildNewURI -Segments $Segments

--- a/Functions/DCIM/Manufacturers/Set-NBDCIMManufacturer.ps1
+++ b/Functions/DCIM/Manufacturers/Set-NBDCIMManufacturer.ps1
@@ -56,7 +56,7 @@ function Set-NBDCIMManufacturer {
         Write-Verbose "Updating DCIM Manufacturer"
         foreach ($ManufacturerId in $Id) {
 
-            if ($Force -or $PSCmdlet.ShouldProcess("$("ID $ManufacturerId")", "Update manufacturer")) {
+            if ($Force -or $PSCmdlet.ShouldProcess("ID $ManufacturerId", "Update manufacturer")) {
                 $Segments = [System.Collections.ArrayList]::new(@('dcim', 'manufacturers', $ManufacturerId))
 
                 $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw', 'Force'

--- a/Functions/DCIM/ModuleBayTemplates/Remove-NBDCIMModuleBayTemplate.ps1
+++ b/Functions/DCIM/ModuleBayTemplates/Remove-NBDCIMModuleBayTemplate.ps1
@@ -19,7 +19,7 @@
 #>
 function Remove-NBDCIMModuleBayTemplate {
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param(
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)][uint64]$Id,
         [switch]$Raw

--- a/Functions/DCIM/ModuleBays/Remove-NBDCIMModuleBay.ps1
+++ b/Functions/DCIM/ModuleBays/Remove-NBDCIMModuleBay.ps1
@@ -19,7 +19,7 @@
 #>
 function Remove-NBDCIMModuleBay {
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param(
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)][uint64]$Id,
         [switch]$Raw

--- a/Functions/DCIM/ModuleTypeProfiles/Remove-NBDCIMModuleTypeProfile.ps1
+++ b/Functions/DCIM/ModuleTypeProfiles/Remove-NBDCIMModuleTypeProfile.ps1
@@ -19,7 +19,7 @@
 #>
 function Remove-NBDCIMModuleTypeProfile {
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param(
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)][uint64]$Id,
         [switch]$Raw

--- a/Functions/DCIM/ModuleTypes/Remove-NBDCIMModuleType.ps1
+++ b/Functions/DCIM/ModuleTypes/Remove-NBDCIMModuleType.ps1
@@ -19,7 +19,7 @@
 #>
 function Remove-NBDCIMModuleType {
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param(
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)][uint64]$Id,
         [switch]$Raw

--- a/Functions/DCIM/Modules/Remove-NBDCIMModule.ps1
+++ b/Functions/DCIM/Modules/Remove-NBDCIMModule.ps1
@@ -19,7 +19,7 @@
 #>
 function Remove-NBDCIMModule {
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param(
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)][uint64]$Id,
         [switch]$Raw

--- a/Functions/DCIM/Platforms/Get-NBDCIMPlatform.ps1
+++ b/Functions/DCIM/Platforms/Get-NBDCIMPlatform.ps1
@@ -15,8 +15,8 @@
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>
 function Get-NBDCIMPlatform {
-    [CmdletBinding()]
-    [OutputType([pscustomobject])]
+    [CmdletBinding(DefaultParameterSetName = 'Query')]
+    [OutputType([PSCustomObject])]
     param
     (
         [switch]$All,
@@ -40,12 +40,16 @@ function Get-NBDCIMPlatform {
         [Parameter(ParameterSetName = 'ById', ValueFromPipelineByPropertyName = $true)]
         [uint64[]]$Id,
 
+        [Parameter(ParameterSetName = 'Query')]
         [string]$Name,
 
+        [Parameter(ParameterSetName = 'Query')]
         [string]$Slug,
 
+        [Parameter(ParameterSetName = 'Query')]
         [uint64]$Manufacturer_Id,
 
+        [Parameter(ParameterSetName = 'Query')]
         [string]$Manufacturer,
 
         [switch]$Raw

--- a/Functions/DCIM/Platforms/Remove-NBDCIMPlatform.ps1
+++ b/Functions/DCIM/Platforms/Remove-NBDCIMPlatform.ps1
@@ -19,7 +19,7 @@
 #>
 function Remove-NBDCIMPlatform {
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param(
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)][uint64]$Id,
         [switch]$Raw

--- a/Functions/DCIM/PowerFeeds/Remove-NBDCIMPowerFeed.ps1
+++ b/Functions/DCIM/PowerFeeds/Remove-NBDCIMPowerFeed.ps1
@@ -19,7 +19,7 @@
 #>
 function Remove-NBDCIMPowerFeed {
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param(
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)][uint64]$Id,
         [switch]$Raw

--- a/Functions/DCIM/PowerOutletTemplates/Remove-NBDCIMPowerOutletTemplate.ps1
+++ b/Functions/DCIM/PowerOutletTemplates/Remove-NBDCIMPowerOutletTemplate.ps1
@@ -19,7 +19,7 @@
 #>
 function Remove-NBDCIMPowerOutletTemplate {
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param(
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)][uint64]$Id,
         [switch]$Raw

--- a/Functions/DCIM/PowerOutlets/Remove-NBDCIMPowerOutlet.ps1
+++ b/Functions/DCIM/PowerOutlets/Remove-NBDCIMPowerOutlet.ps1
@@ -19,7 +19,7 @@
 #>
 function Remove-NBDCIMPowerOutlet {
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param(
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)][uint64]$Id,
         [switch]$Raw

--- a/Functions/DCIM/PowerPanels/Remove-NBDCIMPowerPanel.ps1
+++ b/Functions/DCIM/PowerPanels/Remove-NBDCIMPowerPanel.ps1
@@ -19,7 +19,7 @@
 #>
 function Remove-NBDCIMPowerPanel {
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param(
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)][uint64]$Id,
         [switch]$Raw

--- a/Functions/DCIM/PowerPortTemplates/Remove-NBDCIMPowerPortTemplate.ps1
+++ b/Functions/DCIM/PowerPortTemplates/Remove-NBDCIMPowerPortTemplate.ps1
@@ -19,7 +19,7 @@
 #>
 function Remove-NBDCIMPowerPortTemplate {
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param(
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)][uint64]$Id,
         [switch]$Raw

--- a/Functions/DCIM/PowerPorts/Remove-NBDCIMPowerPort.ps1
+++ b/Functions/DCIM/PowerPorts/Remove-NBDCIMPowerPort.ps1
@@ -19,7 +19,7 @@
 #>
 function Remove-NBDCIMPowerPort {
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param(
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)][uint64]$Id,
         [switch]$Raw

--- a/Functions/DCIM/RackReservations/Remove-NBDCIMRackReservation.ps1
+++ b/Functions/DCIM/RackReservations/Remove-NBDCIMRackReservation.ps1
@@ -19,7 +19,7 @@
 #>
 function Remove-NBDCIMRackReservation {
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param(
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)][uint64]$Id,
         [switch]$Raw

--- a/Functions/DCIM/RackRoles/Remove-NBDCIMRackRole.ps1
+++ b/Functions/DCIM/RackRoles/Remove-NBDCIMRackRole.ps1
@@ -19,7 +19,7 @@
 #>
 function Remove-NBDCIMRackRole {
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param(
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)][uint64]$Id,
         [switch]$Raw

--- a/Functions/DCIM/RackTypes/Remove-NBDCIMRackType.ps1
+++ b/Functions/DCIM/RackTypes/Remove-NBDCIMRackType.ps1
@@ -19,7 +19,7 @@
 #>
 function Remove-NBDCIMRackType {
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param(
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)][uint64]$Id,
         [switch]$Raw

--- a/Functions/DCIM/Racks/Get-NBDCIMRackElevation.ps1
+++ b/Functions/DCIM/Racks/Get-NBDCIMRackElevation.ps1
@@ -65,7 +65,7 @@ function Get-NBDCIMRackElevation {
         https://netbox.readthedocs.io/en/stable/models/dcim/rack/
 #>
 
-    [CmdletBinding()]
+    [CmdletBinding(DefaultParameterSetName = 'Query')]
     [OutputType([PSCustomObject], [string])]
     param
     (

--- a/Functions/DCIM/Racks/Remove-NBDCIMRack.ps1
+++ b/Functions/DCIM/Racks/Remove-NBDCIMRack.ps1
@@ -48,7 +48,7 @@ function Remove-NBDCIMRack {
         Write-Verbose "Removing DCIM Rack"
         foreach ($RackId in $Id) {
 
-            if ($Force -or $PSCmdlet.ShouldProcess("$("ID $RackId")", "Delete rack")) {
+            if ($Force -or $PSCmdlet.ShouldProcess("ID $RackId", "Delete rack")) {
                 $Segments = [System.Collections.ArrayList]::new(@('dcim', 'racks', $RackId))
 
                 $URI = BuildNewURI -Segments $Segments

--- a/Functions/DCIM/Racks/Set-NBDCIMRack.ps1
+++ b/Functions/DCIM/Racks/Set-NBDCIMRack.ps1
@@ -161,7 +161,7 @@ function Set-NBDCIMRack {
         Write-Verbose "Updating DCIM Rack"
         foreach ($RackId in $Id) {
 
-            if ($Force -or $PSCmdlet.ShouldProcess("$("ID $RackId")", "Update rack")) {
+            if ($Force -or $PSCmdlet.ShouldProcess("ID $RackId", "Update rack")) {
                 $Segments = [System.Collections.ArrayList]::new(@('dcim', 'racks', $RackId))
 
                 $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw', 'Force'

--- a/Functions/DCIM/RearPortTemplates/Remove-NBDCIMRearPortTemplate.ps1
+++ b/Functions/DCIM/RearPortTemplates/Remove-NBDCIMRearPortTemplate.ps1
@@ -19,7 +19,7 @@
 #>
 function Remove-NBDCIMRearPortTemplate {
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param(
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)][uint64]$Id,
         [switch]$Raw

--- a/Functions/DCIM/RearPorts/Get-NBDCIMRearPort.ps1
+++ b/Functions/DCIM/RearPorts/Get-NBDCIMRearPort.ps1
@@ -16,7 +16,7 @@
 #>
 function Get-NBDCIMRearPort {
     [CmdletBinding(DefaultParameterSetName = 'Query')]
-    [OutputType([pscustomobject])]
+    [OutputType([PSCustomObject])]
     param
     (
         [switch]$All,
@@ -61,7 +61,7 @@ function Get-NBDCIMRearPort {
             'ByID' { foreach ($i in $Id) { InvokeNetboxRequest -URI (BuildNewURI -Segments @('dcim', 'rear-ports', $i)) -Raw:$Raw } }
             default {
                 $Segments = [System.Collections.ArrayList]::new(@('dcim', 'rear-ports'))
-                $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'All', 'PageSize'
+                $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'All', 'PageSize'
                 $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
                 InvokeNetboxRequest -URI $URI -Raw:$Raw -All:$All -PageSize $PageSize
             }

--- a/Functions/DCIM/RearPorts/Remove-NBDCIMRearPort.ps1
+++ b/Functions/DCIM/RearPorts/Remove-NBDCIMRearPort.ps1
@@ -21,7 +21,7 @@ function Remove-NBDCIMRearPort {
 
     [CmdletBinding(ConfirmImpact = 'High',
         SupportsShouldProcess = $true)]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param
     (
         [Parameter(Mandatory = $true,
@@ -36,7 +36,7 @@ function Remove-NBDCIMRearPort {
     process {
         Write-Verbose "Removing DCIM Rear Port"
         foreach ($RearPortID in $Id) {
-            if ($Force -or $pscmdlet.ShouldProcess("Rear Port ID $RearPortID", "Remove")) {
+            if ($Force -or $PSCmdlet.ShouldProcess("Rear Port ID $RearPortID", "Remove")) {
                 $Segments = [System.Collections.ArrayList]::new(@('dcim', 'rear-ports', $RearPortID))
 
                 $URI = BuildNewURI -Segments $Segments

--- a/Functions/DCIM/RearPorts/Set-NBDCIMRearPort.ps1
+++ b/Functions/DCIM/RearPorts/Set-NBDCIMRearPort.ps1
@@ -71,7 +71,7 @@
 function Set-NBDCIMRearPort {
     [CmdletBinding(ConfirmImpact = 'Medium',
         SupportsShouldProcess = $true)]
-    [OutputType([pscustomobject])]
+    [OutputType([PSCustomObject])]
     param
     (
         [Parameter(Mandatory = $true,
@@ -134,7 +134,7 @@ function Set-NBDCIMRearPort {
                 $URIComponents.Parameters['front_ports'] = $Front_Ports
             }
 
-            if ($Force -or $pscmdlet.ShouldProcess("Rear Port ID $RearPortID", "Set")) {
+            if ($Force -or $PSCmdlet.ShouldProcess("Rear Port ID $RearPortID", "Set")) {
                 InvokeNetboxRequest -URI $URI -Body $URIComponents.Parameters -Method PATCH -Raw:$Raw
             }
         }

--- a/Functions/DCIM/Regions/Remove-NBDCIMRegion.ps1
+++ b/Functions/DCIM/Regions/Remove-NBDCIMRegion.ps1
@@ -24,7 +24,7 @@ function Remove-NBDCIMRegion {
 #>
 
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param
     (
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]

--- a/Functions/DCIM/SiteGroups/Remove-NBDCIMSiteGroup.ps1
+++ b/Functions/DCIM/SiteGroups/Remove-NBDCIMSiteGroup.ps1
@@ -24,7 +24,7 @@ function Remove-NBDCIMSiteGroup {
 #>
 
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param
     (
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]

--- a/Functions/DCIM/Sites/Get-NBDCIMSite.ps1
+++ b/Functions/DCIM/Sites/Get-NBDCIMSite.ps1
@@ -16,7 +16,7 @@
 #>
 function Get-NBDCIMSite {
     [CmdletBinding(DefaultParameterSetName = 'Query')]
-    [OutputType([pscustomobject])]
+    [OutputType([PSCustomObject])]
     param
     (
         [switch]$All,
@@ -101,7 +101,7 @@ function Get-NBDCIMSite {
                 foreach ($Site_ID in $ID) {
                     $Segments = [System.Collections.ArrayList]::new(@('dcim', 'sites', $Site_Id))
 
-                    $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'All', 'PageSize'
+                    $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw', 'All', 'PageSize'
 
                     $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
 
@@ -112,7 +112,7 @@ function Get-NBDCIMSite {
             default {
                 $Segments = [System.Collections.ArrayList]::new(@('dcim', 'sites'))
 
-                $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'All', 'PageSize'
+                $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'All', 'PageSize'
 
                 $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
 

--- a/Functions/DCIM/Sites/New-NBDCIMSite.ps1
+++ b/Functions/DCIM/Sites/New-NBDCIMSite.ps1
@@ -30,7 +30,7 @@ function New-NBDCIMSite {
 
     [CmdletBinding(ConfirmImpact = 'Low',
         SupportsShouldProcess = $true)]
-    [OutputType([pscustomobject])]
+    [OutputType([PSCustomObject])]
     param
     (
         [Parameter(Mandatory = $true)]
@@ -73,7 +73,6 @@ function New-NBDCIMSite {
     process {
         Write-Verbose "Creating DCIM Site"
         $Segments = [System.Collections.ArrayList]::new(@('dcim', 'sites'))
-        $Method = 'POST'
 
         if (-not $PSBoundParameters.ContainsKey('slug')) {
             $PSBoundParameters.Add('slug', $name)
@@ -84,7 +83,7 @@ function New-NBDCIMSite {
         $URI = BuildNewURI -Segments $URIComponents.Segments
 
         if ($PSCmdlet.ShouldProcess($name, 'Create new Site')) {
-            InvokeNetboxRequest -URI $URI -Method $Method -Body $URIComponents.Parameters -Raw:$Raw
+            InvokeNetboxRequest -URI $URI -Method POST -Body $URIComponents.Parameters -Raw:$Raw
         }
     }
 }

--- a/Functions/DCIM/Sites/Remove-NBDCIMSite.ps1
+++ b/Functions/DCIM/Sites/Remove-NBDCIMSite.ps1
@@ -32,7 +32,7 @@ function Remove-NBDCIMSite {
     process {
         Write-Verbose "Removing DCIM Site"
 
-        if ($pscmdlet.ShouldProcess("ID $Id", "Remove Site")) {
+        if ($PSCmdlet.ShouldProcess("ID $Id", "Remove Site")) {
             $Segments = [System.Collections.ArrayList]::new(@('dcim', 'sites', $Id))
 
             $URI = BuildNewURI -Segments $Segments

--- a/Functions/DCIM/VirtualChassis/Remove-NBDCIMVirtualChassis.ps1
+++ b/Functions/DCIM/VirtualChassis/Remove-NBDCIMVirtualChassis.ps1
@@ -19,7 +19,7 @@
 #>
 function Remove-NBDCIMVirtualChassis {
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param(
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)][uint64]$Id,
         [switch]$Raw

--- a/Functions/DCIM/VirtualDeviceContexts/Remove-NBDCIMVirtualDeviceContext.ps1
+++ b/Functions/DCIM/VirtualDeviceContexts/Remove-NBDCIMVirtualDeviceContext.ps1
@@ -19,7 +19,7 @@
 #>
 function Remove-NBDCIMVirtualDeviceContext {
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param(
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)][uint64]$Id,
         [switch]$Raw

--- a/Functions/Extras/Bookmarks/Remove-NBBookmark.ps1
+++ b/Functions/Extras/Bookmarks/Remove-NBBookmark.ps1
@@ -19,7 +19,7 @@
 #>
 function Remove-NBBookmark {
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param (
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
         [uint64]$Id,

--- a/Functions/Extras/ConfigContexts/Remove-NBConfigContext.ps1
+++ b/Functions/Extras/ConfigContexts/Remove-NBConfigContext.ps1
@@ -19,7 +19,7 @@
 #>
 function Remove-NBConfigContext {
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param (
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
         [uint64]$Id,

--- a/Functions/Extras/CustomFieldChoiceSets/Remove-NBCustomFieldChoiceSet.ps1
+++ b/Functions/Extras/CustomFieldChoiceSets/Remove-NBCustomFieldChoiceSet.ps1
@@ -19,7 +19,7 @@
 #>
 function Remove-NBCustomFieldChoiceSet {
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param (
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
         [uint64]$Id,

--- a/Functions/Extras/CustomFields/Remove-NBCustomField.ps1
+++ b/Functions/Extras/CustomFields/Remove-NBCustomField.ps1
@@ -19,7 +19,7 @@
 #>
 function Remove-NBCustomField {
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param (
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
         [uint64]$Id,

--- a/Functions/Extras/CustomLinks/Remove-NBCustomLink.ps1
+++ b/Functions/Extras/CustomLinks/Remove-NBCustomLink.ps1
@@ -19,7 +19,7 @@
 #>
 function Remove-NBCustomLink {
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param (
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
         [uint64]$Id,

--- a/Functions/Extras/EventRules/Remove-NBEventRule.ps1
+++ b/Functions/Extras/EventRules/Remove-NBEventRule.ps1
@@ -19,7 +19,7 @@
 #>
 function Remove-NBEventRule {
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param (
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
         [uint64]$Id,

--- a/Functions/Extras/ExportTemplates/Remove-NBExportTemplate.ps1
+++ b/Functions/Extras/ExportTemplates/Remove-NBExportTemplate.ps1
@@ -19,7 +19,7 @@
 #>
 function Remove-NBExportTemplate {
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param (
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
         [uint64]$Id,

--- a/Functions/Extras/ImageAttachments/New-NBImageAttachment.ps1
+++ b/Functions/Extras/ImageAttachments/New-NBImageAttachment.ps1
@@ -110,11 +110,7 @@ function New-NBImageAttachment {
 
                 try {
                     $Response = Invoke-RestMethod -Uri $URI -Method POST -Form $Form -Headers $Headers @InvokeParams
-                    if ($Raw) {
-                        $Response
-                    } else {
-                        $Response
-                    }
+                    $Response
                 }
                 catch {
                     $ErrorBody = (GetNetboxAPIErrorBody -Response $_.Exception.Response).Body
@@ -192,11 +188,7 @@ function New-NBImageAttachment {
 
                     if ($HttpResponse.IsSuccessStatusCode) {
                         $Result = $ResponseContent | ConvertFrom-Json
-                        if ($Raw) {
-                            $Result
-                        } else {
-                            $Result
-                        }
+                        $Result
                     }
                     else {
                         throw "HTTP $([int]$HttpResponse.StatusCode): $ResponseContent"

--- a/Functions/Extras/ImageAttachments/Remove-NBImageAttachment.ps1
+++ b/Functions/Extras/ImageAttachments/Remove-NBImageAttachment.ps1
@@ -19,7 +19,7 @@
 #>
 function Remove-NBImageAttachment {
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param (
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
         [uint64]$Id,

--- a/Functions/Extras/JournalEntries/Remove-NBJournalEntry.ps1
+++ b/Functions/Extras/JournalEntries/Remove-NBJournalEntry.ps1
@@ -19,7 +19,7 @@
 #>
 function Remove-NBJournalEntry {
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param (
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
         [uint64]$Id,

--- a/Functions/Extras/SavedFilters/Remove-NBSavedFilter.ps1
+++ b/Functions/Extras/SavedFilters/Remove-NBSavedFilter.ps1
@@ -19,7 +19,7 @@
 #>
 function Remove-NBSavedFilter {
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param (
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
         [uint64]$Id,

--- a/Functions/Extras/Tags/Get-NBTag.ps1
+++ b/Functions/Extras/Tags/Get-NBTag.ps1
@@ -55,7 +55,7 @@ function Get-NBTag {
             'ByID' { foreach ($i in $Id) { InvokeNetboxRequest -URI (BuildNewURI -Segments @('extras', 'tags', $i)) -Raw:$Raw } }
             default {
                 $Segments = [System.Collections.ArrayList]::new(@('extras', 'tags'))
-                $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'All', 'PageSize'
+                $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'All', 'PageSize'
                 $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
                 InvokeNetboxRequest -URI $URI -Raw:$Raw -All:$All -PageSize $PageSize
             }

--- a/Functions/Extras/Tags/Remove-NBTag.ps1
+++ b/Functions/Extras/Tags/Remove-NBTag.ps1
@@ -19,7 +19,7 @@
 #>
 function Remove-NBTag {
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param (
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
         [uint64]$Id,

--- a/Functions/Extras/Webhooks/Remove-NBWebhook.ps1
+++ b/Functions/Extras/Webhooks/Remove-NBWebhook.ps1
@@ -19,7 +19,7 @@
 #>
 function Remove-NBWebhook {
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param (
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
         [uint64]$Id,

--- a/Functions/IPAM/ASN/Remove-NBIPAMASN.ps1
+++ b/Functions/IPAM/ASN/Remove-NBIPAMASN.ps1
@@ -19,7 +19,7 @@ function Remove-NBIPAMASN {
 #>
 
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param
     (
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]

--- a/Functions/IPAM/ASNRange/Remove-NBIPAMASNRange.ps1
+++ b/Functions/IPAM/ASNRange/Remove-NBIPAMASNRange.ps1
@@ -19,7 +19,7 @@ function Remove-NBIPAMASNRange {
 #>
 
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param
     (
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]

--- a/Functions/IPAM/Address/Get-NBIPAMAddress.ps1
+++ b/Functions/IPAM/Address/Get-NBIPAMAddress.ps1
@@ -109,7 +109,7 @@ function Get-NBIPAMAddress {
             foreach ($IP_ID in $Id) {
                 $Segments = [System.Collections.ArrayList]::new(@('ipam', 'ip-addresses', $IP_ID))
 
-                $URIComponents = BuildURIComponents -URISegments $Segments -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'All', 'PageSize'
+                $URIComponents = BuildURIComponents -URISegments $Segments -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw', 'All', 'PageSize'
 
                 $uri = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
 
@@ -122,7 +122,7 @@ function Get-NBIPAMAddress {
         default {
             $Segments = [System.Collections.ArrayList]::new(@('ipam', 'ip-addresses'))
 
-            $URIComponents = BuildURIComponents -URISegments $Segments -ParametersDictionary $PSBoundParameters -SkipParameterByName 'All', 'PageSize'
+            $URIComponents = BuildURIComponents -URISegments $Segments -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'All', 'PageSize'
 
             $uri = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
 

--- a/Functions/IPAM/Address/Get-NBIPAMAvailableIP.ps1
+++ b/Functions/IPAM/Address/Get-NBIPAMAvailableIP.ps1
@@ -63,7 +63,7 @@ function Get-NBIPAMAvailableIP {
         Write-Verbose "Retrieving IPAM Available IP"
         $Segments = [System.Collections.ArrayList]::new(@('ipam', 'prefixes', $Prefix_ID, 'available-ips'))
 
-        $URIComponents = BuildURIComponents -URISegments $Segments -ParametersDictionary $PSBoundParameters -SkipParameterByName 'prefix_id', 'All', 'PageSize'
+        $URIComponents = BuildURIComponents -URISegments $Segments -ParametersDictionary $PSBoundParameters -SkipParameterByName 'prefix_id', 'Raw', 'All', 'PageSize'
 
         $uri = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
 

--- a/Functions/IPAM/Address/New-NBIPAMAddress.ps1
+++ b/Functions/IPAM/Address/New-NBIPAMAddress.ps1
@@ -184,15 +184,6 @@ function New-NBIPAMAddress {
                     $key = $prop.Name.ToLower()
                     $value = $prop.Value
 
-                    # Handle property name mappings
-                    switch ($key) {
-                        'nat_inside' { $key = 'nat_inside' }
-                        'custom_fields' { $key = 'custom_fields' }
-                        'dns_name' { $key = 'dns_name' }
-                        'assigned_object_type' { $key = 'assigned_object_type' }
-                        'assigned_object_id' { $key = 'assigned_object_id' }
-                    }
-
                     $item[$key] = $value
                 }
 

--- a/Functions/IPAM/Address/Set-NBIPAMAddress.ps1
+++ b/Functions/IPAM/Address/Set-NBIPAMAddress.ps1
@@ -202,15 +202,6 @@ function Set-NBIPAMAddress {
                     $key = $prop.Name.ToLower()
                     $value = $prop.Value
 
-                    # Handle property name mappings
-                    switch ($key) {
-                        'nat_inside' { $key = 'nat_inside' }
-                        'custom_fields' { $key = 'custom_fields' }
-                        'assigned_object_type' { $key = 'assigned_object_type' }
-                        'assigned_object_id' { $key = 'assigned_object_id' }
-                        'dns_name' { $key = 'dns_name' }
-                    }
-
                     $item[$key] = $value
                 }
                 [void]$bulkItems.Add([PSCustomObject]$item)

--- a/Functions/IPAM/Aggregate/Get-NBIPAMAggregate.ps1
+++ b/Functions/IPAM/Aggregate/Get-NBIPAMAggregate.ps1
@@ -70,7 +70,7 @@ process {
             foreach ($IP_ID in $Id) {
                 $Segments = [System.Collections.ArrayList]::new(@('ipam', 'aggregates', $IP_ID))
 
-                $URIComponents = BuildURIComponents -URISegments $Segments -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'All', 'PageSize'
+                $URIComponents = BuildURIComponents -URISegments $Segments -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw', 'All', 'PageSize'
 
                 $uri = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
 
@@ -82,7 +82,7 @@ process {
         default {
             $Segments = [System.Collections.ArrayList]::new(@('ipam', 'aggregates'))
 
-            $URIComponents = BuildURIComponents -URISegments $Segments -ParametersDictionary $PSBoundParameters -SkipParameterByName 'All', 'PageSize'
+            $URIComponents = BuildURIComponents -URISegments $Segments -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'All', 'PageSize'
 
             $uri = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
 

--- a/Functions/IPAM/Aggregate/Remove-NBIPAMAggregate.ps1
+++ b/Functions/IPAM/Aggregate/Remove-NBIPAMAggregate.ps1
@@ -19,7 +19,7 @@
 #>
 function Remove-NBIPAMAggregate {
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param(
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)][uint64]$Id,
         [switch]$Raw

--- a/Functions/IPAM/FHRPGroup/Remove-NBIPAMFHRPGroup.ps1
+++ b/Functions/IPAM/FHRPGroup/Remove-NBIPAMFHRPGroup.ps1
@@ -19,7 +19,7 @@
 #>
 function Remove-NBIPAMFHRPGroup {
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param(
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)][uint64]$Id,
         [switch]$Raw

--- a/Functions/IPAM/FHRPGroupAssignment/Remove-NBIPAMFHRPGroupAssignment.ps1
+++ b/Functions/IPAM/FHRPGroupAssignment/Remove-NBIPAMFHRPGroupAssignment.ps1
@@ -19,7 +19,7 @@
 #>
 function Remove-NBIPAMFHRPGroupAssignment {
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param(
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)][uint64]$Id,
         [switch]$Raw

--- a/Functions/IPAM/Prefix/Get-NBIPAMPrefix.ps1
+++ b/Functions/IPAM/Prefix/Get-NBIPAMPrefix.ps1
@@ -183,7 +183,7 @@ function Get-NBIPAMPrefix {
             foreach ($Prefix_ID in $Id) {
                 $Segments = [System.Collections.ArrayList]::new(@('ipam', 'prefixes', $Prefix_ID))
 
-                $URIComponents = BuildURIComponents -URISegments $Segments -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'All', 'PageSize'
+                $URIComponents = BuildURIComponents -URISegments $Segments -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw', 'All', 'PageSize'
 
                 $uri = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
 
@@ -196,7 +196,7 @@ function Get-NBIPAMPrefix {
         default {
             $Segments = [System.Collections.ArrayList]::new(@('ipam', 'prefixes'))
 
-            $URIComponents = BuildURIComponents -URISegments $Segments -ParametersDictionary $PSBoundParameters -SkipParameterByName 'All', 'PageSize'
+            $URIComponents = BuildURIComponents -URISegments $Segments -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'All', 'PageSize'
 
             $uri = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
 

--- a/Functions/IPAM/Prefix/New-NBIPAMPrefix.ps1
+++ b/Functions/IPAM/Prefix/New-NBIPAMPrefix.ps1
@@ -165,7 +165,6 @@ function New-NBIPAMPrefix {
                     # Handle property name mappings
                     switch ($key) {
                         'ispool' { $key = 'is_pool' }
-                        'custom_fields' { $key = 'custom_fields' }
                     }
 
                     $item[$key] = $value

--- a/Functions/IPAM/Prefix/Remove-NBIPAMPrefix.ps1
+++ b/Functions/IPAM/Prefix/Remove-NBIPAMPrefix.ps1
@@ -19,7 +19,7 @@
 #>
 function Remove-NBIPAMPrefix {
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param(
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)][uint64]$Id,
         [switch]$Raw

--- a/Functions/IPAM/Prefix/Set-NBIPAMPrefix.ps1
+++ b/Functions/IPAM/Prefix/Set-NBIPAMPrefix.ps1
@@ -30,6 +30,7 @@ function Set-NBIPAMPrefix {
 
         [string]$Prefix,
 
+        [ValidateSet('active', 'reserved', 'deprecated', 'container', IgnoreCase = $true)]
         [string]$Status,
 
         [uint64]$Tenant,

--- a/Functions/IPAM/RIR/Remove-NBIPAMRIR.ps1
+++ b/Functions/IPAM/RIR/Remove-NBIPAMRIR.ps1
@@ -19,7 +19,7 @@
 #>
 function Remove-NBIPAMRIR {
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param(
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)][uint64]$Id,
         [switch]$Raw

--- a/Functions/IPAM/Range/Get-NBIPAMAddressRange.ps1
+++ b/Functions/IPAM/Range/Get-NBIPAMAddressRange.ps1
@@ -49,13 +49,13 @@ function Get-NBIPAMAddressRange {
         [string]$VRF,
 
         [Parameter(ParameterSetName = 'Query')]
-        [uint32]$VRF_Id,
+        [uint64]$VRF_Id,
 
         [Parameter(ParameterSetName = 'Query')]
         [string]$Tenant,
 
         [Parameter(ParameterSetName = 'Query')]
-        [uint32]$Tenant_Id,
+        [uint64]$Tenant_Id,
 
         [Parameter(ParameterSetName = 'Query')]
         [ValidateSet('active', 'reserved', 'deprecated', IgnoreCase = $true)]
@@ -80,7 +80,7 @@ function Get-NBIPAMAddressRange {
             foreach ($Range_ID in $Id) {
                 $Segments = [System.Collections.ArrayList]::new(@('ipam', 'ip-ranges', $Range_ID))
 
-                $URIComponents = BuildURIComponents -URISegments $Segments -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'All', 'PageSize'
+                $URIComponents = BuildURIComponents -URISegments $Segments -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw', 'All', 'PageSize'
 
                 $uri = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
 
@@ -93,7 +93,7 @@ function Get-NBIPAMAddressRange {
         default {
             $Segments = [System.Collections.ArrayList]::new(@('ipam', 'ip-ranges'))
 
-            $URIComponents = BuildURIComponents -URISegments $Segments -ParametersDictionary $PSBoundParameters -SkipParameterByName 'All', 'PageSize'
+            $URIComponents = BuildURIComponents -URISegments $Segments -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'All', 'PageSize'
 
             $uri = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
 

--- a/Functions/IPAM/Range/New-NBIPAMAddressRange.ps1
+++ b/Functions/IPAM/Range/New-NBIPAMAddressRange.ps1
@@ -92,14 +92,13 @@ function New-NBIPAMAddressRange {
     process {
         Write-Verbose "Creating IPAM Address Range"
         $Segments = [System.Collections.ArrayList]::new(@('ipam', 'ip-ranges'))
-        $Method = 'POST'
 
         $URIComponents = BuildURIComponents -URISegments $Segments -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw'
 
         $URI = BuildNewURI -Segments $URIComponents.Segments
 
         if ($PSCmdlet.ShouldProcess($Start_Address, 'Create new IP address range')) {
-            InvokeNetboxRequest -URI $URI -Method $Method -Body $URIComponents.Parameters -Raw:$Raw
+            InvokeNetboxRequest -URI $URI -Method POST -Body $URIComponents.Parameters -Raw:$Raw
         }
     }
 }

--- a/Functions/IPAM/Range/Remove-NBIPAMAddressRange.ps1
+++ b/Functions/IPAM/Range/Remove-NBIPAMAddressRange.ps1
@@ -38,7 +38,7 @@ function Remove-NBIPAMAddressRange {
 
             $Segments = [System.Collections.ArrayList]::new(@('ipam', 'ip-ranges', $Range_Id))
 
-            if ($Force -or $pscmdlet.ShouldProcess("ID $Range_Id", "Delete")) {
+            if ($Force -or $PSCmdlet.ShouldProcess("ID $Range_Id", "Delete")) {
                 $URI = BuildNewURI -Segments $Segments
 
                 InvokeNetboxRequest -URI $URI -Method DELETE -Raw:$Raw

--- a/Functions/IPAM/Role/Get-NBIPAMRole.ps1
+++ b/Functions/IPAM/Role/Get-NBIPAMRole.ps1
@@ -80,7 +80,7 @@ function Get-NBIPAMRole {
             foreach ($Role_ID in $Id) {
                 $Segments = [System.Collections.ArrayList]::new(@('ipam', 'roles', $Role_ID))
 
-                $URIComponents = BuildURIComponents -URISegments $Segments -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'All', 'PageSize'
+                $URIComponents = BuildURIComponents -URISegments $Segments -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw', 'All', 'PageSize'
 
                 $uri = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
 
@@ -93,7 +93,7 @@ function Get-NBIPAMRole {
         default {
             $Segments = [System.Collections.ArrayList]::new(@('ipam', 'roles'))
 
-            $URIComponents = BuildURIComponents -URISegments $Segments -ParametersDictionary $PSBoundParameters -SkipParameterByName 'All', 'PageSize'
+            $URIComponents = BuildURIComponents -URISegments $Segments -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'All', 'PageSize'
 
             $uri = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
 

--- a/Functions/IPAM/Role/Remove-NBIPAMRole.ps1
+++ b/Functions/IPAM/Role/Remove-NBIPAMRole.ps1
@@ -19,7 +19,7 @@
 #>
 function Remove-NBIPAMRole {
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param(
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)][uint64]$Id,
         [switch]$Raw

--- a/Functions/IPAM/RouteTarget/Remove-NBIPAMRouteTarget.ps1
+++ b/Functions/IPAM/RouteTarget/Remove-NBIPAMRouteTarget.ps1
@@ -24,7 +24,7 @@ function Remove-NBIPAMRouteTarget {
 #>
 
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param
     (
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]

--- a/Functions/IPAM/Service/Remove-NBIPAMService.ps1
+++ b/Functions/IPAM/Service/Remove-NBIPAMService.ps1
@@ -19,7 +19,7 @@ function Remove-NBIPAMService {
 #>
 
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param
     (
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]

--- a/Functions/IPAM/ServiceTemplate/Remove-NBIPAMServiceTemplate.ps1
+++ b/Functions/IPAM/ServiceTemplate/Remove-NBIPAMServiceTemplate.ps1
@@ -19,7 +19,7 @@ function Remove-NBIPAMServiceTemplate {
 #>
 
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param
     (
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]

--- a/Functions/IPAM/VLAN/Get-NBIPAMVLAN.ps1
+++ b/Functions/IPAM/VLAN/Get-NBIPAMVLAN.ps1
@@ -98,7 +98,7 @@ function Get-NBIPAMVLAN {
             foreach ($VLAN_ID in $Id) {
                 $Segments = [System.Collections.ArrayList]::new(@('ipam', 'vlans', $VLAN_ID))
 
-                $URIComponents = BuildURIComponents -URISegments $Segments -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'All', 'PageSize'
+                $URIComponents = BuildURIComponents -URISegments $Segments -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw', 'All', 'PageSize'
 
                 $uri = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
 
@@ -111,7 +111,7 @@ function Get-NBIPAMVLAN {
         default {
             $Segments = [System.Collections.ArrayList]::new(@('ipam', 'vlans'))
 
-            $URIComponents = BuildURIComponents -URISegments $Segments -ParametersDictionary $PSBoundParameters -SkipParameterByName 'All', 'PageSize'
+            $URIComponents = BuildURIComponents -URISegments $Segments -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'All', 'PageSize'
 
             $uri = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
 

--- a/Functions/IPAM/VLAN/New-NBIPAMVLAN.ps1
+++ b/Functions/IPAM/VLAN/New-NBIPAMVLAN.ps1
@@ -157,11 +157,6 @@ function New-NBIPAMVLAN {
                     $key = $prop.Name.ToLower()
                     $value = $prop.Value
 
-                    # Handle property name mappings
-                    switch ($key) {
-                        'custom_fields' { $key = 'custom_fields' }
-                    }
-
                     # Validate VID range in bulk mode
                     if ($key -eq 'vid') {
                         if ($value -lt 1 -or $value -gt 4094) {

--- a/Functions/IPAM/VLAN/Remove-NBIPAMVLAN.ps1
+++ b/Functions/IPAM/VLAN/Remove-NBIPAMVLAN.ps1
@@ -19,7 +19,7 @@
 #>
 function Remove-NBIPAMVLAN {
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param(
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)][uint64]$Id,
         [switch]$Raw

--- a/Functions/IPAM/VLAN/Set-NBIPAMVLAN.ps1
+++ b/Functions/IPAM/VLAN/Set-NBIPAMVLAN.ps1
@@ -24,6 +24,7 @@ function Set-NBIPAMVLAN {
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)][uint64]$Id,
         [ValidateRange(1, 4094)][uint16]$VID,
         [string]$Name,
+        [ValidateSet('active', 'reserved', 'deprecated', IgnoreCase = $true)]
         [string]$Status,
         [uint64]$Site,
         [uint64]$Group,

--- a/Functions/IPAM/VLANGroup/Remove-NBIPAMVLANGroup.ps1
+++ b/Functions/IPAM/VLANGroup/Remove-NBIPAMVLANGroup.ps1
@@ -19,7 +19,7 @@
 #>
 function Remove-NBIPAMVLANGroup {
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param(
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)][uint64]$Id,
         [switch]$Raw

--- a/Functions/IPAM/VLANTranslationPolicy/Remove-NBIPAMVLANTranslationPolicy.ps1
+++ b/Functions/IPAM/VLANTranslationPolicy/Remove-NBIPAMVLANTranslationPolicy.ps1
@@ -19,7 +19,7 @@
 #>
 function Remove-NBIPAMVLANTranslationPolicy {
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param(
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)][uint64]$Id,
         [switch]$Raw

--- a/Functions/IPAM/VLANTranslationRule/Remove-NBIPAMVLANTranslationRule.ps1
+++ b/Functions/IPAM/VLANTranslationRule/Remove-NBIPAMVLANTranslationRule.ps1
@@ -19,7 +19,7 @@
 #>
 function Remove-NBIPAMVLANTranslationRule {
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param(
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)][uint64]$Id,
         [switch]$Raw

--- a/Functions/IPAM/VRF/Remove-NBIPAMVRF.ps1
+++ b/Functions/IPAM/VRF/Remove-NBIPAMVRF.ps1
@@ -24,7 +24,7 @@ function Remove-NBIPAMVRF {
 #>
 
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param
     (
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]

--- a/Functions/Plugins/Branching/Branch/Remove-NBBranch.ps1
+++ b/Functions/Plugins/Branching/Branch/Remove-NBBranch.ps1
@@ -29,7 +29,7 @@
 #>
 function Remove-NBBranch {
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param(
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
         [uint64]$Id,

--- a/Functions/Tenancy/ContactAssignment/Get-NBContactAssignment.ps1
+++ b/Functions/Tenancy/ContactAssignment/Get-NBContactAssignment.ps1
@@ -97,25 +97,22 @@ function Get-NBContactAssignment {
             foreach ($ContactAssignment_ID in $Id) {
                 $Segments = [System.Collections.ArrayList]::new(@('tenancy', 'contact-assignments', $ContactAssignment_ID))
 
-                $URIComponents = BuildURIComponents -URISegments $Segments -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'All', 'PageSize'
+                $URIComponents = BuildURIComponents -URISegments $Segments -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw', 'All', 'PageSize'
 
                 $uri = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
 
                 InvokeNetboxRequest -URI $uri -Raw:$Raw -All:$All -PageSize $PageSize
             }
-
-            break
         }
 
         default {
             $Segments = [System.Collections.ArrayList]::new(@('tenancy', 'contact-assignments'))
 
-            $URIComponents = BuildURIComponents -URISegments $Segments -ParametersDictionary $PSBoundParameters -SkipParameterByName 'All', 'PageSize'
+            $URIComponents = BuildURIComponents -URISegments $Segments -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'All', 'PageSize'
 
             $uri = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
 
             InvokeNetboxRequest -URI $uri -Raw:$Raw -All:$All -PageSize $PageSize
-            break
         }
     }
     }

--- a/Functions/Tenancy/ContactAssignment/Get-NBContactAssignment.ps1
+++ b/Functions/Tenancy/ContactAssignment/Get-NBContactAssignment.ps1
@@ -103,6 +103,7 @@ function Get-NBContactAssignment {
 
                 InvokeNetboxRequest -URI $uri -Raw:$Raw -All:$All -PageSize $PageSize
             }
+            return
         }
 
         default {

--- a/Functions/Tenancy/ContactAssignment/New-NBContactAssignment.ps1
+++ b/Functions/Tenancy/ContactAssignment/New-NBContactAssignment.ps1
@@ -57,10 +57,6 @@ function New-NBContactAssignment {
         [switch]$Raw
     )
 
-    begin {
-        $Method = 'POST'
-    }
-
     process {
         Write-Verbose "Creating Contact Assignment"
         $Segments = [System.Collections.ArrayList]::new(@('tenancy', 'contact-assignments'))
@@ -70,7 +66,7 @@ function New-NBContactAssignment {
         $URI = BuildNewURI -Segments $URIComponents.Segments
 
         if ($PSCmdlet.ShouldProcess($Content_Type, 'Create new contact assignment')) {
-            InvokeNetboxRequest -URI $URI -Method $Method -Body $URIComponents.Parameters -Raw:$Raw
+            InvokeNetboxRequest -URI $URI -Method POST -Body $URIComponents.Parameters -Raw:$Raw
         }
     }
 }

--- a/Functions/Tenancy/ContactAssignment/Remove-NBContactAssignment.ps1
+++ b/Functions/Tenancy/ContactAssignment/Remove-NBContactAssignment.ps1
@@ -36,7 +36,7 @@
 #>
 function Remove-NBContactAssignment {
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param
     (
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]

--- a/Functions/Tenancy/ContactRoles/Get-NBContactRole.ps1
+++ b/Functions/Tenancy/ContactRoles/Get-NBContactRole.ps1
@@ -79,25 +79,22 @@ function Get-NBContactRole {
             foreach ($ContactRole_ID in $Id) {
                 $Segments = [System.Collections.ArrayList]::new(@('tenancy', 'contact-roles', $ContactRole_ID))
 
-                $URIComponents = BuildURIComponents -URISegments $Segments -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'All', 'PageSize'
+                $URIComponents = BuildURIComponents -URISegments $Segments -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw', 'All', 'PageSize'
 
                 $uri = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
 
                 InvokeNetboxRequest -URI $uri -Raw:$Raw -All:$All -PageSize $PageSize
             }
-
-            break
         }
 
         default {
             $Segments = [System.Collections.ArrayList]::new(@('tenancy', 'contact-roles'))
 
-            $URIComponents = BuildURIComponents -URISegments $Segments -ParametersDictionary $PSBoundParameters -SkipParameterByName 'All', 'PageSize'
+            $URIComponents = BuildURIComponents -URISegments $Segments -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'All', 'PageSize'
 
             $uri = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
 
             InvokeNetboxRequest -URI $uri -Raw:$Raw -All:$All -PageSize $PageSize
-            break
         }
     }
     }

--- a/Functions/Tenancy/ContactRoles/Get-NBContactRole.ps1
+++ b/Functions/Tenancy/ContactRoles/Get-NBContactRole.ps1
@@ -85,6 +85,7 @@ function Get-NBContactRole {
 
                 InvokeNetboxRequest -URI $uri -Raw:$Raw -All:$All -PageSize $PageSize
             }
+            return
         }
 
         default {

--- a/Functions/Tenancy/ContactRoles/New-NBContactRole.ps1
+++ b/Functions/Tenancy/ContactRoles/New-NBContactRole.ps1
@@ -52,14 +52,13 @@ function New-NBContactRole {
     process {
         Write-Verbose "Creating Contact Role"
         $Segments = [System.Collections.ArrayList]::new(@('tenancy', 'contact-roles'))
-        $Method = 'POST'
 
         $URIComponents = BuildURIComponents -URISegments $Segments -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw'
 
         $URI = BuildNewURI -Segments $URIComponents.Segments
 
         if ($PSCmdlet.ShouldProcess($Name, 'Create new contact role')) {
-            InvokeNetboxRequest -URI $URI -Method $Method -Body $URIComponents.Parameters -Raw:$Raw
+            InvokeNetboxRequest -URI $URI -Method POST -Body $URIComponents.Parameters -Raw:$Raw
         }
     }
 }

--- a/Functions/Tenancy/ContactRoles/Remove-NBContactRole.ps1
+++ b/Functions/Tenancy/ContactRoles/Remove-NBContactRole.ps1
@@ -30,7 +30,7 @@
 #>
 function Remove-NBContactRole {
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param
     (
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
@@ -49,7 +49,7 @@ function Remove-NBContactRole {
 
             $URI = BuildNewURI -Segments $Segments
 
-            if ($Force -or $PSCmdlet.ShouldProcess("$("ID $RoleId")", 'Delete contact role')) {
+            if ($Force -or $PSCmdlet.ShouldProcess("ID $RoleId", 'Delete contact role')) {
                 InvokeNetboxRequest -URI $URI -Method DELETE -Raw:$Raw
             }
         }

--- a/Functions/Tenancy/Contacts/Get-NBContact.ps1
+++ b/Functions/Tenancy/Contacts/Get-NBContact.ps1
@@ -108,25 +108,22 @@ function Get-NBContact {
             foreach ($Contact_ID in $Id) {
                 $Segments = [System.Collections.ArrayList]::new(@('tenancy', 'contacts', $Contact_ID))
 
-                $URIComponents = BuildURIComponents -URISegments $Segments -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'All', 'PageSize'
+                $URIComponents = BuildURIComponents -URISegments $Segments -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw', 'All', 'PageSize'
 
                 $uri = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
 
                 InvokeNetboxRequest -URI $uri -Raw:$Raw -All:$All -PageSize $PageSize
             }
-
-            break
         }
 
         default {
             $Segments = [System.Collections.ArrayList]::new(@('tenancy', 'contacts'))
 
-            $URIComponents = BuildURIComponents -URISegments $Segments -ParametersDictionary $PSBoundParameters -SkipParameterByName 'All', 'PageSize'
+            $URIComponents = BuildURIComponents -URISegments $Segments -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'All', 'PageSize'
 
             $uri = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
 
             InvokeNetboxRequest -URI $uri -Raw:$Raw -All:$All -PageSize $PageSize
-            break
         }
     }
     }

--- a/Functions/Tenancy/Contacts/Get-NBContact.ps1
+++ b/Functions/Tenancy/Contacts/Get-NBContact.ps1
@@ -114,6 +114,7 @@ function Get-NBContact {
 
                 InvokeNetboxRequest -URI $uri -Raw:$Raw -All:$All -PageSize $PageSize
             }
+            return
         }
 
         default {

--- a/Functions/Tenancy/Contacts/New-NBContact.ps1
+++ b/Functions/Tenancy/Contacts/New-NBContact.ps1
@@ -79,14 +79,13 @@ function New-NBContact {
     process {
         Write-Verbose "Creating Contact"
         $Segments = [System.Collections.ArrayList]::new(@('tenancy', 'contacts'))
-        $Method = 'POST'
 
         $URIComponents = BuildURIComponents -URISegments $Segments -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw'
 
         $URI = BuildNewURI -Segments $URIComponents.Segments
 
         if ($PSCmdlet.ShouldProcess($Name, 'Create new contact')) {
-            InvokeNetboxRequest -URI $URI -Method $Method -Body $URIComponents.Parameters -Raw:$Raw
+            InvokeNetboxRequest -URI $URI -Method POST -Body $URIComponents.Parameters -Raw:$Raw
         }
     }
 }

--- a/Functions/Tenancy/Contacts/Remove-NBContact.ps1
+++ b/Functions/Tenancy/Contacts/Remove-NBContact.ps1
@@ -35,7 +35,7 @@
 #>
 function Remove-NBContact {
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param
     (
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
@@ -54,7 +54,7 @@ function Remove-NBContact {
 
             $URI = BuildNewURI -Segments $Segments
 
-            if ($Force -or $PSCmdlet.ShouldProcess("$("ID $ContactId")", 'Delete contact')) {
+            if ($Force -or $PSCmdlet.ShouldProcess("ID $ContactId", 'Delete contact')) {
                 InvokeNetboxRequest -URI $URI -Method DELETE -Raw:$Raw
             }
         }

--- a/Functions/Tenancy/TenantGroups/Remove-NBTenantGroup.ps1
+++ b/Functions/Tenancy/TenantGroups/Remove-NBTenantGroup.ps1
@@ -30,7 +30,7 @@
 #>
 function Remove-NBTenantGroup {
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param
     (
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
@@ -49,7 +49,7 @@ function Remove-NBTenantGroup {
 
             $URI = BuildNewURI -Segments $Segments
 
-            if ($Force -or $PSCmdlet.ShouldProcess("$("ID $GroupId")", 'Delete tenant group')) {
+            if ($Force -or $PSCmdlet.ShouldProcess("ID $GroupId", 'Delete tenant group')) {
                 InvokeNetboxRequest -URI $URI -Method DELETE -Raw:$Raw
             }
         }

--- a/Functions/Tenancy/TenantGroups/Set-NBTenantGroup.ps1
+++ b/Functions/Tenancy/TenantGroups/Set-NBTenantGroup.ps1
@@ -81,7 +81,7 @@ function Set-NBTenantGroup {
 
             $URI = BuildNewURI -Segments $URIComponents.Segments
 
-            if ($Force -or $PSCmdlet.ShouldProcess("$("ID $GroupId")", 'Update tenant group')) {
+            if ($Force -or $PSCmdlet.ShouldProcess("ID $GroupId", 'Update tenant group')) {
                 InvokeNetboxRequest -URI $URI -Method PATCH -Body $URIComponents.Parameters -Raw:$Raw
             }
         }

--- a/Functions/Tenancy/Tenants/Get-NBTenant.ps1
+++ b/Functions/Tenancy/Tenants/Get-NBTenant.ps1
@@ -104,6 +104,7 @@ function Get-NBTenant {
 
                 InvokeNetboxRequest -URI $uri -Raw:$Raw -All:$All -PageSize $PageSize
             }
+            return
         }
 
         default {

--- a/Functions/Tenancy/Tenants/Get-NBTenant.ps1
+++ b/Functions/Tenancy/Tenants/Get-NBTenant.ps1
@@ -98,25 +98,22 @@ function Get-NBTenant {
             foreach ($Tenant_ID in $Id) {
                 $Segments = [System.Collections.ArrayList]::new(@('tenancy', 'tenants', $Tenant_ID))
 
-                $URIComponents = BuildURIComponents -URISegments $Segments -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'All', 'PageSize'
+                $URIComponents = BuildURIComponents -URISegments $Segments -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw', 'All', 'PageSize'
 
                 $uri = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
 
                 InvokeNetboxRequest -URI $uri -Raw:$Raw -All:$All -PageSize $PageSize
             }
-
-            break
         }
 
         default {
             $Segments = [System.Collections.ArrayList]::new(@('tenancy', 'tenants'))
 
-            $URIComponents = BuildURIComponents -URISegments $Segments -ParametersDictionary $PSBoundParameters -SkipParameterByName 'All', 'PageSize'
+            $URIComponents = BuildURIComponents -URISegments $Segments -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'All', 'PageSize'
 
             $uri = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
 
             InvokeNetboxRequest -URI $uri -Raw:$Raw -All:$All -PageSize $PageSize
-            break
         }
     }
     }

--- a/Functions/Tenancy/Tenants/New-NBTenant.ps1
+++ b/Functions/Tenancy/Tenants/New-NBTenant.ps1
@@ -53,14 +53,13 @@ function New-NBTenant {
     process {
         Write-Verbose "Creating Tenant"
         $Segments = [System.Collections.ArrayList]::new(@('tenancy', 'tenants'))
-        $Method = 'POST'
 
         $URIComponents = BuildURIComponents -URISegments $Segments -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw'
 
         $URI = BuildNewURI -Segments $URIComponents.Segments
 
         if ($PSCmdlet.ShouldProcess($Name, 'Create new tenant')) {
-            InvokeNetboxRequest -URI $URI -Method $Method -Body $URIComponents.Parameters -Raw:$Raw
+            InvokeNetboxRequest -URI $URI -Method POST -Body $URIComponents.Parameters -Raw:$Raw
         }
     }
 }

--- a/Functions/Tenancy/Tenants/Remove-NBTenant.ps1
+++ b/Functions/Tenancy/Tenants/Remove-NBTenant.ps1
@@ -35,7 +35,7 @@
 #>
 function Remove-NBTenant {
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param
     (
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
@@ -54,7 +54,7 @@ function Remove-NBTenant {
 
             $URI = BuildNewURI -Segments $Segments
 
-            if ($Force -or $PSCmdlet.ShouldProcess("$("ID $TenantId")", 'Delete tenant')) {
+            if ($Force -or $PSCmdlet.ShouldProcess("ID $TenantId", 'Delete tenant')) {
                 InvokeNetboxRequest -URI $URI -Method DELETE -Raw:$Raw
             }
         }

--- a/Functions/Tenancy/Tenants/Set-NBTenant.ps1
+++ b/Functions/Tenancy/Tenants/Set-NBTenant.ps1
@@ -86,7 +86,7 @@ function Set-NBTenant {
 
             $URI = BuildNewURI -Segments $URIComponents.Segments
 
-            if ($Force -or $PSCmdlet.ShouldProcess("$("ID $TenantId")", 'Update tenant')) {
+            if ($Force -or $PSCmdlet.ShouldProcess("ID $TenantId", 'Update tenant')) {
                 InvokeNetboxRequest -URI $URI -Method PATCH -Body $URIComponents.Parameters -Raw:$Raw
             }
         }

--- a/Functions/Users/Groups/Remove-NBGroup.ps1
+++ b/Functions/Users/Groups/Remove-NBGroup.ps1
@@ -19,7 +19,7 @@
 #>
 function Remove-NBGroup {
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param (
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
         [uint64]$Id,

--- a/Functions/Users/OwnerGroups/Remove-NBOwnerGroup.ps1
+++ b/Functions/Users/OwnerGroups/Remove-NBOwnerGroup.ps1
@@ -24,7 +24,7 @@
 #>
 function Remove-NBOwnerGroup {
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param (
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
         [uint64]$Id,

--- a/Functions/Users/Owners/Remove-NBOwner.ps1
+++ b/Functions/Users/Owners/Remove-NBOwner.ps1
@@ -24,7 +24,7 @@
 #>
 function Remove-NBOwner {
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param (
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
         [uint64]$Id,

--- a/Functions/Users/Permissions/Remove-NBPermission.ps1
+++ b/Functions/Users/Permissions/Remove-NBPermission.ps1
@@ -19,7 +19,7 @@
 #>
 function Remove-NBPermission {
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param (
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
         [uint64]$Id,

--- a/Functions/Users/Tokens/Remove-NBToken.ps1
+++ b/Functions/Users/Tokens/Remove-NBToken.ps1
@@ -19,7 +19,7 @@
 #>
 function Remove-NBToken {
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param (
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
         [uint64]$Id,

--- a/Functions/Users/Users/Remove-NBUser.ps1
+++ b/Functions/Users/Users/Remove-NBUser.ps1
@@ -19,7 +19,7 @@
 #>
 function Remove-NBUser {
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param (
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
         [uint64]$Id,

--- a/Functions/VPN/IKEPolicy/Remove-NBVPNIKEPolicy.ps1
+++ b/Functions/VPN/IKEPolicy/Remove-NBVPNIKEPolicy.ps1
@@ -19,7 +19,7 @@
 #>
 function Remove-NBVPNIKEPolicy {
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param([Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)][uint64]$Id,[switch]$Raw)
     process { if ($PSCmdlet.ShouldProcess($Id, 'Delete IKE policy')) { InvokeNetboxRequest -URI (BuildNewURI -Segments @('vpn','ike-policies',$Id)) -Method DELETE -Raw:$Raw } }
 }

--- a/Functions/VPN/IKEProposal/Remove-NBVPNIKEProposal.ps1
+++ b/Functions/VPN/IKEProposal/Remove-NBVPNIKEProposal.ps1
@@ -19,7 +19,7 @@
 #>
 function Remove-NBVPNIKEProposal {
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param([Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)][uint64]$Id,[switch]$Raw)
     process { if ($PSCmdlet.ShouldProcess($Id, 'Delete IKE proposal')) { InvokeNetboxRequest -URI (BuildNewURI -Segments @('vpn','ike-proposals',$Id)) -Method DELETE -Raw:$Raw } }
 }

--- a/Functions/VPN/IPSecPolicy/Remove-NBVPNIPSecPolicy.ps1
+++ b/Functions/VPN/IPSecPolicy/Remove-NBVPNIPSecPolicy.ps1
@@ -19,7 +19,7 @@
 #>
 function Remove-NBVPNIPSecPolicy {
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param([Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)][uint64]$Id,[switch]$Raw)
     process { if ($PSCmdlet.ShouldProcess($Id, 'Delete IPSec policy')) { InvokeNetboxRequest -URI (BuildNewURI -Segments @('vpn','ipsec-policies',$Id)) -Method DELETE -Raw:$Raw } }
 }

--- a/Functions/VPN/IPSecProfile/Remove-NBVPNIPSecProfile.ps1
+++ b/Functions/VPN/IPSecProfile/Remove-NBVPNIPSecProfile.ps1
@@ -19,7 +19,7 @@
 #>
 function Remove-NBVPNIPSecProfile {
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param([Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)][uint64]$Id,[switch]$Raw)
     process { if ($PSCmdlet.ShouldProcess($Id, 'Delete IPSec profile')) { InvokeNetboxRequest -URI (BuildNewURI -Segments @('vpn','ipsec-profiles',$Id)) -Method DELETE -Raw:$Raw } }
 }

--- a/Functions/VPN/IPSecProposal/Remove-NBVPNIPSecProposal.ps1
+++ b/Functions/VPN/IPSecProposal/Remove-NBVPNIPSecProposal.ps1
@@ -19,7 +19,7 @@
 #>
 function Remove-NBVPNIPSecProposal {
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param([Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)][uint64]$Id,[switch]$Raw)
     process { if ($PSCmdlet.ShouldProcess($Id, 'Delete IPSec proposal')) { InvokeNetboxRequest -URI (BuildNewURI -Segments @('vpn','ipsec-proposals',$Id)) -Method DELETE -Raw:$Raw } }
 }

--- a/Functions/VPN/L2VPN/Remove-NBVPNL2VPN.ps1
+++ b/Functions/VPN/L2VPN/Remove-NBVPNL2VPN.ps1
@@ -19,7 +19,7 @@
 #>
 function Remove-NBVPNL2VPN {
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param([Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)][uint64]$Id,[switch]$Raw)
     process { if ($PSCmdlet.ShouldProcess($Id, 'Delete L2VPN')) { InvokeNetboxRequest -URI (BuildNewURI -Segments @('vpn','l2vpns',$Id)) -Method DELETE -Raw:$Raw } }
 }

--- a/Functions/VPN/L2VPNTermination/Remove-NBVPNL2VPNTermination.ps1
+++ b/Functions/VPN/L2VPNTermination/Remove-NBVPNL2VPNTermination.ps1
@@ -19,7 +19,7 @@
 #>
 function Remove-NBVPNL2VPNTermination {
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param([Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)][uint64]$Id,[switch]$Raw)
     process { if ($PSCmdlet.ShouldProcess($Id, 'Delete L2VPN termination')) { InvokeNetboxRequest -URI (BuildNewURI -Segments @('vpn','l2vpn-terminations',$Id)) -Method DELETE -Raw:$Raw } }
 }

--- a/Functions/VPN/Tunnel/Remove-NBVPNTunnel.ps1
+++ b/Functions/VPN/Tunnel/Remove-NBVPNTunnel.ps1
@@ -19,7 +19,7 @@
 #>
 function Remove-NBVPNTunnel {
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param
     (
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)][uint64]$Id,

--- a/Functions/VPN/TunnelGroup/Remove-NBVPNTunnelGroup.ps1
+++ b/Functions/VPN/TunnelGroup/Remove-NBVPNTunnelGroup.ps1
@@ -19,7 +19,7 @@
 #>
 function Remove-NBVPNTunnelGroup {
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param([Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)][uint64]$Id,[switch]$Raw)
     process { if ($PSCmdlet.ShouldProcess($Id, 'Delete tunnel group')) { InvokeNetboxRequest -URI (BuildNewURI -Segments @('vpn','tunnel-groups',$Id)) -Method DELETE -Raw:$Raw } }
 }

--- a/Functions/VPN/TunnelTermination/Remove-NBVPNTunnelTermination.ps1
+++ b/Functions/VPN/TunnelTermination/Remove-NBVPNTunnelTermination.ps1
@@ -19,7 +19,7 @@
 #>
 function Remove-NBVPNTunnelTermination {
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param([Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)][uint64]$Id,[switch]$Raw)
     process { if ($PSCmdlet.ShouldProcess($Id, 'Delete tunnel termination')) { InvokeNetboxRequest -URI (BuildNewURI -Segments @('vpn','tunnel-terminations',$Id)) -Method DELETE -Raw:$Raw } }
 }

--- a/Functions/Virtualization/VirtualMachine/New-NBVirtualMachine.ps1
+++ b/Functions/Virtualization/VirtualMachine/New-NBVirtualMachine.ps1
@@ -192,10 +192,6 @@ function New-NBVirtualMachine {
 
                     # Handle property name mappings
                     switch ($key) {
-                        'vcpus' { $key = 'vcpus' }
-                        'primary_ip4' { $key = 'primary_ip4' }
-                        'primary_ip6' { $key = 'primary_ip6' }
-                        'custom_fields' { $key = 'custom_fields' }
                         'device_role' { $key = 'role' }  # Backwards compatibility
                     }
 

--- a/Functions/Virtualization/VirtualMachine/Remove-NBVirtualMachine.ps1
+++ b/Functions/Virtualization/VirtualMachine/Remove-NBVirtualMachine.ps1
@@ -85,7 +85,7 @@ function Remove-NBVirtualMachine {
         if ($PSCmdlet.ParameterSetName -eq 'Single') {
             foreach ($VMId in $Id) {
 
-                if ($Force -or $PSCmdlet.ShouldProcess("$("ID $VMId")/$($VMId)", "Remove")) {
+                if ($Force -or $PSCmdlet.ShouldProcess("ID $VMId", "Remove")) {
                     $VMSegments = [System.Collections.ArrayList]::new(@('virtualization', 'virtual-machines', $VMId))
 
                     $VMURI = BuildNewURI -Segments $VMSegments

--- a/Functions/Virtualization/VirtualMachine/Set-NBVirtualMachine.ps1
+++ b/Functions/Virtualization/VirtualMachine/Set-NBVirtualMachine.ps1
@@ -202,13 +202,6 @@ function Set-NBVirtualMachine {
                     $key = $prop.Name.ToLower()
                     $value = $prop.Value
 
-                    # Handle property name mappings
-                    switch ($key) {
-                        'primary_ip4' { $key = 'primary_ip4' }
-                        'primary_ip6' { $key = 'primary_ip6' }
-                        'custom_fields' { $key = 'custom_fields' }
-                    }
-
                     $item[$key] = $value
                 }
                 [void]$bulkItems.Add([PSCustomObject]$item)

--- a/Functions/Virtualization/VirtualMachineInterface/Get-NBVirtualMachineInterface.ps1
+++ b/Functions/Virtualization/VirtualMachineInterface/Get-NBVirtualMachineInterface.ps1
@@ -96,7 +96,7 @@ function Get-NBVirtualMachineInterface {
             'ByID' { foreach ($i in $Id) { InvokeNetboxRequest -URI (BuildNewURI -Segments @('virtualization', 'interfaces', $i)) -Raw:$Raw } }
             default {
                 $Segments = [System.Collections.ArrayList]::new(@('virtualization', 'interfaces'))
-                $URIComponents = BuildURIComponents -URISegments $Segments -ParametersDictionary $PSBoundParameters -SkipParameterByName 'All', 'PageSize'
+                $URIComponents = BuildURIComponents -URISegments $Segments -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'All', 'PageSize'
                 $uri = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
                 InvokeNetboxRequest -URI $uri -Raw:$Raw -All:$All -PageSize $PageSize
             }

--- a/Functions/Virtualization/VirtualMachineInterface/New-NBVirtualMachineInterface.ps1
+++ b/Functions/Virtualization/VirtualMachineInterface/New-NBVirtualMachineInterface.ps1
@@ -186,15 +186,6 @@ function New-NBVirtualMachineInterface {
                     $key = $prop.Name.ToLower()
                     $value = $prop.Value
 
-                    # Handle property name mappings
-                    switch ($key) {
-                        'virtual_machine' { $key = 'virtual_machine' }
-                        'mac_address' { $key = 'mac_address' }
-                        'untagged_vlan' { $key = 'untagged_vlan' }
-                        'tagged_vlans' { $key = 'tagged_vlans' }
-                        'custom_fields' { $key = 'custom_fields' }
-                    }
-
                     $item[$key] = $value
                 }
 

--- a/Functions/Virtualization/VirtualMachineInterface/Remove-NBVirtualMachineInterface.ps1
+++ b/Functions/Virtualization/VirtualMachineInterface/Remove-NBVirtualMachineInterface.ps1
@@ -41,7 +41,7 @@
 #>
 function Remove-NBVirtualMachineInterface {
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param
     (
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]

--- a/Functions/Virtualization/VirtualMachineInterface/Set-NBVirtualMachineInterface.ps1
+++ b/Functions/Virtualization/VirtualMachineInterface/Set-NBVirtualMachineInterface.ps1
@@ -51,7 +51,7 @@ function Set-NBVirtualMachineInterface {
 
             $Segments = [System.Collections.ArrayList]::new(@('virtualization', 'interfaces', $VMI_ID))
 
-            if ($Force -or $pscmdlet.ShouldProcess("VM Interface ID $VMI_ID", "Set")) {
+            if ($Force -or $PSCmdlet.ShouldProcess("VM Interface ID $VMI_ID", "Set")) {
                 $URIComponents = BuildURIComponents -URISegments $Segments -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw', 'Force'
 
                 $URI = BuildNewURI -Segments $URIComponents.Segments

--- a/Functions/Virtualization/VirtualizationCluster/Get-NBVirtualizationCluster.ps1
+++ b/Functions/Virtualization/VirtualizationCluster/Get-NBVirtualizationCluster.ps1
@@ -106,7 +106,7 @@ function Get-NBVirtualizationCluster {
             'ByID' { foreach ($i in $Id) { InvokeNetboxRequest -URI (BuildNewURI -Segments @('virtualization', 'clusters', $i)) -Raw:$Raw } }
             default {
                 $Segments = [System.Collections.ArrayList]::new(@('virtualization', 'clusters'))
-                $URIComponents = BuildURIComponents -URISegments $Segments -ParametersDictionary $PSBoundParameters -SkipParameterByName 'All', 'PageSize'
+                $URIComponents = BuildURIComponents -URISegments $Segments -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'All', 'PageSize'
                 $uri = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
                 InvokeNetboxRequest -URI $uri -Raw:$Raw -All:$All -PageSize $PageSize
             }

--- a/Functions/Virtualization/VirtualizationCluster/Get-NBVirtualizationClusterGroup.ps1
+++ b/Functions/Virtualization/VirtualizationCluster/Get-NBVirtualizationClusterGroup.ps1
@@ -61,7 +61,7 @@ function Get-NBVirtualizationClusterGroup {
             'ByID' { foreach ($i in $Id) { InvokeNetboxRequest -URI (BuildNewURI -Segments @('virtualization', 'cluster-groups', $i)) -Raw:$Raw } }
             default {
                 $Segments = [System.Collections.ArrayList]::new(@('virtualization', 'cluster-groups'))
-                $URIComponents = BuildURIComponents -URISegments $Segments -ParametersDictionary $PSBoundParameters -SkipParameterByName 'All', 'PageSize'
+                $URIComponents = BuildURIComponents -URISegments $Segments -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'All', 'PageSize'
                 $uri = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
                 InvokeNetboxRequest -URI $uri -Raw:$Raw -All:$All -PageSize $PageSize
             }

--- a/Functions/Virtualization/VirtualizationCluster/Remove-NBVirtualizationCluster.ps1
+++ b/Functions/Virtualization/VirtualizationCluster/Remove-NBVirtualizationCluster.ps1
@@ -36,7 +36,7 @@
 #>
 function Remove-NBVirtualizationCluster {
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param
     (
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
@@ -55,7 +55,7 @@ function Remove-NBVirtualizationCluster {
 
             $URI = BuildNewURI -Segments $Segments
 
-            if ($Force -or $PSCmdlet.ShouldProcess("$("ID $ClusterId")", 'Delete cluster')) {
+            if ($Force -or $PSCmdlet.ShouldProcess("ID $ClusterId", 'Delete cluster')) {
                 InvokeNetboxRequest -URI $URI -Method DELETE -Raw:$Raw
             }
         }

--- a/Functions/Virtualization/VirtualizationCluster/Remove-NBVirtualizationClusterGroup.ps1
+++ b/Functions/Virtualization/VirtualizationCluster/Remove-NBVirtualizationClusterGroup.ps1
@@ -30,7 +30,7 @@
 #>
 function Remove-NBVirtualizationClusterGroup {
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param
     (
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
@@ -49,7 +49,7 @@ function Remove-NBVirtualizationClusterGroup {
 
             $URI = BuildNewURI -Segments $Segments
 
-            if ($Force -or $PSCmdlet.ShouldProcess("$("ID $GroupId")", 'Delete cluster group')) {
+            if ($Force -or $PSCmdlet.ShouldProcess("ID $GroupId", 'Delete cluster group')) {
                 InvokeNetboxRequest -URI $URI -Method DELETE -Raw:$Raw
             }
         }

--- a/Functions/Virtualization/VirtualizationCluster/Set-NBVirtualizationCluster.ps1
+++ b/Functions/Virtualization/VirtualizationCluster/Set-NBVirtualizationCluster.ps1
@@ -102,7 +102,7 @@ function Set-NBVirtualizationCluster {
 
             $URI = BuildNewURI -Segments $URIComponents.Segments
 
-            if ($Force -or $PSCmdlet.ShouldProcess("$("ID $ClusterId")", 'Update cluster')) {
+            if ($Force -or $PSCmdlet.ShouldProcess("ID $ClusterId", 'Update cluster')) {
                 InvokeNetboxRequest -URI $URI -Method PATCH -Body $URIComponents.Parameters -Raw:$Raw
             }
         }

--- a/Functions/Virtualization/VirtualizationCluster/Set-NBVirtualizationClusterGroup.ps1
+++ b/Functions/Virtualization/VirtualizationCluster/Set-NBVirtualizationClusterGroup.ps1
@@ -76,7 +76,7 @@ function Set-NBVirtualizationClusterGroup {
 
             $URI = BuildNewURI -Segments $URIComponents.Segments
 
-            if ($Force -or $PSCmdlet.ShouldProcess("$("ID $GroupId")", 'Update cluster group')) {
+            if ($Force -or $PSCmdlet.ShouldProcess("ID $GroupId", 'Update cluster group')) {
                 InvokeNetboxRequest -URI $URI -Method PATCH -Body $URIComponents.Parameters -Raw:$Raw
             }
         }

--- a/Functions/Virtualization/VirtualizationClusterType/Remove-NBVirtualizationClusterType.ps1
+++ b/Functions/Virtualization/VirtualizationClusterType/Remove-NBVirtualizationClusterType.ps1
@@ -30,7 +30,7 @@
 #>
 function Remove-NBVirtualizationClusterType {
     [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param
     (
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
@@ -49,7 +49,7 @@ function Remove-NBVirtualizationClusterType {
 
             $URI = BuildNewURI -Segments $Segments
 
-            if ($Force -or $PSCmdlet.ShouldProcess("$("ID $TypeId")", 'Delete cluster type')) {
+            if ($Force -or $PSCmdlet.ShouldProcess("ID $TypeId", 'Delete cluster type')) {
                 InvokeNetboxRequest -URI $URI -Method DELETE -Raw:$Raw
             }
         }

--- a/Functions/Virtualization/VirtualizationClusterType/Set-NBVirtualizationClusterType.ps1
+++ b/Functions/Virtualization/VirtualizationClusterType/Set-NBVirtualizationClusterType.ps1
@@ -76,7 +76,7 @@ function Set-NBVirtualizationClusterType {
 
             $URI = BuildNewURI -Segments $URIComponents.Segments
 
-            if ($Force -or $PSCmdlet.ShouldProcess("$("ID $TypeId")", 'Update cluster type')) {
+            if ($Force -or $PSCmdlet.ShouldProcess("ID $TypeId", 'Update cluster type')) {
                 InvokeNetboxRequest -URI $URI -Method PATCH -Body $URIComponents.Parameters -Raw:$Raw
             }
         }

--- a/Functions/Wireless/WirelessLAN/Remove-NBWirelessLAN.ps1
+++ b/Functions/Wireless/WirelessLAN/Remove-NBWirelessLAN.ps1
@@ -19,7 +19,7 @@
 #>
 function Remove-NBWirelessLAN {
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param([Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)][uint64]$Id,[switch]$Raw)
     process { if ($PSCmdlet.ShouldProcess($Id, 'Delete wireless LAN')) { InvokeNetboxRequest -URI (BuildNewURI -Segments @('wireless','wireless-lans',$Id)) -Method DELETE -Raw:$Raw } }
 }

--- a/Functions/Wireless/WirelessLANGroup/Remove-NBWirelessLANGroup.ps1
+++ b/Functions/Wireless/WirelessLANGroup/Remove-NBWirelessLANGroup.ps1
@@ -19,7 +19,7 @@
 #>
 function Remove-NBWirelessLANGroup {
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param([Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)][uint64]$Id,[switch]$Raw)
     process { if ($PSCmdlet.ShouldProcess($Id, 'Delete wireless LAN group')) { InvokeNetboxRequest -URI (BuildNewURI -Segments @('wireless','wireless-lan-groups',$Id)) -Method DELETE -Raw:$Raw } }
 }

--- a/Functions/Wireless/WirelessLink/Remove-NBWirelessLink.ps1
+++ b/Functions/Wireless/WirelessLink/Remove-NBWirelessLink.ps1
@@ -19,7 +19,7 @@
 #>
 function Remove-NBWirelessLink {
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
-    [OutputType([PSCustomObject])]
+    [OutputType([void])]
     param([Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)][uint64]$Id,[switch]$Raw)
     process { if ($PSCmdlet.ShouldProcess($Id, 'Delete wireless link')) { InvokeNetboxRequest -URI (BuildNewURI -Segments @('wireless','wireless-links',$Id)) -Method DELETE -Raw:$Raw } }
 }


### PR DESCRIPTION
## Summary
Combined code quality improvements across 173 files:

**OutputType corrections (#317):**
- Change 107 `Remove-NB*` functions from `[PSCustomObject]` to `[void]` — DELETE operations return nothing
- Fix lowercase `[pscustomobject]` to `[PSCustomObject]` in 10 DCIM files

**SkipParameterByName and DefaultParameterSetName (#316):**
- Add `'Raw'` to `SkipParameterByName` in 22 Get function ByID/Query paths — prevents `-Raw` being sent as API query parameter
- Add `DefaultParameterSetName = 'Query'` to 5 DCIM Get functions missing it

**Code style standardization (#318):**
- Fix `$pscmdlet` to `$PSCmdlet` (PascalCase convention) in 11 files
- Remove redundant `$Method = 'POST'` variable in 7 New functions (inline directly)
- Replace `break` with `return` in 4 Tenancy Get function switch blocks
- Simplify `ShouldProcess` string interpolation

**Dead code and redundant logic (#319):**
- Remove no-op bulk property mappings in 8 functions (e.g., `'dns_name' { $key = 'dns_name' }`)
- Fix redundant `if ($Raw) { $Response } else { $Response }` in New-NBImageAttachment
- Fix `[uint32]` to `[uint64]` for VRF_Id/Tenant_Id in Get-NBIPAMAddressRange
- Add `[ValidateSet]` to Set-NBIPAMVLAN and Set-NBIPAMPrefix Status parameters

## Test plan
- [ ] Run `Invoke-Pester ./Tests/` — all unit tests pass
- [ ] Verify Remove functions still work (no output change)
- [ ] Verify Get functions with `-Raw` flag work correctly
- [ ] Verify bulk operations still work (New-NBIPAMAddress, Set-NBDCIMDevice, etc.)

Closes #316, closes #317, closes #318, closes #319

🤖 Generated with [Claude Code](https://claude.com/claude-code)