### PR TITLE
test: Add 126 Omit parameter tests across 17 test files

### DIFF
--- a/Tests/Branching.Tests.ps1
+++ b/Tests/Branching.Tests.ps1
@@ -550,4 +550,20 @@ Describe "Branching Module Tests" -Tag 'Branching' {
         }
     }
     #endregion
+
+    #region Omit Parameter Tests
+    Context "Omit Parameter" {
+        $omitTestCases = @(
+            @{ Command = 'Get-NBBranch' }
+            @{ Command = 'Get-NBBranchEvent' }
+            @{ Command = 'Get-NBChangeDiff' }
+        )
+
+        It 'Should pass -Omit to query string for <Command>' -TestCases $omitTestCases {
+            param($Command)
+            $Result = & $Command -Omit @('comments', 'description')
+            $Result.Uri | Should -Match 'omit=comments%2Cdescription'
+        }
+    }
+    #endregion
 }

--- a/Tests/Branching.Tests.ps1
+++ b/Tests/Branching.Tests.ps1
@@ -562,7 +562,7 @@ Describe "Branching Module Tests" -Tag 'Branching' {
         It 'Should pass -Omit to query string for <Command>' -TestCases $omitTestCases {
             param($Command)
             $Result = & $Command -Omit @('comments', 'description')
-            $Result.Uri | Should -Match 'omit=comments%2Cdescription'
+            $Result.Uri | Should -Match 'omit=comments(%2C|,)description'
         }
     }
     #endregion

--- a/Tests/Circuits.Tests.ps1
+++ b/Tests/Circuits.Tests.ps1
@@ -716,4 +716,28 @@ Describe "Circuits Module Tests" -Tag 'Circuits' {
         }
     }
     #endregion
+
+    #region Omit Parameter Tests
+    Context "Omit Parameter" {
+        $omitTestCases = @(
+            @{ Command = 'Get-NBCircuit' }
+            @{ Command = 'Get-NBCircuitGroup' }
+            @{ Command = 'Get-NBCircuitGroupAssignment' }
+            @{ Command = 'Get-NBCircuitProvider' }
+            @{ Command = 'Get-NBCircuitProviderAccount' }
+            @{ Command = 'Get-NBCircuitProviderNetwork' }
+            @{ Command = 'Get-NBCircuitTermination' }
+            @{ Command = 'Get-NBCircuitType' }
+            @{ Command = 'Get-NBVirtualCircuit' }
+            @{ Command = 'Get-NBVirtualCircuitTermination' }
+            @{ Command = 'Get-NBVirtualCircuitType' }
+        )
+
+        It 'Should pass -Omit to query string for <Command>' -TestCases $omitTestCases {
+            param($Command)
+            $Result = & $Command -Omit @('comments', 'description')
+            $Result.Uri | Should -Match 'omit=comments%2Cdescription'
+        }
+    }
+    #endregion
 }

--- a/Tests/Core.Tests.ps1
+++ b/Tests/Core.Tests.ps1
@@ -307,4 +307,23 @@ Describe "Core Module Tests" -Tag 'Core' {
         }
     }
     #endregion
+
+    #region Omit Parameter Tests
+    Context "Omit Parameter" {
+        $omitTestCases = @(
+            @{ Command = 'Get-NBContentType' }
+            @{ Command = 'Get-NBDataFile' }
+            @{ Command = 'Get-NBDataSource' }
+            @{ Command = 'Get-NBJob' }
+            @{ Command = 'Get-NBObjectChange' }
+            @{ Command = 'Get-NBObjectType' }
+        )
+
+        It 'Should pass -Omit to query string for <Command>' -TestCases $omitTestCases {
+            param($Command)
+            $Result = & $Command -Omit @('comments', 'description')
+            $Result.Uri | Should -Match 'omit=comments%2Cdescription'
+        }
+    }
+    #endregion
 }

