### PR TITLE
fix: remove inapplicable params from special Get functions

### DIFF
--- a/Functions/DCIM/ConnectedDevice/Get-NBDCIMConnectedDevice.ps1
+++ b/Functions/DCIM/ConnectedDevice/Get-NBDCIMConnectedDevice.ps1
@@ -3,41 +3,36 @@
     Retrieves Connected Device objects from Netbox DCIM module.
 
 .DESCRIPTION
-    Retrieves Connected Device objects from Netbox DCIM module.
+    Retrieves the connected device for a given peer device and interface.
+    Returns a single device object (no pagination).
+
+.PARAMETER Peer_Device
+    The name of the peer device.
+
+.PARAMETER Peer_Interface
+    The name of the peer interface.
 
 .PARAMETER Raw
     Return the raw API response instead of the results array.
 
 .EXAMPLE
-    Get-NBDCIMConnectedDevice
+    Get-NBDCIMConnectedDevice -Peer_Device "switch01" -Peer_Interface "GigabitEthernet0/1"
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>
 function Get-NBDCIMConnectedDevice {
-    [CmdletBinding(DefaultParameterSetName = 'Query')]
+    [CmdletBinding()]
     [OutputType([PSCustomObject])]
     param(
-        [switch]$All,
-
-        [ValidateRange(1, 1000)]
-        [int]$PageSize = 100,
-
-        [switch]$Brief,
-
-        [string[]]$Fields,
-
-
-        [string[]]$Omit,
-
-        [Parameter(ParameterSetName = 'Query', Mandatory = $true)][string]$Peer_Device,
-        [Parameter(ParameterSetName = 'Query', Mandatory = $true)][string]$Peer_Interface,
+        [Parameter(Mandatory = $true)][string]$Peer_Device,
+        [Parameter(Mandatory = $true)][string]$Peer_Interface,
         [switch]$Raw
     )
     process {
         Write-Verbose "Retrieving DCIM Connected Device"
         $Segments = [System.Collections.ArrayList]::new(@('dcim','connected-device'))
-        $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'All', 'PageSize'
-        InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters) -Raw:$Raw -All:$All -PageSize $PageSize
+        $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw'
+        InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters) -Raw:$Raw
     }
 }

