### PR TITLE
Eliminate duplicate API call and improve config state management

### DIFF
--- a/Functions/Setup/Support/SetupNetboxConfigVariable.ps1
+++ b/Functions/Setup/Support/SetupNetboxConfigVariable.ps1
@@ -10,10 +10,17 @@ function SetupNetboxConfigVariable {
         Write-Verbose "Creating Netbox Config hashtable"
         $script:NetboxConfig = @{
             'Connected'     = $false
-            'Choices'       = @{
-            }
+            'Hostname'      = $null
+            'Credential'    = $null
+            'HostScheme'    = $null
+            'HostPort'      = $null
+            'InvokeParams'  = $null
+            'Timeout'       = $null
+            'NetboxVersion' = $null
+            'ParsedVersion' = $null
+            'Choices'       = @{}
             'APIDefinition' = $null
-            'ContentTypes' = $null
+            'ContentTypes'  = $null
             'BranchStack'   = [System.Collections.Generic.Stack[object]]::new()
         }
     }


### PR DESCRIPTION
## Summary
- Reuse `VerifyAPIConnectivity` response in `Connect-NBAPI` instead of calling `Get-NBVersion` separately — both hit `/api/status/`, eliminating one API round trip on every connection
- Reset config state with `SetupNetboxConfigVariable -Overwrite` when version check fails, instead of only setting `Connected = $false` (prevents stale config values from a failed connection)
- Set `Connected = $false` on connectivity failure in the catch block
- Pre-initialize all expected config keys (`Hostname`, `Credential`, `HostScheme`, `HostPort`, `InvokeParams`, `Timeout`, `NetboxVersion`, `ParsedVersion`) in `SetupNetboxConfigVariable` for self-documenting config structure

## Test plan
- [ ] Run `Invoke-Pester ./Tests/` — all unit tests pass (1462 passed, 9 pre-existing workflow failures)
- [ ] Verify `Connect-NBAPI` still works with valid credentials
- [ ] Verify connection failure properly resets config state

Closes #313

🤖 Generated with [Claude Code](https://claude.com/claude-code)