--- a/Tests/DCIM.Additional.Tests.ps1
+++ b/Tests/DCIM.Additional.Tests.ps1
@@ -1711,9 +1711,7 @@ Describe "DCIM Additional Tests" -Tag 'DCIM' {
         It 'Should pass -Omit to query string for <Command>' -TestCases $omitTestCases {
             param($Command, $Parameters)
             $splat = @{ Omit = @('comments', 'description') }
-            if ($Parameters) {
-                foreach ($key in $Parameters.Keys) { $splat[$key] = $Parameters[$key] }
-            }
+            if ($Parameters) { $splat += $Parameters }
             $Result = & $Command @splat
             $Result.Uri | Should -Match 'omit=comments%2Cdescription'
         }

--- a/Tests/DCIM.Additional.Tests.ps1
+++ b/Tests/DCIM.Additional.Tests.ps1
@@ -1674,4 +1674,49 @@ Describe "DCIM Additional Tests" -Tag 'DCIM' {
         }
     }
     #endregion
+
+    #region Omit Parameter Tests
+    Context "Omit Parameter" {
+        $omitTestCases = @(
+            @{ Command = 'Get-NBDCIMCable' }
+            @{ Command = 'Get-NBDCIMCableTermination' }
+            @{ Command = 'Get-NBDCIMConnectedDevice'; Parameters = @{ Peer_Device = 'switch01'; Peer_Interface = 'eth0' } }
+            @{ Command = 'Get-NBDCIMConsolePort' }
+            @{ Command = 'Get-NBDCIMConsoleServerPort' }
+            @{ Command = 'Get-NBDCIMDeviceBay' }
+            @{ Command = 'Get-NBDCIMFrontPort' }
+            @{ Command = 'Get-NBDCIMInventoryItem' }
+            @{ Command = 'Get-NBDCIMInventoryItemRole' }
+            @{ Command = 'Get-NBDCIMLocation' }
+            @{ Command = 'Get-NBDCIMMACAddress' }
+            @{ Command = 'Get-NBDCIMManufacturer' }
+            @{ Command = 'Get-NBDCIMModule' }
+            @{ Command = 'Get-NBDCIMModuleBay' }
+            @{ Command = 'Get-NBDCIMModuleType' }
+            @{ Command = 'Get-NBDCIMModuleTypeProfile' }
+            @{ Command = 'Get-NBDCIMPowerFeed' }
+            @{ Command = 'Get-NBDCIMPowerOutlet' }
+            @{ Command = 'Get-NBDCIMPowerPanel' }
+            @{ Command = 'Get-NBDCIMPowerPort' }
+            @{ Command = 'Get-NBDCIMRackReservation' }
+            @{ Command = 'Get-NBDCIMRackRole' }
+            @{ Command = 'Get-NBDCIMRackType' }
+            @{ Command = 'Get-NBDCIMRearPort' }
+            @{ Command = 'Get-NBDCIMRegion' }
+            @{ Command = 'Get-NBDCIMSiteGroup' }
+            @{ Command = 'Get-NBDCIMVirtualChassis' }
+            @{ Command = 'Get-NBDCIMVirtualDeviceContext' }
+        )
+
+        It 'Should pass -Omit to query string for <Command>' -TestCases $omitTestCases {
+            param($Command, $Parameters)
+            $splat = @{ Omit = @('comments', 'description') }
+            if ($Parameters) {
+                foreach ($key in $Parameters.Keys) { $splat[$key] = $Parameters[$key] }
+            }
+            $Result = & $Command @splat
+            $Result.Uri | Should -Match 'omit=comments%2Cdescription'
+        }
+    }
+    #endregion
 }

--- a/Tests/DCIM.Devices.Tests.ps1
+++ b/Tests/DCIM.Devices.Tests.ps1
@@ -448,4 +448,20 @@ Describe "DCIM Devices Tests" -Tag 'DCIM', 'Devices' {
         }
     }
     #endregion
