### PR TITLE
ci: Add code coverage threshold enforcement at 70%

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,7 +65,7 @@ jobs:
         run: |
           $config = New-PesterConfiguration
           $config.Run.Path = './Tests/*.Tests.ps1'
-          $config.Run.Exit = $true
+          $config.Run.PassThru = $true
           $config.Filter.ExcludeTag = @('Integration', 'Live')
           $config.TestResult.Enabled = $true
           $config.TestResult.OutputPath = 'TestResults.xml'
@@ -73,10 +73,30 @@ jobs:
           $config.Output.Verbosity = 'Detailed'
           # Code coverage configuration
           $config.CodeCoverage.Enabled = $true
-          $config.CodeCoverage.Path = @('./Functions/')
+          $config.CodeCoverage.Path = @('./PowerNetbox/PowerNetbox.psm1')
           $config.CodeCoverage.OutputPath = 'coverage.xml'
           $config.CodeCoverage.OutputFormat = 'JaCoCo'
-          Invoke-Pester -Configuration $config
+          $config.CodeCoverage.CoveragePercentTarget = 70
+          $config.CodeCoverage.UseBreakpoints = $false
+
+          $result = Invoke-Pester -Configuration $config
+
+          # Fail on test failures
+          if ($result.FailedCount -gt 0) {
+              Write-Error "$($result.FailedCount) test(s) failed"
+              exit 1
+          }
+
+          # Enforce coverage threshold on Linux runner (single canonical measurement)
+          if ($env:RUNNER_OS -eq 'Linux') {
+              $coverage = [math]::Round($result.CodeCoverage.CoveragePercent, 2)
+              Write-Host "Code coverage: $coverage% (threshold: 70%)"
+              if ($coverage -lt 70) {
+                  Write-Error "Code coverage ($coverage%) is below the 70% threshold"
+                  exit 1
+              }
+              Write-Host "Coverage threshold passed"
+          }
 
       - name: Run Pester tests (powershell)
         if: '!matrix.pwsh'
@@ -90,11 +110,8 @@ jobs:
           $config.TestResult.OutputPath = 'TestResults.xml'
           $config.TestResult.OutputFormat = 'NUnitXml'
           $config.Output.Verbosity = 'Detailed'
-          # Code coverage configuration
-          $config.CodeCoverage.Enabled = $true
-          $config.CodeCoverage.Path = @('./Functions/')
-          $config.CodeCoverage.OutputPath = 'coverage.xml'
-          $config.CodeCoverage.OutputFormat = 'JaCoCo'
+          # Code coverage disabled on PS 5.1: profiler requires PS 7+,
+          # and breakpoint-based coverage is too slow on 40K-line built module
           Invoke-Pester -Configuration $config
 
       - name: Upload test results
@@ -107,9 +124,9 @@ jobs:
 
       - name: Upload coverage report
         uses: actions/upload-artifact@v4
-        if: always()
+        if: always() && matrix.pwsh
         with:
-          name: coverage-${{ matrix.os }}-${{ matrix.pwsh && 'pwsh' || 'ps51' }}
+          name: coverage-${{ matrix.os }}
           path: coverage.xml
           retention-days: 30
 


### PR DESCRIPTION
## Summary

- **Fix coverage path**: `./Functions/` -> `./PowerNetbox/PowerNetbox.psm1` — tests load the built (concatenated) module, not individual source files. Coverage was always 0% with the old path.
- **Profiler-based coverage**: Use `UseBreakpoints=$false` for ~20x faster coverage analysis on the 40K-line built module (~60s vs 20+ minutes)
- **70% threshold enforcement** on Ubuntu runner — fails the build if coverage drops below 70%
- **Switch pwsh step** from `Run.Exit` to `Run.PassThru` to enable post-run coverage checks
- **Disable coverage on PS 5.1**: profiler requires PS 7+, breakpoint-based coverage too slow on large module

### Current coverage: 91.07%
- 6,101 commands analyzed
- 5,556 commands executed
- 545 commands missed

Part of #324 (P1.3 code coverage thresholds)