### PR TITLE
test: Add 14 representative pipeline input tests

### DIFF
--- a/Tests/Circuits.Tests.ps1
+++ b/Tests/Circuits.Tests.ps1
@@ -777,4 +777,18 @@ Describe "Circuits Module Tests" -Tag 'Circuits' {
         }
     }
     #endregion
+
+    #region Pipeline Input Tests
+    Context "Pipeline Input" {
+        $pipelineTestCases = @(
+            @{ Command = 'Get-NBCircuitType' }
+        )
+
+        It 'Should accept pipeline input by property name for <Command>' -TestCases $pipelineTestCases {
+            param($Command)
+            $Result = [pscustomobject]@{ 'Id' = 10 } | & $Command
+            $Result.Uri | Should -Match '/10/'
+        }
+    }
+    #endregion
 }

--- a/Tests/DCIM.Additional.Tests.ps1
+++ b/Tests/DCIM.Additional.Tests.ps1
@@ -1772,4 +1772,20 @@ Describe "DCIM Additional Tests" -Tag 'DCIM' {
         }
     }
     #endregion
+
+    #region Pipeline Input Tests
+    Context "Pipeline Input" {
+        $pipelineTestCases = @(
+            @{ Command = 'Get-NBDCIMSite' }
+            @{ Command = 'Get-NBDCIMCable' }
+            @{ Command = 'Get-NBDCIMManufacturer' }
+        )
+
+        It 'Should accept pipeline input by property name for <Command>' -TestCases $pipelineTestCases {
+            param($Command)
+            $Result = [pscustomobject]@{ 'Id' = 10 } | & $Command
+            $Result.Uri | Should -Match '/10/'
+        }
+    }
+    #endregion
 }

--- a/Tests/DCIM.Templates.Tests.ps1
+++ b/Tests/DCIM.Templates.Tests.ps1
@@ -744,4 +744,18 @@ Describe "DCIM Template Functions" -Tag 'Build', 'DCIM' {
         }
     }
     #endregion
+
+    #region Pipeline Input Tests
+    Context "Pipeline Input" {
+        $pipelineTestCases = @(
+            @{ Command = 'Get-NBDCIMConsolePortTemplate' }
+        )
+
+        It 'Should accept pipeline input by property name for <Command>' -TestCases $pipelineTestCases {
+            param($Command)
+            $Result = [pscustomobject]@{ 'Id' = 10 } | & $Command
+            $Result.Uri | Should -Match '/10/'
+        }
+    }
+    #endregion
 }

--- a/Tests/Extras.Tests.ps1
+++ b/Tests/Extras.Tests.ps1
@@ -833,4 +833,19 @@ Describe "Extras Module Tests" -Tag 'Extras' {
         }
     }
     #endregion
+
+    #region Pipeline Input Tests
+    Context "Pipeline Input" {
+        $pipelineTestCases = @(
+            @{ Command = 'Get-NBTag' }
+            @{ Command = 'Get-NBCustomField' }
+        )
+
+        It 'Should accept pipeline input by property name for <Command>' -TestCases $pipelineTestCases {
+            param($Command)
+            $Result = [pscustomobject]@{ 'Id' = 10 } | & $Command
+            $Result.Uri | Should -Match '/10/'
+        }
+    }
+    #endregion
 }

--- a/Tests/IPAM.Tests.ps1
+++ b/Tests/IPAM.Tests.ps1
@@ -1161,4 +1161,19 @@ Describe "IPAM tests" -Tag 'Ipam' {
         }
     }
     #endregion
+
+    #region Pipeline Input Tests
+    Context "Pipeline Input" {
+        $pipelineTestCases = @(
+            @{ Command = 'Get-NBIPAMAddress' }
+            @{ Command = 'Get-NBIPAMVLAN' }
+        )
+
+        It 'Should accept pipeline input by property name for <Command>' -TestCases $pipelineTestCases {
+            param($Command)
+            $Result = [pscustomobject]@{ 'Id' = 10 } | & $Command
+            $Result.Uri | Should -Match '/10/'
+        }
+    }
+    #endregion
 }

--- a/Tests/Tenancy.Tests.ps1
+++ b/Tests/Tenancy.Tests.ps1
@@ -460,4 +460,18 @@ Describe "Tenancy Module Tests" -Tag 'Tenancy' {
         }
     }
     #endregion