+
+    #region Omit Parameter Tests
+    Context "Omit Parameter" {
+        $omitTestCases = @(
+            @{ Command = 'Get-NBDCIMDevice' }
+            @{ Command = 'Get-NBDCIMDeviceRole' }
+            @{ Command = 'Get-NBDCIMDeviceType' }
+        )
+
+        It 'Should pass -Omit to query string for <Command>' -TestCases $omitTestCases {
+            param($Command)
+            $Result = & $Command -Omit @('comments', 'description')
+            $Result.Uri | Should -Match 'omit=comments%2Cdescription'
+        }
+    }
+    #endregion
 }

--- a/Tests/DCIM.Interfaces.Tests.ps1
+++ b/Tests/DCIM.Interfaces.Tests.ps1
@@ -315,4 +315,19 @@ Describe "DCIM Interfaces Tests" -Tag 'DCIM', 'Interfaces' {
         }
     }
     #endregion
+
+    #region Omit Parameter Tests
+    Context "Omit Parameter" {
+        $omitTestCases = @(
+            @{ Command = 'Get-NBDCIMInterface' }
+            @{ Command = 'Get-NBDCIMInterfaceConnection' }
+        )
+
+        It 'Should pass -Omit to query string for <Command>' -TestCases $omitTestCases {
+            param($Command)
+            $Result = & $Command -Omit @('comments', 'description')
+            $Result.Uri | Should -Match 'omit=comments%2Cdescription'
+        }
+    }
+    #endregion
 }

--- a/Tests/DCIM.Platforms.Tests.ps1
+++ b/Tests/DCIM.Platforms.Tests.ps1
@@ -84,4 +84,18 @@ Describe "DCIM Platforms Tests" -Tag 'DCIM', 'platforms' {
         }
     }
     #endregion
+
+    #region Omit Parameter Tests
+    Context "Omit Parameter" {
+        $omitTestCases = @(
+            @{ Command = 'Get-NBDCIMPlatform' }
+        )
+
+        It 'Should pass -Omit to query string for <Command>' -TestCases $omitTestCases {
+            param($Command)
+            $Result = & $Command -Omit @('comments', 'description')
+            $Result.Uri | Should -Match 'omit=comments%2Cdescription'
+        }
+    }
+    #endregion
 }

--- a/Tests/DCIM.Racks.Tests.ps1
+++ b/Tests/DCIM.Racks.Tests.ps1
@@ -85,4 +85,18 @@ Describe "DCIM Racks Tests" -Tag 'DCIM', 'Racks' {
         }
     }
     #endregion
+
+    #region Omit Parameter Tests
+    Context "Omit Parameter" {
+        $omitTestCases = @(
+            @{ Command = 'Get-NBDCIMRack' }
+        )
+
+        It 'Should pass -Omit to query string for <Command>' -TestCases $omitTestCases {
+            param($Command)
+            $Result = & $Command -Omit @('comments', 'description')
+            $Result.Uri | Should -Match 'omit=comments%2Cdescription'
+        }
+    }
+    #endregion
 }

--- a/Tests/DCIM.Sites.Tests.ps1
+++ b/Tests/DCIM.Sites.Tests.ps1
@@ -116,4 +116,18 @@ Describe "DCIM Sites Tests" -Tag 'DCIM', 'Sites' {
         }
     }
     #endregion
+
+    #region Omit Parameter Tests
+    Context "Omit Parameter" {
+        $omitTestCases = @(
+            @{ Command = 'Get-NBDCIMSite' }
+        )
+
+        It 'Should pass -Omit to query string for <Command>' -TestCases $omitTestCases {
+            param($Command)
+            $Result = & $Command -Omit @('comments', 'description')
+            $Result.Uri | Should -Match 'omit=comments%2Cdescription'
+        }
+    }
+    #endregion
 }

--- a/Tests/DCIM.Templates.Tests.ps1
+++ b/Tests/DCIM.Templates.Tests.ps1
@@ -684,4 +684,27 @@ Describe "DCIM Template Functions" -Tag 'Build', 'DCIM' {
         }
     }
     #endregion
