### PR TITLE
refactor: replace backtick line continuations with splatting

### DIFF
--- a/Functions/DCIM/Devices/New-NBDCIMDevice.ps1
+++ b/Functions/DCIM/Devices/New-NBDCIMDevice.ps1
@@ -204,8 +204,15 @@ function New-NBDCIMDevice {
             if ($Force -or $PSCmdlet.ShouldProcess($target, 'Create devices (bulk)')) {
                 Write-Verbose "Processing $($bulkItems.Count) devices in bulk mode with batch size $BatchSize"
 
-                $result = Send-NBBulkRequest -URI $URI -Items $bulkItems.ToArray() -Method POST `
-                    -BatchSize $BatchSize -ShowProgress -ActivityName 'Creating devices'
+                $bulkParams = @{
+                    URI          = $URI
+                    Items        = $bulkItems.ToArray()
+                    Method       = 'POST'
+                    BatchSize    = $BatchSize
+                    ShowProgress = $true
+                    ActivityName = 'Creating devices'
+                }
+                $result = Send-NBBulkRequest @bulkParams
 
                 # Output succeeded items to pipeline
                 foreach ($item in $result.Succeeded) {

--- a/Functions/DCIM/Devices/Remove-NBDCIMDevice.ps1
+++ b/Functions/DCIM/Devices/Remove-NBDCIMDevice.ps1
@@ -124,8 +124,15 @@ function Remove-NBDCIMDevice {
             if ($Force -or $PSCmdlet.ShouldProcess($target, 'Delete devices (bulk)')) {
                 Write-Verbose "Processing $($bulkItems.Count) devices in bulk DELETE mode with batch size $BatchSize"
 
-                $result = Send-NBBulkRequest -URI $URI -Items $bulkItems.ToArray() -Method DELETE `
-                    -BatchSize $BatchSize -ShowProgress -ActivityName 'Deleting devices'
+                $bulkParams = @{
+                    URI          = $URI
+                    Items        = $bulkItems.ToArray()
+                    Method       = 'DELETE'
+                    BatchSize    = $BatchSize
+                    ShowProgress = $true
+                    ActivityName = 'Deleting devices'
+                }
+                $result = Send-NBBulkRequest @bulkParams
 
                 # Write summary
                 if ($result.HasErrors) {

--- a/Functions/DCIM/Devices/Set-NBDCIMDevice.ps1
+++ b/Functions/DCIM/Devices/Set-NBDCIMDevice.ps1
@@ -250,8 +250,15 @@ function Set-NBDCIMDevice {
             if ($Force -or $PSCmdlet.ShouldProcess($target, 'Update devices (bulk)')) {
                 Write-Verbose "Processing $($bulkItems.Count) devices in bulk PATCH mode with batch size $BatchSize"
 
-                $result = Send-NBBulkRequest -URI $URI -Items $bulkItems.ToArray() -Method PATCH `
-                    -BatchSize $BatchSize -ShowProgress -ActivityName 'Updating devices'
+                $bulkParams = @{
+                    URI          = $URI
+                    Items        = $bulkItems.ToArray()
+                    Method       = 'PATCH'
+                    BatchSize    = $BatchSize
+                    ShowProgress = $true
+                    ActivityName = 'Updating devices'
+                }
+                $result = Send-NBBulkRequest @bulkParams
 
                 # Output succeeded items to pipeline
                 foreach ($item in $result.Succeeded) {

--- a/Functions/DCIM/Interfaces/New-NBDCIMInterface.ps1
+++ b/Functions/DCIM/Interfaces/New-NBDCIMInterface.ps1
@@ -212,8 +212,15 @@ function New-NBDCIMInterface {
             if ($Force -or $PSCmdlet.ShouldProcess($target, 'Create interfaces (bulk)')) {
                 Write-Verbose "Processing $($bulkItems.Count) interfaces in bulk mode with batch size $BatchSize"
 
-                $result = Send-NBBulkRequest -URI $URI -Items $bulkItems.ToArray() -Method POST `
-                    -BatchSize $BatchSize -ShowProgress -ActivityName 'Creating interfaces'
+                $bulkParams = @{
+                    URI          = $URI
+                    Items        = $bulkItems.ToArray()
+                    Method       = 'POST'
+                    BatchSize    = $BatchSize
+                    ShowProgress = $true
+                    ActivityName = 'Creating interfaces'
+                }
+                $result = Send-NBBulkRequest @bulkParams
 
                 # Output succeeded items to pipeline
                 foreach ($item in $result.Succeeded) {

--- a/Functions/DCIM/Racks/Export-NBRackElevation.ps1
+++ b/Functions/DCIM/Racks/Export-NBRackElevation.ps1
@@ -159,8 +159,14 @@ function Export-NBRackElevation {
                 }
                 else {
                     # HTML with embedded SVG
-                    ConvertTo-NBRackHTML -RackName $rackName -SiteName $siteName -UHeight $rackHeight `
-                        -Face $faceLabel -SvgContent $svgContent
+                    $htmlParams = @{
+                        RackName   = $rackName
+                        SiteName   = $siteName
+                        UHeight    = $rackHeight
+                        Face       = $faceLabel
+                        SvgContent = $svgContent
+                    }
+                    ConvertTo-NBRackHTML @htmlParams
                 }
             }
             else {
@@ -180,16 +186,36 @@ function Export-NBRackElevation {
 
                 switch ($Format) {
                     'HTML' {
-                        ConvertTo-NBRackHTML -RackName $rackName -SiteName $siteName -UHeight $rackHeight `
-                            -Face $faceLabel -ElevationData $elevation
+                        $htmlParams = @{
+                            RackName      = $rackName
+                            SiteName      = $siteName
+                            UHeight       = $rackHeight
+                            Face          = $faceLabel
+                            ElevationData = $elevation
+                        }
+                        ConvertTo-NBRackHTML @htmlParams
                     }
                     'Markdown' {
-                        ConvertTo-NBRackMarkdown -RackName $rackName -SiteName $siteName -UHeight $rackHeight `
-                            -Face $faceLabel -ElevationData $elevation
+                        $mdParams = @{
+                            RackName      = $rackName
+                            SiteName      = $siteName
+                            UHeight       = $rackHeight
+                            Face          = $faceLabel
+                            ElevationData = $elevation
+                        }
+                        ConvertTo-NBRackMarkdown @mdParams
                     }
                     'Console' {
-                        ConvertTo-NBRackConsole -RackName $rackName -SiteName $siteName -UHeight $rackHeight `
-                            -Face $faceLabel -ElevationData $elevation -Compact:$Compact -NoColor:$NoColor
+                        $consoleParams = @{
+                            RackName      = $rackName
+                            SiteName      = $siteName
+                            UHeight       = $rackHeight
+                            Face          = $faceLabel
+                            ElevationData = $elevation
+                            Compact       = [bool]$Compact
+                            NoColor       = [bool]$NoColor
+                        }
+                        ConvertTo-NBRackConsole @consoleParams
                     }
                 }
             }

--- a/Functions/DCIM/Racks/Export-NBRackElevation.ps1
+++ b/Functions/DCIM/Racks/Export-NBRackElevation.ps1
@@ -212,8 +212,8 @@ function Export-NBRackElevation {
                             UHeight       = $rackHeight
                             Face          = $faceLabel
                             ElevationData = $elevation
-                            Compact       = [bool]$Compact
-                            NoColor       = [bool]$NoColor
+                            Compact       = $Compact
+                            NoColor       = $NoColor
                         }
                         ConvertTo-NBRackConsole @consoleParams
                     }

--- a/Functions/Helpers/InvokeNetboxRequest.ps1
+++ b/Functions/Helpers/InvokeNetboxRequest.ps1
@@ -120,8 +120,17 @@ function InvokeNetboxRequest {
             Write-Verbose "Fetching page ${pageNum}..."
 
             # Make single-page request (recursive call without -All)
-            $pageResult = InvokeNetboxRequest -URI $currentUri -Headers $Headers -Body $Body `
-                -Timeout $Timeout -Method $Method -Raw -MaxRetries $MaxRetries -RetryDelayMs $RetryDelayMs
+            $pageParams = @{
+                URI         = $currentUri
+                Headers     = $Headers
+                Body        = $Body
+                Timeout     = $Timeout
+                Method      = $Method
+                Raw         = $true
+                MaxRetries  = $MaxRetries
+                RetryDelayMs = $RetryDelayMs
+            }
+            $pageResult = InvokeNetboxRequest @pageParams
 
             if ($pageResult.results) {
                 $itemCount = $pageResult.results.Count
@@ -131,9 +140,12 @@ function InvokeNetboxRequest {
                 # Show progress for large datasets
                 if ($pageResult.count -gt 0) {
                     $percentComplete = [Math]::Min(100, [int](($allResults.Count / $pageResult.count) * 100))
-                    Write-Progress -Activity "Fetching all results" `
-                        -Status "$($allResults.Count) of $($pageResult.count) items" `
-                        -PercentComplete $percentComplete
+                    $progressParams = @{
+                        Activity        = 'Fetching all results'
+                        Status          = "$($allResults.Count) of $($pageResult.count) items"
+                        PercentComplete = $percentComplete
+                    }
+                    Write-Progress @progressParams
                 }
             }
 
@@ -297,12 +309,14 @@ function InvokeNetboxRequest {
             # Non-retryable error or max retries reached - throw detailed error
             $statusName = if ($statusCode) { GetHttpStatusName -StatusCode $statusCode } else { "Unknown" }
 
-            $detailedMessage = BuildDetailedErrorMessage `
-                -StatusCode $statusCode `
-                -StatusName $statusName `
-                -Method $Method `
-                -Endpoint $URI.Uri.AbsoluteUri `
-                -ErrorMessage $errorMessage
+            $errorParams = @{
+                StatusCode   = $statusCode
+                StatusName   = $statusName
+                Method       = $Method
+                Endpoint     = $URI.Uri.AbsoluteUri
+                ErrorMessage = $errorMessage
+            }
+            $detailedMessage = BuildDetailedErrorMessage @errorParams
 
             $errorRecord = [System.Management.Automation.ErrorRecord]::new(
                 [System.Exception]::new($detailedMessage),

--- a/Functions/Helpers/Send-NBBulkRequest.ps1
+++ b/Functions/Helpers/Send-NBBulkRequest.ps1
@@ -82,10 +82,13 @@ function Send-NBBulkRequest {
 
         if ($ShowProgress) {
             $percentComplete = [int](($currentBatch / $totalBatches) * 100)
-            Write-Progress -Activity $ActivityName `
-                -Status "Batch $currentBatch of $totalBatches ($($batch.Count) items)" `
-                -PercentComplete $percentComplete `
-                -CurrentOperation "$Method request"
+            $progressParams = @{
+                Activity         = $ActivityName
+                Status           = "Batch $currentBatch of $totalBatches ($($batch.Count) items)"
+                PercentComplete  = $percentComplete
+                CurrentOperation = "$Method request"
+            }
+            Write-Progress @progressParams
         }
 
         try {

--- a/Functions/IPAM/Address/New-NBIPAMAddress.ps1
+++ b/Functions/IPAM/Address/New-NBIPAMAddress.ps1
@@ -205,8 +205,15 @@ function New-NBIPAMAddress {
             if ($Force -or $PSCmdlet.ShouldProcess($target, 'Create IP addresses (bulk)')) {
                 Write-Verbose "Processing $($bulkItems.Count) IP addresses in bulk mode with batch size $BatchSize"
 
-                $result = Send-NBBulkRequest -URI $URI -Items $bulkItems.ToArray() -Method POST `
-                    -BatchSize $BatchSize -ShowProgress -ActivityName 'Creating IP addresses'
+                $bulkParams = @{
+                    URI          = $URI
+                    Items        = $bulkItems.ToArray()
+                    Method       = 'POST'
+                    BatchSize    = $BatchSize
+                    ShowProgress = $true
+                    ActivityName = 'Creating IP addresses'
+                }
+                $result = Send-NBBulkRequest @bulkParams
 
                 # Output succeeded items to pipeline
                 foreach ($item in $result.Succeeded) {

--- a/Functions/IPAM/Address/Remove-NBIPAMAddress.ps1
+++ b/Functions/IPAM/Address/Remove-NBIPAMAddress.ps1
@@ -120,8 +120,15 @@ function Remove-NBIPAMAddress {
             if ($Force -or $PSCmdlet.ShouldProcess($target, 'Delete IP addresses (bulk)')) {
                 Write-Verbose "Processing $($bulkItems.Count) IP addresses in bulk DELETE mode with batch size $BatchSize"
 
-                $result = Send-NBBulkRequest -URI $URI -Items $bulkItems.ToArray() -Method DELETE `
-                    -BatchSize $BatchSize -ShowProgress -ActivityName 'Deleting IP addresses'
+                $bulkParams = @{
+                    URI          = $URI
+                    Items        = $bulkItems.ToArray()
+                    Method       = 'DELETE'
+                    BatchSize    = $BatchSize
+                    ShowProgress = $true
+                    ActivityName = 'Deleting IP addresses'
+                }
+                $result = Send-NBBulkRequest @bulkParams
 
                 # Write errors for failed items
                 foreach ($failure in $result.Failed) {

--- a/Functions/IPAM/Address/Set-NBIPAMAddress.ps1
+++ b/Functions/IPAM/Address/Set-NBIPAMAddress.ps1
@@ -216,8 +216,15 @@ function Set-NBIPAMAddress {
             if ($Force -or $PSCmdlet.ShouldProcess($target, 'Update IP addresses (bulk)')) {
                 Write-Verbose "Processing $($bulkItems.Count) IP addresses in bulk PATCH mode with batch size $BatchSize"
 
-                $result = Send-NBBulkRequest -URI $URI -Items $bulkItems.ToArray() -Method PATCH `
-                    -BatchSize $BatchSize -ShowProgress -ActivityName 'Updating IP addresses'
+                $bulkParams = @{
+                    URI          = $URI
+                    Items        = $bulkItems.ToArray()
+                    Method       = 'PATCH'
+                    BatchSize    = $BatchSize
+                    ShowProgress = $true
+                    ActivityName = 'Updating IP addresses'
+                }
+                $result = Send-NBBulkRequest @bulkParams
 
                 # Output succeeded items to pipeline
                 foreach ($item in $result.Succeeded) {

--- a/Functions/IPAM/Prefix/New-NBIPAMPrefix.ps1
+++ b/Functions/IPAM/Prefix/New-NBIPAMPrefix.ps1
@@ -181,8 +181,15 @@ function New-NBIPAMPrefix {
             if ($Force -or $PSCmdlet.ShouldProcess($target, 'Create prefixes (bulk)')) {
                 Write-Verbose "Processing $($bulkItems.Count) prefixes in bulk mode with batch size $BatchSize"
 
-                $result = Send-NBBulkRequest -URI $URI -Items $bulkItems.ToArray() -Method POST `
-                    -BatchSize $BatchSize -ShowProgress -ActivityName 'Creating prefixes'
+                $bulkParams = @{
+                    URI          = $URI
+                    Items        = $bulkItems.ToArray()
+                    Method       = 'POST'
+                    BatchSize    = $BatchSize
+                    ShowProgress = $true
+                    ActivityName = 'Creating prefixes'
+                }
+                $result = Send-NBBulkRequest @bulkParams
 
                 # Output succeeded items to pipeline
                 foreach ($item in $result.Succeeded) {

--- a/Functions/IPAM/VLAN/New-NBIPAMVLAN.ps1
+++ b/Functions/IPAM/VLAN/New-NBIPAMVLAN.ps1
@@ -179,8 +179,15 @@ function New-NBIPAMVLAN {
             if ($Force -or $PSCmdlet.ShouldProcess($target, 'Create VLANs (bulk)')) {
                 Write-Verbose "Processing $($bulkItems.Count) VLANs in bulk mode with batch size $BatchSize"
 
-                $result = Send-NBBulkRequest -URI $URI -Items $bulkItems.ToArray() -Method POST `
-                    -BatchSize $BatchSize -ShowProgress -ActivityName 'Creating VLANs'
+                $bulkParams = @{
+                    URI          = $URI
+                    Items        = $bulkItems.ToArray()
+                    Method       = 'POST'
+                    BatchSize    = $BatchSize
+                    ShowProgress = $true
+                    ActivityName = 'Creating VLANs'
+                }
+                $result = Send-NBBulkRequest @bulkParams
 
                 # Output succeeded items to pipeline
                 foreach ($item in $result.Succeeded) {

--- a/Functions/Virtualization/VirtualMachine/New-NBVirtualMachine.ps1
+++ b/Functions/Virtualization/VirtualMachine/New-NBVirtualMachine.ps1
@@ -209,8 +209,15 @@ function New-NBVirtualMachine {
             if ($Force -or $PSCmdlet.ShouldProcess($target, 'Create virtual machines (bulk)')) {
                 Write-Verbose "Processing $($bulkItems.Count) VMs in bulk mode with batch size $BatchSize"
 
-                $result = Send-NBBulkRequest -URI $URI -Items $bulkItems.ToArray() -Method POST `
-                    -BatchSize $BatchSize -ShowProgress -ActivityName 'Creating virtual machines'
+                $bulkParams = @{
+                    URI          = $URI
+                    Items        = $bulkItems.ToArray()
+                    Method       = 'POST'
+                    BatchSize    = $BatchSize
+                    ShowProgress = $true
+                    ActivityName = 'Creating virtual machines'
+                }
+                $result = Send-NBBulkRequest @bulkParams
 
                 # Output succeeded items to pipeline
                 foreach ($item in $result.Succeeded) {

--- a/Functions/Virtualization/VirtualMachine/Remove-NBVirtualMachine.ps1
+++ b/Functions/Virtualization/VirtualMachine/Remove-NBVirtualMachine.ps1
@@ -120,8 +120,15 @@ function Remove-NBVirtualMachine {
             if ($Force -or $PSCmdlet.ShouldProcess($target, 'Delete virtual machines (bulk)')) {
                 Write-Verbose "Processing $($bulkItems.Count) VMs in bulk DELETE mode with batch size $BatchSize"
 
-                $result = Send-NBBulkRequest -URI $URI -Items $bulkItems.ToArray() -Method DELETE `
-                    -BatchSize $BatchSize -ShowProgress -ActivityName 'Deleting virtual machines'
+                $bulkParams = @{
+                    URI          = $URI
+                    Items        = $bulkItems.ToArray()
+                    Method       = 'DELETE'
+                    BatchSize    = $BatchSize
+                    ShowProgress = $true
+                    ActivityName = 'Deleting virtual machines'
+                }
+                $result = Send-NBBulkRequest @bulkParams
 
                 # Write errors for failed items
                 foreach ($failure in $result.Failed) {

--- a/Functions/Virtualization/VirtualMachine/Set-NBVirtualMachine.ps1
+++ b/Functions/Virtualization/VirtualMachine/Set-NBVirtualMachine.ps1
@@ -216,8 +216,15 @@ function Set-NBVirtualMachine {
             if ($Force -or $PSCmdlet.ShouldProcess($target, 'Update virtual machines (bulk)')) {
                 Write-Verbose "Processing $($bulkItems.Count) VMs in bulk PATCH mode with batch size $BatchSize"
 
-                $result = Send-NBBulkRequest -URI $URI -Items $bulkItems.ToArray() -Method PATCH `
-                    -BatchSize $BatchSize -ShowProgress -ActivityName 'Updating virtual machines'
+                $bulkParams = @{
+                    URI          = $URI
+                    Items        = $bulkItems.ToArray()
+                    Method       = 'PATCH'
+                    BatchSize    = $BatchSize
+                    ShowProgress = $true
+                    ActivityName = 'Updating virtual machines'
+                }
+                $result = Send-NBBulkRequest @bulkParams
 
                 # Output succeeded items to pipeline
                 foreach ($item in $result.Succeeded) {

--- a/Functions/Virtualization/VirtualMachineInterface/New-NBVirtualMachineInterface.ps1
+++ b/Functions/Virtualization/VirtualMachineInterface/New-NBVirtualMachineInterface.ps1
@@ -206,8 +206,15 @@ function New-NBVirtualMachineInterface {
             if ($Force -or $PSCmdlet.ShouldProcess($target, 'Create VM interfaces (bulk)')) {
                 Write-Verbose "Processing $($bulkItems.Count) VM interfaces in bulk mode with batch size $BatchSize"
 
-                $result = Send-NBBulkRequest -URI $URI -Items $bulkItems.ToArray() -Method POST `
-                    -BatchSize $BatchSize -ShowProgress -ActivityName 'Creating VM interfaces'
+                $bulkParams = @{
+                    URI          = $URI
+                    Items        = $bulkItems.ToArray()
+                    Method       = 'POST'
+                    BatchSize    = $BatchSize
+                    ShowProgress = $true
+                    ActivityName = 'Creating VM interfaces'
+                }
+                $result = Send-NBBulkRequest @bulkParams
 
                 # Output succeeded items to pipeline
                 foreach ($item in $result.Succeeded) {


### PR DESCRIPTION
## Summary
- Converts all backtick (`` ` ``) line continuation patterns to hashtable splatting across 16 files
- Improves readability and maintainability per PowerShell best practices (PoshCode/PowerShellPracticeAndStyle)
- No functional changes — pure refactoring

## Files Changed
- `InvokeNetboxRequest.ps1` — 3 patterns (recursive pagination call, Write-Progress, BuildDetailedErrorMessage)
- `Send-NBBulkRequest.ps1` — 1 pattern (Write-Progress)
- `Export-NBRackElevation.ps1` — 4 patterns (ConvertTo-NBRack* calls)
- 13 bulk operation files — 1 pattern each (Send-NBBulkRequest calls)

## Test plan
- [ ] All existing tests pass (no functional changes)
- [ ] Lint checks pass

Closes #348