+
+    #region Pipeline Input Tests
+    Context "Pipeline Input" {
+        $pipelineTestCases = @(
+            @{ Command = 'Get-NBTenant' }
+        )
+
+        It 'Should accept pipeline input by property name for <Command>' -TestCases $pipelineTestCases {
+            param($Command)
+            $Result = [pscustomobject]@{ 'Id' = 10 } | & $Command
+            $Result.Uri | Should -Match '/10/'
+        }
+    }
+    #endregion
 }

--- a/Tests/Users.Tests.ps1
+++ b/Tests/Users.Tests.ps1
@@ -759,4 +759,18 @@ Describe "Users Module Tests" -Tag 'Users' {
         }
     }
     #endregion
+
+    #region Pipeline Input Tests
+    Context "Pipeline Input" {
+        $pipelineTestCases = @(
+            @{ Command = 'Get-NBUser' }
+        )
+
+        It 'Should accept pipeline input by property name for <Command>' -TestCases $pipelineTestCases {
+            param($Command)
+            $Result = [pscustomobject]@{ 'Id' = 10 } | & $Command
+            $Result.Uri | Should -Match '/10/'
+        }
+    }
+    #endregion
 }

--- a/Tests/VPN.Tests.ps1
+++ b/Tests/VPN.Tests.ps1
@@ -601,4 +601,18 @@ Describe "VPN Module Tests" -Tag 'VPN' {
         }
     }
     #endregion
+
+    #region Pipeline Input Tests
+    Context "Pipeline Input" {
+        $pipelineTestCases = @(
+            @{ Command = 'Get-NBVPNTunnel' }
+        )
+
+        It 'Should accept pipeline input by property name for <Command>' -TestCases $pipelineTestCases {
+            param($Command)
+            $Result = [pscustomobject]@{ 'Id' = 10 } | & $Command
+            $Result.Uri | Should -Match '/10/'
+        }
+    }
+    #endregion
 }

--- a/Tests/Virtualization.Tests.ps1
+++ b/Tests/Virtualization.Tests.ps1
@@ -695,4 +695,18 @@ Describe "Virtualization tests" -Tag 'Virtualization' {
         }
     }
     #endregion
+
+    #region Pipeline Input Tests
+    Context "Pipeline Input" {
+        $pipelineTestCases = @(
+            @{ Command = 'Get-NBVirtualMachine' }
+        )
+
+        It 'Should accept pipeline input by property name for <Command>' -TestCases $pipelineTestCases {
+            param($Command)
+            $Result = [pscustomobject]@{ 'Id' = 10 } | & $Command
+            $Result.Uri | Should -Match '/10/'
+        }
+    }
+    #endregion
 }

--- a/Tests/Wireless.Tests.ps1
+++ b/Tests/Wireless.Tests.ps1
@@ -386,4 +386,18 @@ Describe "Wireless Module Tests" -Tag 'Wireless' {
         }
     }
     #endregion
+
+    #region Pipeline Input Tests
+    Context "Pipeline Input" {
+        $pipelineTestCases = @(
+            @{ Command = 'Get-NBWirelessLANGroup' }
+        )
+
+        It 'Should accept pipeline input by property name for <Command>' -TestCases $pipelineTestCases {
+            param($Command)
+            $Result = [pscustomobject]@{ 'Id' = 10 } | & $Command
+            $Result.Uri | Should -Match '/10/'
+        }
+    }
+    #endregion
 }


### PR DESCRIPTION
## Summary
- Add 14 data-driven pipeline input tests across 10 modules, verifying `ValueFromPipelineByPropertyName` on `$Id` works correctly for representative Get functions
- Functions tested: Site, Cable, Manufacturer, ConsolePortTemplate, CircuitType, Tag, CustomField, IPAMAddress, VLAN, Tenant, User, VPNTunnel, VirtualMachine, WirelessLANGroup
- Uses consistent pattern: pipe `[pscustomobject]@{ 'Id' = 10 }` and verify URI contains `/10/`

Addresses #324 (partial — P3.1)

## Test plan
- [x] All 1997 unit tests pass locally (1983 + 14 new)
- [x] Pattern matches existing pipeline tests in DCIM.Devices and DCIM.Interfaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)