+
+    #region Omit Parameter Tests
+    Context "Omit Parameter" {
+        $omitTestCases = @(
+            @{ Command = 'Get-NBDCIMConsolePortTemplate' }
+            @{ Command = 'Get-NBDCIMConsoleServerPortTemplate' }
+            @{ Command = 'Get-NBDCIMDeviceBayTemplate' }
+            @{ Command = 'Get-NBDCIMFrontPortTemplate' }
+            @{ Command = 'Get-NBDCIMInterfaceTemplate' }
+            @{ Command = 'Get-NBDCIMInventoryItemTemplate' }
+            @{ Command = 'Get-NBDCIMModuleBayTemplate' }
+            @{ Command = 'Get-NBDCIMPowerOutletTemplate' }
+            @{ Command = 'Get-NBDCIMPowerPortTemplate' }
+            @{ Command = 'Get-NBDCIMRearPortTemplate' }
+        )
+
+        It 'Should pass -Omit to query string for <Command>' -TestCases $omitTestCases {
+            param($Command)
+            $Result = & $Command -Omit @('comments', 'description')
+            $Result.Uri | Should -Match 'omit=comments%2Cdescription'
+        }
+    }
+    #endregion
 }

--- a/Tests/Extras.Tests.ps1
+++ b/Tests/Extras.Tests.ps1
@@ -770,4 +770,29 @@ Describe "Extras Module Tests" -Tag 'Extras' {
         }
     }
     #endregion
+
+    #region Omit Parameter Tests
+    Context "Omit Parameter" {
+        $omitTestCases = @(
+            @{ Command = 'Get-NBBookmark' }
+            @{ Command = 'Get-NBConfigContext' }
+            @{ Command = 'Get-NBCustomField' }
+            @{ Command = 'Get-NBCustomFieldChoiceSet' }
+            @{ Command = 'Get-NBCustomLink' }
+            @{ Command = 'Get-NBEventRule' }
+            @{ Command = 'Get-NBExportTemplate' }
+            @{ Command = 'Get-NBImageAttachment' }
+            @{ Command = 'Get-NBJournalEntry' }
+            @{ Command = 'Get-NBSavedFilter' }
+            @{ Command = 'Get-NBTag' }
+            @{ Command = 'Get-NBWebhook' }
+        )
+
+        It 'Should pass -Omit to query string for <Command>' -TestCases $omitTestCases {
+            param($Command)
+            $Result = & $Command -Omit @('comments', 'description')
+            $Result.Uri | Should -Match 'omit=comments%2Cdescription'
+        }
+    }
+    #endregion
 }

--- a/Tests/IPAM.Tests.ps1
+++ b/Tests/IPAM.Tests.ps1
@@ -1110,9 +1110,7 @@ Describe "IPAM tests" -Tag 'Ipam' {
         It 'Should pass -Omit to query string for <Command>' -TestCases $omitTestCases {
             param($Command, $Parameters)
             $splat = @{ Omit = @('comments', 'description') }
-            if ($Parameters) {
-                foreach ($key in $Parameters.Keys) { $splat[$key] = $Parameters[$key] }
-            }
+            if ($Parameters) { $splat += $Parameters }
             $Result = & $Command @splat
             $Result.Uri | Should -Match 'omit=comments%2Cdescription'
         }

--- a/Tests/IPAM.Tests.ps1
+++ b/Tests/IPAM.Tests.ps1
@@ -1082,4 +1082,40 @@ Describe "IPAM tests" -Tag 'Ipam' {
         }
     }
     #endregion