--- a/Functions/DCIM/Racks/Get-NBDCIMRackElevation.ps1
+++ b/Functions/DCIM/Racks/Get-NBDCIMRackElevation.ps1
@@ -74,13 +74,6 @@ function Get-NBDCIMRackElevation {
         [ValidateRange(1, 1000)]
         [int]$PageSize = 100,
 
-        [switch]$Brief,
-
-        [string[]]$Fields,
-
-
-        [string[]]$Omit,
-
         [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
         [uint64[]]$Id,
 

--- a/Functions/IPAM/Address/Get-NBIPAMAvailableIP.ps1
+++ b/Functions/IPAM/Address/Get-NBIPAMAvailableIP.ps1
@@ -36,18 +36,6 @@ function Get-NBIPAMAvailableIP {
     [OutputType([PSCustomObject])]
     param
     (
-        [switch]$All,
-
-        [ValidateRange(1, 1000)]
-        [int]$PageSize = 100,
-
-        [switch]$Brief,
-
-        [string[]]$Fields,
-
-
-        [string[]]$Omit,
-
         [Parameter(Mandatory = $true,
             ValueFromPipelineByPropertyName = $true)]
         [Alias('Id')]
@@ -63,10 +51,10 @@ function Get-NBIPAMAvailableIP {
         Write-Verbose "Retrieving IPAM Available IP"
         $Segments = [System.Collections.ArrayList]::new(@('ipam', 'prefixes', $Prefix_ID, 'available-ips'))
 
-        $URIComponents = BuildURIComponents -URISegments $Segments -ParametersDictionary $PSBoundParameters -SkipParameterByName 'prefix_id', 'Raw', 'All', 'PageSize'
+        $URIComponents = BuildURIComponents -URISegments $Segments -ParametersDictionary $PSBoundParameters -SkipParameterByName 'prefix_id', 'Raw'
 
         $uri = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
 
-        InvokeNetboxRequest -URI $uri -Raw:$Raw -All:$All -PageSize $PageSize
+        InvokeNetboxRequest -URI $uri -Raw:$Raw
     }
 }

--- a/Tests/DCIM.Additional.Tests.ps1
+++ b/Tests/DCIM.Additional.Tests.ps1
@@ -1680,7 +1680,6 @@ Describe "DCIM Additional Tests" -Tag 'DCIM' {
         $allPageSizeTestCases = @(
             @{ Command = 'Get-NBDCIMCable' }
             @{ Command = 'Get-NBDCIMCableTermination' }
-            @{ Command = 'Get-NBDCIMConnectedDevice'; Parameters = @{ Peer_Device = 'switch01'; Peer_Interface = 'eth0' } }
             @{ Command = 'Get-NBDCIMConsolePort' }
             @{ Command = 'Get-NBDCIMConsoleServerPort' }
             @{ Command = 'Get-NBDCIMDeviceBay' }
@@ -1735,7 +1734,6 @@ Describe "DCIM Additional Tests" -Tag 'DCIM' {
         $omitTestCases = @(
             @{ Command = 'Get-NBDCIMCable' }
             @{ Command = 'Get-NBDCIMCableTermination' }
-            @{ Command = 'Get-NBDCIMConnectedDevice'; Parameters = @{ Peer_Device = 'switch01'; Peer_Interface = 'eth0' } }
             @{ Command = 'Get-NBDCIMConsolePort' }
             @{ Command = 'Get-NBDCIMConsoleServerPort' }
             @{ Command = 'Get-NBDCIMDeviceBay' }

--- a/Tests/IPAM.Tests.ps1
+++ b/Tests/IPAM.Tests.ps1
@@ -1139,7 +1139,6 @@ Describe "IPAM tests" -Tag 'Ipam' {
             @{ Command = 'Get-NBIPAMAggregate' }
             @{ Command = 'Get-NBIPAMASN' }
             @{ Command = 'Get-NBIPAMASNRange' }
-            @{ Command = 'Get-NBIPAMAvailableIP'; Parameters = @{ Prefix_ID = 1 } }
             @{ Command = 'Get-NBIPAMFHRPGroup' }
             @{ Command = 'Get-NBIPAMFHRPGroupAssignment' }
             @{ Command = 'Get-NBIPAMPrefix' }
@@ -1184,7 +1183,6 @@ Describe "IPAM tests" -Tag 'Ipam' {
             @{ Command = 'Get-NBIPAMAggregate' }
             @{ Command = 'Get-NBIPAMASN' }
             @{ Command = 'Get-NBIPAMASNRange' }
-            @{ Command = 'Get-NBIPAMAvailableIP'; Parameters = @{ Prefix_ID = 1 } }
             @{ Command = 'Get-NBIPAMFHRPGroup' }
             @{ Command = 'Get-NBIPAMFHRPGroupAssignment' }
             @{ Command = 'Get-NBIPAMPrefix' }


### PR DESCRIPTION
## Summary
- **Get-NBDCIMRackElevation**: Remove `$Brief`, `$Fields`, `$Omit` — elevation endpoint builds params manually and these were silently ignored
- **Get-NBDCIMConnectedDevice**: Remove `$Brief`, `$Fields`, `$Omit`, `$All`, `$PageSize` — single-result endpoint, no pagination
- **Get-NBIPAMAvailableIP**: Remove `$Brief`, `$Fields`, `$Omit`, `$All`, `$PageSize` — convenience endpoint, not paginated
- Update test suites: remove these functions from All/PageSize and Omit parameter test cases

These parameters were added by the automated `Scripts/Add-OmitParameter.ps1` script without checking endpoint applicability. Users who specified these parameters got no error but also no effect.

Closes #338

## Test plan
- [ ] `Get-NBDCIMRackElevation -Id 1` still works (JSON and SVG modes)
- [ ] `Get-NBDCIMConnectedDevice` still works with mandatory params
- [ ] `Get-NBIPAMAvailableIP` still works with Prefix_ID
- [ ] All existing unit tests pass
- [ ] No regressions in DCIM.Racks, DCIM.Additional, IPAM test files