### PR TITLE
test: Setup test isolation + Get-NBAPIDefinition tests

### DIFF
--- a/Tests/Setup.Tests.ps1
+++ b/Tests/Setup.Tests.ps1
@@ -331,6 +331,7 @@ Describe "Setup tests" -Tag 'Core', 'Setup' {
 
         It "Should support YAML format" {
             $Result = Get-NBAPIDefinition -Format 'yaml'
+            $Result.Uri | Should -Match '/api/schema/'
             $Result.Uri | Should -Match 'format=yaml'
         }
     }


### PR DESCRIPTION
## Summary
- **P2.3**: Add 2 tests for `Get-NBAPIDefinition` — the last untested public function (JSON default + YAML format)
- **P2.4**: Fix test isolation in `Setup.Tests.ps1` — hostname/credential empty-state tests now use explicit `InModuleScope` state reset instead of relying on execution order. Combined set/get tests into atomic blocks matching existing HostPort/HostScheme/Timeout pattern.

Addresses #324 (partial — P2.3 + P2.4)

## Test plan
- [x] All 1983 unit tests pass locally
- [x] Setup.Tests.ps1 passes with 25 tests (23 original restructured + 2 new)
- [x] Tests are order-independent (verified by running in isolation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)