+
+    #region Omit Parameter Tests
+    Context "Omit Parameter" {
+        $omitTestCases = @(
+            @{ Command = 'Get-NBIPAMAddress' }
+            @{ Command = 'Get-NBIPAMAddressRange' }
+            @{ Command = 'Get-NBIPAMAggregate' }
+            @{ Command = 'Get-NBIPAMASN' }
+            @{ Command = 'Get-NBIPAMASNRange' }
+            @{ Command = 'Get-NBIPAMAvailableIP'; Parameters = @{ Prefix_ID = 1 } }
+            @{ Command = 'Get-NBIPAMFHRPGroup' }
+            @{ Command = 'Get-NBIPAMFHRPGroupAssignment' }
+            @{ Command = 'Get-NBIPAMPrefix' }
+            @{ Command = 'Get-NBIPAMRIR' }
+            @{ Command = 'Get-NBIPAMRole' }
+            @{ Command = 'Get-NBIPAMRouteTarget' }
+            @{ Command = 'Get-NBIPAMService' }
+            @{ Command = 'Get-NBIPAMServiceTemplate' }
+            @{ Command = 'Get-NBIPAMVLAN' }
+            @{ Command = 'Get-NBIPAMVLANGroup' }
+            @{ Command = 'Get-NBIPAMVLANTranslationPolicy' }
+            @{ Command = 'Get-NBIPAMVLANTranslationRule' }
+            @{ Command = 'Get-NBIPAMVRF' }
+        )
+
+        It 'Should pass -Omit to query string for <Command>' -TestCases $omitTestCases {
+            param($Command, $Parameters)
+            $splat = @{ Omit = @('comments', 'description') }
+            if ($Parameters) {
+                foreach ($key in $Parameters.Keys) { $splat[$key] = $Parameters[$key] }
+            }
+            $Result = & $Command @splat
+            $Result.Uri | Should -Match 'omit=comments%2Cdescription'
+        }
+    }
+    #endregion
 }

--- a/Tests/Tenancy.Tests.ps1
+++ b/Tests/Tenancy.Tests.ps1
@@ -410,4 +410,22 @@ Describe "Tenancy Module Tests" -Tag 'Tenancy' {
         }
     }
     #endregion
+
+    #region Omit Parameter Tests
+    Context "Omit Parameter" {
+        $omitTestCases = @(
+            @{ Command = 'Get-NBContact' }
+            @{ Command = 'Get-NBContactAssignment' }
+            @{ Command = 'Get-NBContactRole' }
+            @{ Command = 'Get-NBTenant' }
+            @{ Command = 'Get-NBTenantGroup' }
+        )
+
+        It 'Should pass -Omit to query string for <Command>' -TestCases $omitTestCases {
+            param($Command)
+            $Result = & $Command -Omit @('comments', 'description')
+            $Result.Uri | Should -Match 'omit=comments%2Cdescription'
+        }
+    }
+    #endregion
 }

--- a/Tests/Users.Tests.ps1
+++ b/Tests/Users.Tests.ps1
@@ -707,4 +707,23 @@ Describe "Users Module Tests" -Tag 'Users' {
         }
     }
     #endregion
+
+    #region Omit Parameter Tests
+    Context "Omit Parameter" {
+        $omitTestCases = @(
+            @{ Command = 'Get-NBGroup' }
+            @{ Command = 'Get-NBOwner' }
+            @{ Command = 'Get-NBOwnerGroup' }
+            @{ Command = 'Get-NBPermission' }
+            @{ Command = 'Get-NBToken' }
+            @{ Command = 'Get-NBUser' }
+        )
+
+        It 'Should pass -Omit to query string for <Command>' -TestCases $omitTestCases {
+            param($Command)
+            $Result = & $Command -Omit @('comments', 'description')
+            $Result.Uri | Should -Match 'omit=comments%2Cdescription'
+        }
+    }
+    #endregion
 }

--- a/Tests/VPN.Tests.ps1
+++ b/Tests/VPN.Tests.ps1
@@ -543,4 +543,27 @@ Describe "VPN Module Tests" -Tag 'VPN' {
         }
     }
     #endregion
