### PR TITLE
fix: parameter declaration best practices

### DIFF
--- a/Functions/Helpers/Get-NBRequestHeaders.ps1
+++ b/Functions/Helpers/Get-NBRequestHeaders.ps1
@@ -13,8 +13,8 @@ function Get-NBRequestHeaders {
     .PARAMETER Branch
         Optional explicit branch schema_id to use instead of the stack context
 
-    .PARAMETER IncludeBranchContext
-        Whether to include branch context header. Defaults to $true.
+    .PARAMETER SkipBranchContext
+        If specified, omits the X-NetBox-Branch header from the returned headers.
 
     .EXAMPLE
         $headers = Get-NBRequestHeaders
@@ -25,7 +25,7 @@ function Get-NBRequestHeaders {
         # Uses explicit branch instead of stack context
 
     .EXAMPLE
-        $headers = Get-NBRequestHeaders -IncludeBranchContext:$false
+        $headers = Get-NBRequestHeaders -SkipBranchContext
         # Only returns Authorization header, no branch context
 #>
 
@@ -34,7 +34,7 @@ function Get-NBRequestHeaders {
     param(
         [string]$Branch,
 
-        [switch]$IncludeBranchContext = $true
+        [switch]$SkipBranchContext
     )
 
     $creds = Get-NBCredential
@@ -54,7 +54,7 @@ function Get-NBRequestHeaders {
     }
 
     # Add branch context if requested
-    if ($IncludeBranchContext) {
+    if (-not $SkipBranchContext) {
         # Determine effective branch context: explicit param > stack context > main
         $effectiveBranchContext = if ($Branch) {
             # Explicit -Branch parameter (schema_id string)

--- a/Functions/Setup/Connect-NBAPI.ps1
+++ b/Functions/Setup/Connect-NBAPI.ps1
@@ -54,7 +54,9 @@ function Connect-NBAPI {
         [string]$Hostname,
 
         [Parameter(Mandatory = $false)]
-        [pscredential]$Credential,
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $Credential,
 
         [Parameter(ParameterSetName = 'Manual')]
         [ValidateSet('https', 'http', IgnoreCase = $true)]
@@ -69,7 +71,7 @@ function Connect-NBAPI {
         [string]$URI,
 
         [Parameter(Mandatory = $false)]
-        [switch]$SkipCertificateCheck = $false,
+        [switch]$SkipCertificateCheck,
 
         [ValidateNotNullOrEmpty()]
         [ValidateRange(1, 65535)]

--- a/Functions/Setup/Set-NBCredential.ps1
+++ b/Functions/Setup/Set-NBCredential.ps1
@@ -22,7 +22,9 @@ function Set-NBCredential {
     (
         [Parameter(ParameterSetName = 'CredsObject',
             Mandatory = $true)]
-        [pscredential]$Credential,
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()]
+        $Credential,
 
         [Parameter(ParameterSetName = 'UserPass',
             Mandatory = $true)]


### PR DESCRIPTION
## Summary
- Rename `IncludeBranchContext` switch (default `$true`) to `SkipBranchContext` (default `$false`) — switches should never default to `$true` per PowerShell best practices
- Remove redundant `= $false` from `SkipCertificateCheck` switch in Connect-NBAPI
- Add `[Credential()]` attribute to `[PSCredential]` parameters in Connect-NBAPI and Set-NBCredential for proper credential coercion

## Test plan
- [ ] Verify `Get-NBRequestHeaders` still includes branch context by default
- [ ] Verify `Connect-NBAPI -SkipCertificateCheck` still works
- [ ] Verify passing a username string to `-Credential` prompts for password

Closes #346, Closes #347