### PR TITLE
test: standardize -Force to -Confirm:$false in unit tests

### DIFF
--- a/Tests/Circuits.Tests.ps1
+++ b/Tests/Circuits.Tests.ps1
@@ -81,7 +81,7 @@ Describe "Circuits Module Tests" -Tag 'Circuits' {
 
     Context "New-NBCircuit" {
         It "Should create a circuit" {
-            $Result = New-NBCircuit -Cid 'CIR-001' -Provider 1 -Type 1 -Status 'active' -Force
+            $Result = New-NBCircuit -Cid 'CIR-001' -Provider 1 -Type 1 -Status 'active' -Confirm:$false
             $Result.Method | Should -Be 'POST'
             $Result.Uri | Should -Be 'https://netbox.domain.com/api/circuits/circuits/'
             $bodyObj = $Result.Body | ConvertFrom-Json
@@ -92,13 +92,13 @@ Describe "Circuits Module Tests" -Tag 'Circuits' {
         }
 
         It "Should create a circuit with commit rate" {
-            $Result = New-NBCircuit -Cid 'CIR-002' -Provider 1 -Type 1 -Status 'active' -Commit_Rate 1000 -Force
+            $Result = New-NBCircuit -Cid 'CIR-002' -Provider 1 -Type 1 -Status 'active' -Commit_Rate 1000 -Confirm:$false
             $bodyObj = $Result.Body | ConvertFrom-Json
             $bodyObj.commit_rate | Should -Be 1000
         }
 
         It "Should create a circuit with description" {
-            $Result = New-NBCircuit -Cid 'CIR-003' -Provider 1 -Type 1 -Status 'active' -Description 'Test circuit' -Force
+            $Result = New-NBCircuit -Cid 'CIR-003' -Provider 1 -Type 1 -Status 'active' -Description 'Test circuit' -Confirm:$false
             $bodyObj = $Result.Body | ConvertFrom-Json
             $bodyObj.description | Should -Be 'Test circuit'
         }

--- a/Tests/DCIM.Devices.Tests.ps1
+++ b/Tests/DCIM.Devices.Tests.ps1
@@ -320,7 +320,7 @@ Describe "DCIM Devices Tests" -Tag 'DCIM', 'Devices' {
         }
 
         It "Should set a device to a new name" {
-            $Result = Set-NBDCIMDevice -Id 1234 -Name 'newtestname' -Force
+            $Result = Set-NBDCIMDevice -Id 1234 -Name 'newtestname' -Confirm:$false
 
             # Uses Id directly without fetching device first (performance optimization #177)
             $Result.Method | Should -Be 'PATCH'
@@ -329,7 +329,7 @@ Describe "DCIM Devices Tests" -Tag 'DCIM', 'Devices' {
         }
 
         It "Should set a device with new properties" {
-            $Result = Set-NBDCIMDevice -Id 1234 -Name 'newtestname' -Cluster 10 -Platform 20 -Site 15 -Force
+            $Result = Set-NBDCIMDevice -Id 1234 -Name 'newtestname' -Cluster 10 -Platform 20 -Site 15 -Confirm:$false
 
             $Result.Method | Should -Be 'PATCH'
             $Result.URI | Should -Be 'https://netbox.domain.com/api/dcim/devices/1234/'
@@ -356,7 +356,7 @@ Describe "DCIM Devices Tests" -Tag 'DCIM', 'Devices' {
         }
 
         It "Should remove a device" {
-            $Result = Remove-NBDCIMDevice -Id 10 -Force
+            $Result = Remove-NBDCIMDevice -Id 10 -Confirm:$false
 
             $Result.Method | Should -Be 'DELETE'
             $Result.URI | Should -Be 'https://netbox.domain.com/api/dcim/devices/10/'
@@ -376,7 +376,7 @@ Describe "DCIM Devices Tests" -Tag 'DCIM', 'Devices' {
                 [pscustomobject]@{ 'Id' = 30 },
                 [pscustomobject]@{ 'Id' = 31 }
             )
-            $items | Remove-NBDCIMDevice -Force
+            $items | Remove-NBDCIMDevice -Confirm:$false
 
             # Verify InvokeNetboxRequest was called with DELETE and the bulk endpoint
             Should -Invoke -CommandName "InvokeNetboxRequest" -ModuleName PowerNetbox -ParameterFilter {

--- a/Tests/DCIM.Interfaces.Tests.ps1
+++ b/Tests/DCIM.Interfaces.Tests.ps1
@@ -180,7 +180,7 @@ Describe "DCIM Interfaces Tests" -Tag 'DCIM', 'Interfaces' {
         }
 
         It "Should remove an interface" {
-            $Result = Remove-NBDCIMInterface -Id 10 -Force
+            $Result = Remove-NBDCIMInterface -Id 10 -Confirm:$false
             $Result.Method | Should -Be 'DELETE'
             $Result.URI | Should -Be 'https://netbox.domain.com/api/dcim/interfaces/10/'
         }
@@ -190,7 +190,7 @@ Describe "DCIM Interfaces Tests" -Tag 'DCIM', 'Interfaces' {
             $Result = @(
                 [pscustomobject]@{ 'Id' = 10 },
                 [pscustomobject]@{ 'Id' = 12 }
-            ) | Remove-NBDCIMInterface -Force
+            ) | Remove-NBDCIMInterface -Confirm:$false
             $Result.Method | Should -Be 'DELETE', 'DELETE'
             $Result.URI | Should -Be 'https://netbox.domain.com/api/dcim/interfaces/10/', 'https://netbox.domain.com/api/dcim/interfaces/12/'
         }
@@ -199,7 +199,7 @@ Describe "DCIM Interfaces Tests" -Tag 'DCIM', 'Interfaces' {
             $Result = @(
                 [pscustomobject]@{ 'Id' = 30 },
                 [pscustomobject]@{ 'Id' = 40 }
-            ) | Remove-NBDCIMInterface -Force
+            ) | Remove-NBDCIMInterface -Confirm:$false
             $Result.Method | Should -Be 'DELETE', 'DELETE'
             $Result.URI | Should -Be 'https://netbox.domain.com/api/dcim/interfaces/30/', 'https://netbox.domain.com/api/dcim/interfaces/40/'
         }
@@ -259,7 +259,7 @@ Describe "DCIM Interfaces Tests" -Tag 'DCIM', 'Interfaces' {
         }
 
         It "Should set an interface connection" {
-            $Result = Set-NBDCIMInterfaceConnection -Id 123 -Interface_B 2 -Force
+            $Result = Set-NBDCIMInterfaceConnection -Id 123 -Interface_B 2 -Confirm:$false
             $Result.Method | Should -Be 'PATCH'
             $Result.Uri | Should -BeExactly 'https://netbox.domain.com/api/dcim/interface-connections/123/'
             $Result.Body | Should -Be '{"interface_b":2}'
@@ -267,7 +267,7 @@ Describe "DCIM Interfaces Tests" -Tag 'DCIM', 'Interfaces' {
 
         It "Should throw when trying to set multiple connections" {
             # Set- functions only accept single Id; this test verifies the validation works
-            { Set-NBDCIMInterfaceConnection -Id 456, 789 -Interface_B 22 -Force } | Should -Throw
+            { Set-NBDCIMInterfaceConnection -Id 456, 789 -Interface_B 22 -Confirm:$false } | Should -Throw
         }
     }
 
@@ -279,7 +279,7 @@ Describe "DCIM Interfaces Tests" -Tag 'DCIM', 'Interfaces' {
         }
 
         It "Should remove an interface connection" {
-            $Result = Remove-NBDCIMInterfaceConnection -Id 10 -Force
+            $Result = Remove-NBDCIMInterfaceConnection -Id 10 -Confirm:$false
             $Result.Method | Should -Be 'DELETE'
             $Result.URI | Should -Be 'https://netbox.domain.com/api/dcim/interface-connections/10/'
         }
@@ -289,7 +289,7 @@ Describe "DCIM Interfaces Tests" -Tag 'DCIM', 'Interfaces' {
             $Result = @(
                 [pscustomobject]@{ 'Id' = 10 },
                 [pscustomobject]@{ 'Id' = 12 }
-            ) | Remove-NBDCIMInterfaceConnection -Force
+            ) | Remove-NBDCIMInterfaceConnection -Confirm:$false
             $Result.Method | Should -Be 'DELETE', 'DELETE'
             $Result.URI | Should -Be 'https://netbox.domain.com/api/dcim/interface-connections/10/', 'https://netbox.domain.com/api/dcim/interface-connections/12/'
         }

--- a/Tests/DCIM.Racks.Tests.ps1
+++ b/Tests/DCIM.Racks.Tests.ps1
@@ -54,7 +54,7 @@ Describe "DCIM Racks Tests" -Tag 'DCIM', 'Racks' {
 
     Context "Set-NBDCIMRack" {
         It "Should update a rack" {
-            $Result = Set-NBDCIMRack -Id 1 -Name 'UpdatedRack' -Force
+            $Result = Set-NBDCIMRack -Id 1 -Name 'UpdatedRack' -Confirm:$false
             $Result.Method | Should -Be 'PATCH'
             $Result.URI | Should -Be 'https://netbox.domain.com/api/dcim/racks/1/'
         }
@@ -62,7 +62,7 @@ Describe "DCIM Racks Tests" -Tag 'DCIM', 'Racks' {
 
     Context "Remove-NBDCIMRack" {
         It "Should remove a rack" {
-            $Result = Remove-NBDCIMRack -Id 10 -Force
+            $Result = Remove-NBDCIMRack -Id 10 -Confirm:$false
             $Result.Method | Should -Be 'DELETE'
             $Result.URI | Should -Be 'https://netbox.domain.com/api/dcim/racks/10/'
         }

--- a/Tests/DCIM.Sites.Tests.ps1
+++ b/Tests/DCIM.Sites.Tests.ps1
@@ -81,7 +81,7 @@ Describe "DCIM Sites Tests" -Tag 'DCIM', 'Sites' {
         }
 
         It "Should update a site" {
-            $Result = Set-NBDCIMSite -Id 1 -Name 'UpdatedSite' -Force
+            $Result = Set-NBDCIMSite -Id 1 -Name 'UpdatedSite' -Confirm:$false
             # Performance optimization: no longer fetches the object before updating
             Should -Invoke -CommandName 'Get-NBDCIMSite' -Times 0 -Exactly -Scope 'It' -ModuleName 'PowerNetbox'
             $Result.Method | Should -Be 'PATCH'

--- a/Tests/IPAM.Tests.ps1
+++ b/Tests/IPAM.Tests.ps1
@@ -96,13 +96,13 @@ Describe "IPAM tests" -Tag 'Ipam' {
         }
 
         It "Should update an IP address" {
-            $Result = Set-NBIPAMAddress -Id 4109 -Status 'reserved' -Force
+            $Result = Set-NBIPAMAddress -Id 4109 -Status 'reserved' -Confirm:$false
             $Result.Method | Should -Be 'PATCH'
             $Result.Uri | Should -Be 'https://netbox.domain.com/api/ipam/ip-addresses/4109/'
         }
 
         It "Should update IP with VRF and Tenant" {
-            $Result = Set-NBIPAMAddress -Id 4110 -VRF 10 -Tenant 14 -Description 'Test' -Force
+            $Result = Set-NBIPAMAddress -Id 4110 -VRF 10 -Tenant 14 -Description 'Test' -Confirm:$false
             $bodyObj = $Result.Body | ConvertFrom-Json
             $bodyObj.vrf | Should -Be 10
             $bodyObj.tenant | Should -Be 14
@@ -117,7 +117,7 @@ Describe "IPAM tests" -Tag 'Ipam' {
         }
 
         It "Should remove an IP address" {
-            $Result = Remove-NBIPAMAddress -Id 4109 -Force
+            $Result = Remove-NBIPAMAddress -Id 4109 -Confirm:$false
             $Result.Method | Should -Be 'DELETE'
             $Result.Uri | Should -Be 'https://netbox.domain.com/api/ipam/ip-addresses/4109/'
         }
@@ -189,7 +189,7 @@ Describe "IPAM tests" -Tag 'Ipam' {
         }
 
         It "Should update a prefix" {
-            $Result = Set-NBIPAMPrefix -Id 1 -Description 'Updated' -Force
+            $Result = Set-NBIPAMPrefix -Id 1 -Description 'Updated' -Confirm:$false
             $Result.Method | Should -Be 'PATCH'
             $Result.Uri | Should -Match '/api/ipam/prefixes/1/'
         }

--- a/Tests/Tenancy.Tests.ps1
+++ b/Tests/Tenancy.Tests.ps1
@@ -91,7 +91,7 @@ Describe "Tenancy Module Tests" -Tag 'Tenancy' {
         }
 
         It "Should update a tenant" {
-            $Result = Set-NBTenant -Id 1 -Name 'UpdatedTenant' -Force
+            $Result = Set-NBTenant -Id 1 -Name 'UpdatedTenant' -Confirm:$false
             $Result.Method | Should -Be 'PATCH'
             $Result.URI | Should -Be 'https://netbox.domain.com/api/tenancy/tenants/1/'
             $bodyObj = $Result.Body | ConvertFrom-Json
@@ -99,7 +99,7 @@ Describe "Tenancy Module Tests" -Tag 'Tenancy' {
         }
 
         It "Should update a tenant description" {
-            $Result = Set-NBTenant -Id 1 -Description 'New description' -Force
+            $Result = Set-NBTenant -Id 1 -Description 'New description' -Confirm:$false
             $bodyObj = $Result.Body | ConvertFrom-Json
             $bodyObj.description | Should -Be 'New description'
         }
@@ -113,7 +113,7 @@ Describe "Tenancy Module Tests" -Tag 'Tenancy' {
         }
 
         It "Should remove a tenant" {
-            $Result = Remove-NBTenant -Id 10 -Force
+            $Result = Remove-NBTenant -Id 10 -Confirm:$false
             $Result.Method | Should -Be 'DELETE'
             $Result.URI | Should -Be 'https://netbox.domain.com/api/tenancy/tenants/10/'
         }
@@ -123,7 +123,7 @@ Describe "Tenancy Module Tests" -Tag 'Tenancy' {
             $Result = @(
                 [pscustomobject]@{ 'Id' = 10 },
                 [pscustomobject]@{ 'Id' = 11 }
-            ) | Remove-NBTenant -Force
+            ) | Remove-NBTenant -Confirm:$false
             $Result.Method | Should -Be 'DELETE', 'DELETE'
         }
     }
@@ -178,7 +178,7 @@ Describe "Tenancy Module Tests" -Tag 'Tenancy' {
         }
 
         It "Should update a tenant group" {
-            $Result = Set-NBTenantGroup -Id 1 -Name 'UpdatedGroup' -Force
+            $Result = Set-NBTenantGroup -Id 1 -Name 'UpdatedGroup' -Confirm:$false
             $Result.Method | Should -Be 'PATCH'
             $Result.URI | Should -Be 'https://netbox.domain.com/api/tenancy/tenant-groups/1/'
         }
@@ -192,7 +192,7 @@ Describe "Tenancy Module Tests" -Tag 'Tenancy' {
         }
 
         It "Should remove a tenant group" {
-            $Result = Remove-NBTenantGroup -Id 5 -Force
+            $Result = Remove-NBTenantGroup -Id 5 -Confirm:$false
             $Result.Method | Should -Be 'DELETE'
             $Result.URI | Should -Be 'https://netbox.domain.com/api/tenancy/tenant-groups/5/'
         }
@@ -237,13 +237,13 @@ Describe "Tenancy Module Tests" -Tag 'Tenancy' {
 
     Context "Set-NBContact" {
         It "Should update a contact" {
-            $Result = Set-NBContact -Id 1 -Name 'Updated Name' -Force
+            $Result = Set-NBContact -Id 1 -Name 'Updated Name' -Confirm:$false
             $Result.Method | Should -Be 'PATCH'
             $Result.URI | Should -Be 'https://netbox.domain.com/api/tenancy/contacts/1/'
         }
 
         It "Should update contact email" {
-            $Result = Set-NBContact -Id 1 -Email 'new@example.com' -Force
+            $Result = Set-NBContact -Id 1 -Email 'new@example.com' -Confirm:$false
             $bodyObj = $Result.Body | ConvertFrom-Json
             $bodyObj.email | Should -Be 'new@example.com'
         }
@@ -257,7 +257,7 @@ Describe "Tenancy Module Tests" -Tag 'Tenancy' {
         }
 
         It "Should remove a contact" {
-            $Result = Remove-NBContact -Id 8 -Force
+            $Result = Remove-NBContact -Id 8 -Confirm:$false
             $Result.Method | Should -Be 'DELETE'
             $Result.URI | Should -Be 'https://netbox.domain.com/api/tenancy/contacts/8/'
         }
@@ -318,7 +318,7 @@ Describe "Tenancy Module Tests" -Tag 'Tenancy' {
         }
 
         It "Should remove a contact role" {
-            $Result = Remove-NBContactRole -Id 3 -Force
+            $Result = Remove-NBContactRole -Id 3 -Confirm:$false
             $Result.Method | Should -Be 'DELETE'
             $Result.URI | Should -Be 'https://netbox.domain.com/api/tenancy/contact-roles/3/'
         }
@@ -374,7 +374,7 @@ Describe "Tenancy Module Tests" -Tag 'Tenancy' {
         }
 
         It "Should remove a contact assignment" {
-            $Result = Remove-NBContactAssignment -Id 6 -Force
+            $Result = Remove-NBContactAssignment -Id 6 -Confirm:$false
             $Result.Method | Should -Be 'DELETE'
             $Result.URI | Should -Be 'https://netbox.domain.com/api/tenancy/contact-assignments/6/'
         }

--- a/Tests/Virtualization.Tests.ps1
+++ b/Tests/Virtualization.Tests.ps1
@@ -329,7 +329,7 @@ Describe "Virtualization tests" -Tag 'Virtualization' {
 
     Context "Set-NBVirtualMachine" {
         It "Should set a VM to a new name" {
-            $Result = Set-NBVirtualMachine -Id 1234 -Name 'newtestname' -Force
+            $Result = Set-NBVirtualMachine -Id 1234 -Name 'newtestname' -Confirm:$false
             # Set-NBVirtualMachine no longer calls Get-NBVirtualMachine (optimized)
             $Result.Method | Should -Be 'PATCH'
             $Result.URI | Should -Be 'https://netbox.domain.com/api/virtualization/virtual-machines/1234/'
@@ -337,7 +337,7 @@ Describe "Virtualization tests" -Tag 'Virtualization' {
         }
 
         It "Should set a VM with a new name, cluster, platform, and status" {
-            $Result = Set-NBVirtualMachine -Id 1234 -Name 'newtestname' -Cluster 10 -Platform 15 -Status 'Offline' -Force
+            $Result = Set-NBVirtualMachine -Id 1234 -Name 'newtestname' -Cluster 10 -Platform 15 -Status 'Offline' -Confirm:$false
             $Result.Method | Should -Be 'PATCH'
             $Result.URI | Should -Be 'https://netbox.domain.com/api/virtualization/virtual-machines/1234/'
             # Compare as objects since JSON key order is not guaranteed
@@ -359,7 +359,7 @@ Describe "Virtualization tests" -Tag 'Virtualization' {
         }
 
         It "Should update a VM with Start_On_Boot (Netbox 4.5+)" {
-            $Result = Set-NBVirtualMachine -Id 1234 -Start_On_Boot 'off' -Force
+            $Result = Set-NBVirtualMachine -Id 1234 -Start_On_Boot 'off' -Confirm:$false
             $bodyObj = $Result.Body | ConvertFrom-Json
             $bodyObj.start_on_boot | Should -Be 'off'
         }
@@ -367,7 +367,7 @@ Describe "Virtualization tests" -Tag 'Virtualization' {
 
     Context "Set-NBVirtualMachineInterface" {
         It "Should set an interface to a new name" {
-            $Result = Set-NBVirtualMachineInterface -Id 1234 -Name 'newtestname' -Force
+            $Result = Set-NBVirtualMachineInterface -Id 1234 -Name 'newtestname' -Confirm:$false
             $Result.Method | Should -Be 'PATCH'
             $Result.URI | Should -Be 'https://netbox.domain.com/api/virtualization/interfaces/1234/'
             $Result.Body | Should -Be '{"name":"newtestname"}'
@@ -380,7 +380,7 @@ Describe "Virtualization tests" -Tag 'Virtualization' {
                 MAC_Address = '11:22:33:44:55:66'
                 MTU         = 9000
                 Description = "Test description"
-                Force       = $true
+                Confirm     = $false
             }
             $Result = Set-NBVirtualMachineInterface @paramSetNetboxVirtualMachineInterface
             $Result.Method | Should -Be 'PATCH'
@@ -397,7 +397,7 @@ Describe "Virtualization tests" -Tag 'Virtualization' {
             $Result = @(
                 [pscustomobject]@{ 'Id' = 4123 },
                 [pscustomobject]@{ 'Id' = 4321 }
-            ) | Set-NBVirtualMachineInterface -Name 'newtestname' -Force
+            ) | Set-NBVirtualMachineInterface -Name 'newtestname' -Confirm:$false
             $Result.Method | Should -Be 'PATCH', 'PATCH'
             $Result.URI | Should -Be 'https://netbox.domain.com/api/virtualization/interfaces/4123/', 'https://netbox.domain.com/api/virtualization/interfaces/4321/'
             $Result.Body | Should -Be '{"name":"newtestname"}', '{"name":"newtestname"}'
@@ -406,14 +406,14 @@ Describe "Virtualization tests" -Tag 'Virtualization' {
 
     Context "Remove-NBVirtualMachine" {
         It "Should remove a single VM" {
-            $Result = Remove-NBVirtualMachine -Id 4125 -Force
+            $Result = Remove-NBVirtualMachine -Id 4125 -Confirm:$false
             $Result.Method | Should -Be 'DELETE'
             $Result.URI | Should -Be 'https://netbox.domain.com/api/virtualization/virtual-machines/4125/'
         }
 
         It "Should remove a VM from the pipeline" {
             # Use a pscustomobject with Id property instead of calling Get-NBVirtualMachine
-            $Result = [pscustomobject]@{ 'Id' = 4125 } | Remove-NBVirtualMachine -Force
+            $Result = [pscustomobject]@{ 'Id' = 4125 } | Remove-NBVirtualMachine -Confirm:$false
             $Result.Method | Should -Be 'DELETE'
             $Result.URI | Should -Be 'https://netbox.domain.com/api/virtualization/virtual-machines/4125/'
         }
@@ -422,7 +422,7 @@ Describe "Virtualization tests" -Tag 'Virtualization' {
             $Result = @(
                 [pscustomobject]@{ 'Id' = 4125 },
                 [pscustomobject]@{ 'Id' = 4132 }
-            ) | Remove-NBVirtualMachine -Force
+            ) | Remove-NBVirtualMachine -Confirm:$false
             $Result.Method | Should -Be 'DELETE', 'DELETE'
             $Result.URI | Should -Be 'https://netbox.domain.com/api/virtualization/virtual-machines/4125/', 'https://netbox.domain.com/api/virtualization/virtual-machines/4132/'
         }
@@ -430,7 +430,7 @@ Describe "Virtualization tests" -Tag 'Virtualization' {
 
     Context "Remove-NBVirtualMachineInterface" {
         It "Should remove a single interface" {
-            $Result = Remove-NBVirtualMachineInterface -Id 100 -Force
+            $Result = Remove-NBVirtualMachineInterface -Id 100 -Confirm:$false
             $Result.Method | Should -Be 'DELETE'
             $Result.URI | Should -Be 'https://netbox.domain.com/api/virtualization/interfaces/100/'
         }
@@ -440,7 +440,7 @@ Describe "Virtualization tests" -Tag 'Virtualization' {
             $Result = @(
                 [pscustomobject]@{ 'Id' = 100 },
                 [pscustomobject]@{ 'Id' = 101 }
-            ) | Remove-NBVirtualMachineInterface -Force
+            ) | Remove-NBVirtualMachineInterface -Confirm:$false
             $Result.Method | Should -Be 'DELETE', 'DELETE'
         }
     }
@@ -472,13 +472,13 @@ Describe "Virtualization tests" -Tag 'Virtualization' {
         }
 
         It "Should update a cluster" {
-            $Result = Set-NBVirtualizationCluster -Id 1 -Name 'updated-cluster' -Force
+            $Result = Set-NBVirtualizationCluster -Id 1 -Name 'updated-cluster' -Confirm:$false
             $Result.Method | Should -Be 'PATCH'
             $Result.URI | Should -Match '/api/virtualization/clusters/1/'
         }
 
         It "Should update cluster description" {
-            $Result = Set-NBVirtualizationCluster -Id 1 -Description 'Updated description' -Force
+            $Result = Set-NBVirtualizationCluster -Id 1 -Description 'Updated description' -Confirm:$false
             $bodyObj = $Result.Body | ConvertFrom-Json
             $bodyObj.description | Should -Be 'Updated description'
         }
@@ -492,7 +492,7 @@ Describe "Virtualization tests" -Tag 'Virtualization' {
         }
 
         It "Should remove a cluster" {
-            $Result = Remove-NBVirtualizationCluster -Id 5 -Force
+            $Result = Remove-NBVirtualizationCluster -Id 5 -Confirm:$false
             $Result.Method | Should -Be 'DELETE'
             $Result.URI | Should -Match '/api/virtualization/clusters/5/'
         }


### PR DESCRIPTION
## Summary
- Standardize confirmation suppression in unit tests: replace `-Force` with `-Confirm:$false` across 8 test files (46 changes)
- `-Confirm:$false` is the universal PowerShell approach (works on all `SupportsShouldProcess` functions)
- `-Force` remains in `BulkOperations.Tests.ps1` and integration/scenario tests where it has specific bulk semantic meaning
- Addresses P3.3 from issue #324

## Files Changed
| File | Changes |
|------|---------|
| Circuits.Tests.ps1 | 3 |
| DCIM.Devices.Tests.ps1 | 4 |
| DCIM.Interfaces.Tests.ps1 | 7 |
| DCIM.Racks.Tests.ps1 | 2 |
| DCIM.Sites.Tests.ps1 | 1 |
| IPAM.Tests.ps1 | 4 |
| Tenancy.Tests.ps1 | 11 |
| Virtualization.Tests.ps1 | 14 |

## Convention
- **Unit tests**: Always use `-Confirm:$false` for confirmation suppression
- **BulkOperations tests**: Use `-Force` (testing explicit bulk `-Force` parameter)
- **Integration/Scenario tests**: Use `-Force` or `-Confirm:$false` as appropriate for the workflow

## Test plan
- [x] All 649 tests in changed files pass locally
- [ ] CI Tests workflow passes
- [ ] CI Integration Tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)