+
+    #region Omit Parameter Tests
+    Context "Omit Parameter" {
+        $omitTestCases = @(
+            @{ Command = 'Get-NBVPNIKEPolicy' }
+            @{ Command = 'Get-NBVPNIKEProposal' }
+            @{ Command = 'Get-NBVPNIPSecPolicy' }
+            @{ Command = 'Get-NBVPNIPSecProfile' }
+            @{ Command = 'Get-NBVPNIPSecProposal' }
+            @{ Command = 'Get-NBVPNL2VPN' }
+            @{ Command = 'Get-NBVPNL2VPNTermination' }
+            @{ Command = 'Get-NBVPNTunnel' }
+            @{ Command = 'Get-NBVPNTunnelGroup' }
+            @{ Command = 'Get-NBVPNTunnelTermination' }
+        )
+
+        It 'Should pass -Omit to query string for <Command>' -TestCases $omitTestCases {
+            param($Command)
+            $Result = & $Command -Omit @('comments', 'description')
+            $Result.Uri | Should -Match 'omit=comments%2Cdescription'
+        }
+    }
+    #endregion
 }

--- a/Tests/Virtualization.Tests.ps1
+++ b/Tests/Virtualization.Tests.ps1
@@ -645,4 +645,22 @@ Describe "Virtualization tests" -Tag 'Virtualization' {
         }
     }
     #endregion
+
+    #region Omit Parameter Tests
+    Context "Omit Parameter" {
+        $omitTestCases = @(
+            @{ Command = 'Get-NBVirtualizationCluster' }
+            @{ Command = 'Get-NBVirtualizationClusterGroup' }
+            @{ Command = 'Get-NBVirtualizationClusterType' }
+            @{ Command = 'Get-NBVirtualMachine' }
+            @{ Command = 'Get-NBVirtualMachineInterface' }
+        )
+
+        It 'Should pass -Omit to query string for <Command>' -TestCases $omitTestCases {
+            param($Command)
+            $Result = & $Command -Omit @('comments', 'description')
+            $Result.Uri | Should -Match 'omit=comments%2Cdescription'
+        }
+    }
+    #endregion
 }

--- a/Tests/Wireless.Tests.ps1
+++ b/Tests/Wireless.Tests.ps1
@@ -340,4 +340,20 @@ Describe "Wireless Module Tests" -Tag 'Wireless' {
         }
     }
     #endregion
+
+    #region Omit Parameter Tests
+    Context "Omit Parameter" {
+        $omitTestCases = @(
+            @{ Command = 'Get-NBWirelessLAN' }
+            @{ Command = 'Get-NBWirelessLANGroup' }
+            @{ Command = 'Get-NBWirelessLink' }
+        )
+
+        It 'Should pass -Omit to query string for <Command>' -TestCases $omitTestCases {
+            param($Command)
+            $Result = & $Command -Omit @('comments', 'description')
+            $Result.Uri | Should -Match 'omit=comments%2Cdescription'
+        }
+    }
+    #endregion
 }


### PR DESCRIPTION
## Summary

- Add data-driven `-TestCases` tests verifying `-Omit` parameter passes through to query string as `?omit=field1%2Cfield2`
- **126 Get functions** tested across **17 test files** covering all modules
- Uses same pattern as P1.1 WhatIf tests (Pester data-driven `$omitTestCases`)
- Special handling for functions with mandatory parameters (ConnectedDevice, AvailableIP)
- Skips `Get-NBDCIMRackElevation` (builds params manually, doesn't use BuildURIComponents)

| Test File | Functions Tested |
|-----------|-----------------|
| DCIM.Sites | 1 |
| DCIM.Devices | 3 |
| DCIM.Racks | 1 |
| DCIM.Interfaces | 2 |
| DCIM.Platforms | 1 |
| DCIM.Templates | 10 |
| DCIM.Additional | 28 |
| IPAM | 19 |
| Circuits | 11 |
| Tenancy | 5 |
| Virtualization | 5 |
| VPN | 10 |
| Wireless | 3 |
| Extras | 12 |
| Users | 6 |
| Core | 6 |
| Branching | 3 |
| **Total** | **126** |

Part of #324 P1.2

## Test plan

- [x] All 1365 tests pass locally (0 failures)
- [ ] CI passes on all platforms (Ubuntu, macOS, Windows PS 7, Windows PS 5.1)
- [ ] CI passes on all Netbox versions (4.3.7, 4.4.10, 4.5.2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)