### PR TITLE
docs: add .PARAMETER docs for common Get function parameters

### DIFF
--- a/Functions/Circuits/CircuitGroupAssignments/Get-NBCircuitGroupAssignment.ps1
+++ b/Functions/Circuits/CircuitGroupAssignments/Get-NBCircuitGroupAssignment.ps1
@@ -26,6 +26,27 @@
 .PARAMETER Raw
     Return the raw API response.
 
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .EXAMPLE
     Get-NBCircuitGroupAssignment
 

--- a/Functions/Circuits/CircuitGroupAssignments/Get-NBCircuitGroupAssignment.ps1
+++ b/Functions/Circuits/CircuitGroupAssignments/Get-NBCircuitGroupAssignment.ps1
@@ -46,7 +46,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .EXAMPLE
     Get-NBCircuitGroupAssignment
 

--- a/Functions/Circuits/CircuitGroups/Get-NBCircuitGroup.ps1
+++ b/Functions/Circuits/CircuitGroups/Get-NBCircuitGroup.ps1
@@ -26,6 +26,27 @@
 .PARAMETER Raw
     Return the raw API response.
 
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .EXAMPLE
     Get-NBCircuitGroup
 

--- a/Functions/Circuits/CircuitGroups/Get-NBCircuitGroup.ps1
+++ b/Functions/Circuits/CircuitGroups/Get-NBCircuitGroup.ps1
@@ -46,7 +46,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .EXAMPLE
     Get-NBCircuitGroup
 

--- a/Functions/Circuits/Circuits/Get-NBCircuit.ps1
+++ b/Functions/Circuits/Circuits/Get-NBCircuit.ps1
@@ -57,6 +57,27 @@ function Get-NBCircuit {
     .PARAMETER ID__IN
         Multiple unique DB IDs to retrieve
 
+    .PARAMETER All
+        Automatically fetch all pages of results. Uses the API's pagination
+        to retrieve all items across multiple requests.
+
+    .PARAMETER PageSize
+        Number of items per page when using -All. Default: 100.
+        Range: 1-1000.
+
+    .PARAMETER Brief
+        Return a minimal representation of objects (id, url, display, name only).
+        Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+    .PARAMETER Fields
+        Specify which fields to include in the response.
+        Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+    .PARAMETER Omit
+        Specify which fields to exclude from the response.
+        Requires Netbox 4.5.0 or later.
+
+
     .EXAMPLE
         PS C:\> Get-NBCircuit
 

--- a/Functions/Circuits/Circuits/Get-NBCircuit.ps1
+++ b/Functions/Circuits/Circuits/Get-NBCircuit.ps1
@@ -77,7 +77,6 @@ function Get-NBCircuit {
         Specify which fields to exclude from the response.
         Requires Netbox 4.5.0 or later.
 
-
     .EXAMPLE
         PS C:\> Get-NBCircuit
 

--- a/Functions/Circuits/ProviderAccounts/Get-NBCircuitProviderAccount.ps1
+++ b/Functions/Circuits/ProviderAccounts/Get-NBCircuitProviderAccount.ps1
@@ -29,6 +29,27 @@
 .PARAMETER Raw
     Return the raw API response.
 
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .EXAMPLE
     Get-NBCircuitProviderAccount
 

--- a/Functions/Circuits/ProviderAccounts/Get-NBCircuitProviderAccount.ps1
+++ b/Functions/Circuits/ProviderAccounts/Get-NBCircuitProviderAccount.ps1
@@ -49,7 +49,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .EXAMPLE
     Get-NBCircuitProviderAccount
 

--- a/Functions/Circuits/ProviderNetworks/Get-NBCircuitProviderNetwork.ps1
+++ b/Functions/Circuits/ProviderNetworks/Get-NBCircuitProviderNetwork.ps1
@@ -46,7 +46,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .EXAMPLE
     Get-NBCircuitProviderNetwork
 

--- a/Functions/Circuits/ProviderNetworks/Get-NBCircuitProviderNetwork.ps1
+++ b/Functions/Circuits/ProviderNetworks/Get-NBCircuitProviderNetwork.ps1
@@ -26,6 +26,27 @@
 .PARAMETER Raw
     Return the raw API response.
 
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .EXAMPLE
     Get-NBCircuitProviderNetwork
 

--- a/Functions/Circuits/Providers/Get-NBCircuitProvider.ps1
+++ b/Functions/Circuits/Providers/Get-NBCircuitProvider.ps1
@@ -28,7 +28,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .EXAMPLE
     Get-NBCircuitProvider
 

--- a/Functions/Circuits/Providers/Get-NBCircuitProvider.ps1
+++ b/Functions/Circuits/Providers/Get-NBCircuitProvider.ps1
@@ -8,6 +8,27 @@
 .PARAMETER Raw
     Return the raw API response instead of the results array.
 
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .EXAMPLE
     Get-NBCircuitProvider
 

--- a/Functions/Circuits/Terminations/Get-NBCircuitTermination.ps1
+++ b/Functions/Circuits/Terminations/Get-NBCircuitTermination.ps1
@@ -8,6 +8,27 @@
 .PARAMETER Raw
     Return the raw API response instead of the results array.
 
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .EXAMPLE
     Get-NBCircuitTermination
 

--- a/Functions/Circuits/Terminations/Get-NBCircuitTermination.ps1
+++ b/Functions/Circuits/Terminations/Get-NBCircuitTermination.ps1
@@ -28,7 +28,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .EXAMPLE
     Get-NBCircuitTermination
 

--- a/Functions/Circuits/Types/Get-NBCircuitType.ps1
+++ b/Functions/Circuits/Types/Get-NBCircuitType.ps1
@@ -8,6 +8,27 @@
 .PARAMETER Raw
     Return the raw API response instead of the results array.
 
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .EXAMPLE
     Get-NBCircuitType
 

--- a/Functions/Circuits/Types/Get-NBCircuitType.ps1
+++ b/Functions/Circuits/Types/Get-NBCircuitType.ps1
@@ -28,7 +28,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .EXAMPLE
     Get-NBCircuitType
 

--- a/Functions/Circuits/VirtualCircuitTerminations/Get-NBVirtualCircuitTermination.ps1
+++ b/Functions/Circuits/VirtualCircuitTerminations/Get-NBVirtualCircuitTermination.ps1
@@ -49,7 +49,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .EXAMPLE
     Get-NBVirtualCircuitTermination
 

--- a/Functions/Circuits/VirtualCircuitTerminations/Get-NBVirtualCircuitTermination.ps1
+++ b/Functions/Circuits/VirtualCircuitTerminations/Get-NBVirtualCircuitTermination.ps1
@@ -29,6 +29,27 @@
 .PARAMETER Raw
     Return the raw API response.
 
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .EXAMPLE
     Get-NBVirtualCircuitTermination
 

--- a/Functions/Circuits/VirtualCircuitTypes/Get-NBVirtualCircuitType.ps1
+++ b/Functions/Circuits/VirtualCircuitTypes/Get-NBVirtualCircuitType.ps1
@@ -26,6 +26,27 @@
 .PARAMETER Raw
     Return the raw API response.
 
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .EXAMPLE
     Get-NBVirtualCircuitType
 

--- a/Functions/Circuits/VirtualCircuitTypes/Get-NBVirtualCircuitType.ps1
+++ b/Functions/Circuits/VirtualCircuitTypes/Get-NBVirtualCircuitType.ps1
@@ -46,7 +46,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .EXAMPLE
     Get-NBVirtualCircuitType
 

--- a/Functions/Circuits/VirtualCircuits/Get-NBVirtualCircuit.ps1
+++ b/Functions/Circuits/VirtualCircuits/Get-NBVirtualCircuit.ps1
@@ -61,7 +61,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .EXAMPLE
     Get-NBVirtualCircuit
 

--- a/Functions/Circuits/VirtualCircuits/Get-NBVirtualCircuit.ps1
+++ b/Functions/Circuits/VirtualCircuits/Get-NBVirtualCircuit.ps1
@@ -41,6 +41,27 @@
 .PARAMETER Raw
     Return the raw API response.
 
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .EXAMPLE
     Get-NBVirtualCircuit
 

--- a/Functions/Core/DataFiles/Get-NBDataFile.ps1
+++ b/Functions/Core/DataFiles/Get-NBDataFile.ps1
@@ -26,6 +26,27 @@
 .PARAMETER Raw
     Return the raw API response.
 
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .EXAMPLE
     Get-NBDataFile
 

--- a/Functions/Core/DataFiles/Get-NBDataFile.ps1
+++ b/Functions/Core/DataFiles/Get-NBDataFile.ps1
@@ -46,7 +46,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .EXAMPLE
     Get-NBDataFile
 

--- a/Functions/Core/DataSources/Get-NBDataSource.ps1
+++ b/Functions/Core/DataSources/Get-NBDataSource.ps1
@@ -29,6 +29,27 @@
 .PARAMETER Raw
     Return the raw API response.
 
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .EXAMPLE
     Get-NBDataSource
 

--- a/Functions/Core/DataSources/Get-NBDataSource.ps1
+++ b/Functions/Core/DataSources/Get-NBDataSource.ps1
@@ -49,7 +49,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .EXAMPLE
     Get-NBDataSource
 

--- a/Functions/Core/Jobs/Get-NBJob.ps1
+++ b/Functions/Core/Jobs/Get-NBJob.ps1
@@ -55,7 +55,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .EXAMPLE
     Get-NBJob
 

--- a/Functions/Core/Jobs/Get-NBJob.ps1
+++ b/Functions/Core/Jobs/Get-NBJob.ps1
@@ -35,6 +35,27 @@
 .PARAMETER Raw
     Return the raw API response.
 
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .EXAMPLE
     Get-NBJob
 

--- a/Functions/Core/ObjectChanges/Get-NBObjectChange.ps1
+++ b/Functions/Core/ObjectChanges/Get-NBObjectChange.ps1
@@ -35,6 +35,27 @@
 .PARAMETER Raw
     Return the raw API response.
 
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .EXAMPLE
     Get-NBObjectChange
 

--- a/Functions/Core/ObjectChanges/Get-NBObjectChange.ps1
+++ b/Functions/Core/ObjectChanges/Get-NBObjectChange.ps1
@@ -55,7 +55,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .EXAMPLE
     Get-NBObjectChange
 

--- a/Functions/Core/ObjectTypes/Get-NBObjectType.ps1
+++ b/Functions/Core/ObjectTypes/Get-NBObjectType.ps1
@@ -29,6 +29,27 @@
 .PARAMETER Raw
     Return the raw API response.
 
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .EXAMPLE
     Get-NBObjectType
 

--- a/Functions/Core/ObjectTypes/Get-NBObjectType.ps1
+++ b/Functions/Core/ObjectTypes/Get-NBObjectType.ps1
@@ -49,7 +49,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .EXAMPLE
     Get-NBObjectType
 

--- a/Functions/DCIM/Cable Terminations/Get-NBDCIMCableTermination.ps1
+++ b/Functions/DCIM/Cable Terminations/Get-NBDCIMCableTermination.ps1
@@ -28,7 +28,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .EXAMPLE
     Get-NBDCIMCableTermination
 

--- a/Functions/DCIM/Cable Terminations/Get-NBDCIMCableTermination.ps1
+++ b/Functions/DCIM/Cable Terminations/Get-NBDCIMCableTermination.ps1
@@ -8,6 +8,27 @@
 .PARAMETER Raw
     Return the raw API response instead of the results array.
 
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .EXAMPLE
     Get-NBDCIMCableTermination
 

--- a/Functions/DCIM/Cables/Get-NBDCIMCable.ps1
+++ b/Functions/DCIM/Cables/Get-NBDCIMCable.ps1
@@ -69,7 +69,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .EXAMPLE
     Get-NBDCIMCable
 

--- a/Functions/DCIM/Cables/Get-NBDCIMCable.ps1
+++ b/Functions/DCIM/Cables/Get-NBDCIMCable.ps1
@@ -57,6 +57,19 @@
 .PARAMETER Raw
     Return the raw API response.
 
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .EXAMPLE
     Get-NBDCIMCable
 

--- a/Functions/DCIM/ConsolePortTemplates/Get-NBDCIMConsolePortTemplate.ps1
+++ b/Functions/DCIM/ConsolePortTemplates/Get-NBDCIMConsolePortTemplate.ps1
@@ -28,7 +28,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .EXAMPLE
     Get-NBDCIMConsolePortTemplate
 

--- a/Functions/DCIM/ConsolePortTemplates/Get-NBDCIMConsolePortTemplate.ps1
+++ b/Functions/DCIM/ConsolePortTemplates/Get-NBDCIMConsolePortTemplate.ps1
@@ -8,6 +8,27 @@
 .PARAMETER Raw
     Return the raw API response instead of the results array.
 
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .EXAMPLE
     Get-NBDCIMConsolePortTemplate
 

--- a/Functions/DCIM/ConsolePorts/Get-NBDCIMConsolePort.ps1
+++ b/Functions/DCIM/ConsolePorts/Get-NBDCIMConsolePort.ps1
@@ -28,7 +28,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .EXAMPLE
     Get-NBDCIMConsolePort
 

--- a/Functions/DCIM/ConsolePorts/Get-NBDCIMConsolePort.ps1
+++ b/Functions/DCIM/ConsolePorts/Get-NBDCIMConsolePort.ps1
@@ -8,6 +8,27 @@
 .PARAMETER Raw
     Return the raw API response instead of the results array.
 
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .EXAMPLE
     Get-NBDCIMConsolePort
 

--- a/Functions/DCIM/ConsoleServerPortTemplates/Get-NBDCIMConsoleServerPortTemplate.ps1
+++ b/Functions/DCIM/ConsoleServerPortTemplates/Get-NBDCIMConsoleServerPortTemplate.ps1
@@ -28,7 +28,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .EXAMPLE
     Get-NBDCIMConsoleServerPortTemplate
 

--- a/Functions/DCIM/ConsoleServerPortTemplates/Get-NBDCIMConsoleServerPortTemplate.ps1
+++ b/Functions/DCIM/ConsoleServerPortTemplates/Get-NBDCIMConsoleServerPortTemplate.ps1
@@ -8,6 +8,27 @@
 .PARAMETER Raw
     Return the raw API response instead of the results array.
 
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .EXAMPLE
     Get-NBDCIMConsoleServerPortTemplate
 

--- a/Functions/DCIM/ConsoleServerPorts/Get-NBDCIMConsoleServerPort.ps1
+++ b/Functions/DCIM/ConsoleServerPorts/Get-NBDCIMConsoleServerPort.ps1
@@ -8,6 +8,27 @@
 .PARAMETER Raw
     Return the raw API response instead of the results array.
 
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .EXAMPLE
     Get-NBDCIMConsoleServerPort
 

--- a/Functions/DCIM/ConsoleServerPorts/Get-NBDCIMConsoleServerPort.ps1
+++ b/Functions/DCIM/ConsoleServerPorts/Get-NBDCIMConsoleServerPort.ps1
@@ -28,7 +28,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .EXAMPLE
     Get-NBDCIMConsoleServerPort
 

--- a/Functions/DCIM/DeviceBayTemplates/Get-NBDCIMDeviceBayTemplate.ps1
+++ b/Functions/DCIM/DeviceBayTemplates/Get-NBDCIMDeviceBayTemplate.ps1
@@ -28,7 +28,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .EXAMPLE
     Get-NBDCIMDeviceBayTemplate
 

--- a/Functions/DCIM/DeviceBayTemplates/Get-NBDCIMDeviceBayTemplate.ps1
+++ b/Functions/DCIM/DeviceBayTemplates/Get-NBDCIMDeviceBayTemplate.ps1
@@ -8,6 +8,27 @@
 .PARAMETER Raw
     Return the raw API response instead of the results array.
 
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .EXAMPLE
     Get-NBDCIMDeviceBayTemplate
 

--- a/Functions/DCIM/DeviceBays/Get-NBDCIMDeviceBay.ps1
+++ b/Functions/DCIM/DeviceBays/Get-NBDCIMDeviceBay.ps1
@@ -8,6 +8,27 @@
 .PARAMETER Raw
     Return the raw API response instead of the results array.
 
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .EXAMPLE
     Get-NBDCIMDeviceBay
 

--- a/Functions/DCIM/DeviceBays/Get-NBDCIMDeviceBay.ps1
+++ b/Functions/DCIM/DeviceBays/Get-NBDCIMDeviceBay.ps1
@@ -28,7 +28,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .EXAMPLE
     Get-NBDCIMDeviceBay
 

--- a/Functions/DCIM/Devices/Get-NBDCIMDevice.ps1
+++ b/Functions/DCIM/Devices/Get-NBDCIMDevice.ps1
@@ -82,7 +82,6 @@ function Get-NBDCIMDevice {
 
         [string[]]$Fields,
 
-
         [string[]]$Omit,
 
         [switch]$IncludeConfigContext,

--- a/Functions/DCIM/Devices/Get-NBDCIMDeviceRole.ps1
+++ b/Functions/DCIM/Devices/Get-NBDCIMDeviceRole.ps1
@@ -28,7 +28,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .EXAMPLE
     Get-NBDCIMDeviceRole
 

--- a/Functions/DCIM/Devices/Get-NBDCIMDeviceRole.ps1
+++ b/Functions/DCIM/Devices/Get-NBDCIMDeviceRole.ps1
@@ -8,6 +8,27 @@
 .PARAMETER Raw
     Return the raw API response instead of the results array.
 
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .EXAMPLE
     Get-NBDCIMDeviceRole
 

--- a/Functions/DCIM/Devices/Get-NBDCIMDeviceType.ps1
+++ b/Functions/DCIM/Devices/Get-NBDCIMDeviceType.ps1
@@ -28,7 +28,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .EXAMPLE
     Get-NBDCIMDeviceType
 

--- a/Functions/DCIM/Devices/Get-NBDCIMDeviceType.ps1
+++ b/Functions/DCIM/Devices/Get-NBDCIMDeviceType.ps1
@@ -8,6 +8,27 @@
 .PARAMETER Raw
     Return the raw API response instead of the results array.
 
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .EXAMPLE
     Get-NBDCIMDeviceType
 

--- a/Functions/DCIM/FrontPortTemplates/Get-NBDCIMFrontPortTemplate.ps1
+++ b/Functions/DCIM/FrontPortTemplates/Get-NBDCIMFrontPortTemplate.ps1
@@ -28,7 +28,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .EXAMPLE
     Get-NBDCIMFrontPortTemplate
 

--- a/Functions/DCIM/FrontPortTemplates/Get-NBDCIMFrontPortTemplate.ps1
+++ b/Functions/DCIM/FrontPortTemplates/Get-NBDCIMFrontPortTemplate.ps1
@@ -8,6 +8,27 @@
 .PARAMETER Raw
     Return the raw API response instead of the results array.
 
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .EXAMPLE
     Get-NBDCIMFrontPortTemplate
 

--- a/Functions/DCIM/FrontPorts/Get-NBDCIMFrontPort.ps1
+++ b/Functions/DCIM/FrontPorts/Get-NBDCIMFrontPort.ps1
@@ -28,7 +28,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .EXAMPLE
     Get-NBDCIMFrontPort
 

--- a/Functions/DCIM/FrontPorts/Get-NBDCIMFrontPort.ps1
+++ b/Functions/DCIM/FrontPorts/Get-NBDCIMFrontPort.ps1
@@ -8,6 +8,27 @@
 .PARAMETER Raw
     Return the raw API response instead of the results array.
 
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .EXAMPLE
     Get-NBDCIMFrontPort
 

--- a/Functions/DCIM/InterfaceTemplates/Get-NBDCIMInterfaceTemplate.ps1
+++ b/Functions/DCIM/InterfaceTemplates/Get-NBDCIMInterfaceTemplate.ps1
@@ -28,7 +28,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .EXAMPLE
     Get-NBDCIMInterfaceTemplate
 

--- a/Functions/DCIM/InterfaceTemplates/Get-NBDCIMInterfaceTemplate.ps1
+++ b/Functions/DCIM/InterfaceTemplates/Get-NBDCIMInterfaceTemplate.ps1
@@ -8,6 +8,27 @@
 .PARAMETER Raw
     Return the raw API response instead of the results array.
 
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .EXAMPLE
     Get-NBDCIMInterfaceTemplate
 

--- a/Functions/DCIM/Interfaces/Get-NBDCIMInterface.ps1
+++ b/Functions/DCIM/Interfaces/Get-NBDCIMInterface.ps1
@@ -28,7 +28,6 @@
     Specify which fields to include in the response.
     Supports nested field selection (e.g., 'site.name', 'device_type.model').
 
-
 .EXAMPLE
     Get-NBDCIMInterface
 
@@ -52,7 +51,6 @@ function Get-NBDCIMInterface {
         [switch]$Brief,
 
         [string[]]$Fields,
-
 
         [string[]]$Omit,
 

--- a/Functions/DCIM/Interfaces/Get-NBDCIMInterface.ps1
+++ b/Functions/DCIM/Interfaces/Get-NBDCIMInterface.ps1
@@ -12,6 +12,23 @@
 .PARAMETER Raw
     Return the raw API response instead of the results array.
 
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+
 .EXAMPLE
     Get-NBDCIMInterface
 

--- a/Functions/DCIM/Interfaces/Get-NBDCIMInterfaceConnection.ps1
+++ b/Functions/DCIM/Interfaces/Get-NBDCIMInterfaceConnection.ps1
@@ -28,7 +28,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .EXAMPLE
     Get-NBDCIMInterfaceConnection
 

--- a/Functions/DCIM/Interfaces/Get-NBDCIMInterfaceConnection.ps1
+++ b/Functions/DCIM/Interfaces/Get-NBDCIMInterfaceConnection.ps1
@@ -8,6 +8,27 @@
 .PARAMETER Raw
     Return the raw API response instead of the results array.
 
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .EXAMPLE
     Get-NBDCIMInterfaceConnection
 

--- a/Functions/DCIM/InventoryItemRoles/Get-NBDCIMInventoryItemRole.ps1
+++ b/Functions/DCIM/InventoryItemRoles/Get-NBDCIMInventoryItemRole.ps1
@@ -8,6 +8,27 @@
 .PARAMETER Raw
     Return the raw API response instead of the results array.
 
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .EXAMPLE
     Get-NBDCIMInventoryItemRole
 

--- a/Functions/DCIM/InventoryItemRoles/Get-NBDCIMInventoryItemRole.ps1
+++ b/Functions/DCIM/InventoryItemRoles/Get-NBDCIMInventoryItemRole.ps1
@@ -28,7 +28,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .EXAMPLE
     Get-NBDCIMInventoryItemRole
 

--- a/Functions/DCIM/InventoryItemTemplates/Get-NBDCIMInventoryItemTemplate.ps1
+++ b/Functions/DCIM/InventoryItemTemplates/Get-NBDCIMInventoryItemTemplate.ps1
@@ -8,6 +8,27 @@
 .PARAMETER Raw
     Return the raw API response instead of the results array.
 
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .EXAMPLE
     Get-NBDCIMInventoryItemTemplate
 

--- a/Functions/DCIM/InventoryItemTemplates/Get-NBDCIMInventoryItemTemplate.ps1
+++ b/Functions/DCIM/InventoryItemTemplates/Get-NBDCIMInventoryItemTemplate.ps1
@@ -28,7 +28,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .EXAMPLE
     Get-NBDCIMInventoryItemTemplate
 

--- a/Functions/DCIM/InventoryItems/Get-NBDCIMInventoryItem.ps1
+++ b/Functions/DCIM/InventoryItems/Get-NBDCIMInventoryItem.ps1
@@ -28,7 +28,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .EXAMPLE
     Get-NBDCIMInventoryItem
 

--- a/Functions/DCIM/InventoryItems/Get-NBDCIMInventoryItem.ps1
+++ b/Functions/DCIM/InventoryItems/Get-NBDCIMInventoryItem.ps1
@@ -8,6 +8,27 @@
 .PARAMETER Raw
     Return the raw API response instead of the results array.
 
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .EXAMPLE
     Get-NBDCIMInventoryItem
 

--- a/Functions/DCIM/Locations/Get-NBDCIMLocation.ps1
+++ b/Functions/DCIM/Locations/Get-NBDCIMLocation.ps1
@@ -63,7 +63,6 @@ function Get-NBDCIMLocation {
         Specify which fields to exclude from the response.
         Requires Netbox 4.5.0 or later.
 
-
     .EXAMPLE
         Get-NBDCIMLocation
 

--- a/Functions/DCIM/Locations/Get-NBDCIMLocation.ps1
+++ b/Functions/DCIM/Locations/Get-NBDCIMLocation.ps1
@@ -43,6 +43,27 @@ function Get-NBDCIMLocation {
     .PARAMETER Raw
         Return the raw API response
 
+    .PARAMETER All
+        Automatically fetch all pages of results. Uses the API's pagination
+        to retrieve all items across multiple requests.
+
+    .PARAMETER PageSize
+        Number of items per page when using -All. Default: 100.
+        Range: 1-1000.
+
+    .PARAMETER Brief
+        Return a minimal representation of objects (id, url, display, name only).
+        Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+    .PARAMETER Fields
+        Specify which fields to include in the response.
+        Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+    .PARAMETER Omit
+        Specify which fields to exclude from the response.
+        Requires Netbox 4.5.0 or later.
+
+
     .EXAMPLE
         Get-NBDCIMLocation
 

--- a/Functions/DCIM/MACAddresses/Get-NBDCIMMACAddress.ps1
+++ b/Functions/DCIM/MACAddresses/Get-NBDCIMMACAddress.ps1
@@ -8,6 +8,27 @@
 .PARAMETER Raw
     Return the raw API response instead of the results array.
 
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .EXAMPLE
     Get-NBDCIMMACAddress
 

--- a/Functions/DCIM/MACAddresses/Get-NBDCIMMACAddress.ps1
+++ b/Functions/DCIM/MACAddresses/Get-NBDCIMMACAddress.ps1
@@ -28,7 +28,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .EXAMPLE
     Get-NBDCIMMACAddress
 

--- a/Functions/DCIM/Manufacturers/Get-NBDCIMManufacturer.ps1
+++ b/Functions/DCIM/Manufacturers/Get-NBDCIMManufacturer.ps1
@@ -47,7 +47,6 @@ function Get-NBDCIMManufacturer {
         Specify which fields to exclude from the response.
         Requires Netbox 4.5.0 or later.
 
-
     .EXAMPLE
         Get-NBDCIMManufacturer
 

--- a/Functions/DCIM/Manufacturers/Get-NBDCIMManufacturer.ps1
+++ b/Functions/DCIM/Manufacturers/Get-NBDCIMManufacturer.ps1
@@ -27,6 +27,27 @@ function Get-NBDCIMManufacturer {
     .PARAMETER Raw
         Return the raw API response
 
+    .PARAMETER All
+        Automatically fetch all pages of results. Uses the API's pagination
+        to retrieve all items across multiple requests.
+
+    .PARAMETER PageSize
+        Number of items per page when using -All. Default: 100.
+        Range: 1-1000.
+
+    .PARAMETER Brief
+        Return a minimal representation of objects (id, url, display, name only).
+        Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+    .PARAMETER Fields
+        Specify which fields to include in the response.
+        Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+    .PARAMETER Omit
+        Specify which fields to exclude from the response.
+        Requires Netbox 4.5.0 or later.
+
+
     .EXAMPLE
         Get-NBDCIMManufacturer
 

--- a/Functions/DCIM/ModuleBayTemplates/Get-NBDCIMModuleBayTemplate.ps1
+++ b/Functions/DCIM/ModuleBayTemplates/Get-NBDCIMModuleBayTemplate.ps1
@@ -28,7 +28,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .EXAMPLE
     Get-NBDCIMModuleBayTemplate
 

--- a/Functions/DCIM/ModuleBayTemplates/Get-NBDCIMModuleBayTemplate.ps1
+++ b/Functions/DCIM/ModuleBayTemplates/Get-NBDCIMModuleBayTemplate.ps1
@@ -8,6 +8,27 @@
 .PARAMETER Raw
     Return the raw API response instead of the results array.
 
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .EXAMPLE
     Get-NBDCIMModuleBayTemplate
 

--- a/Functions/DCIM/ModuleBays/Get-NBDCIMModuleBay.ps1
+++ b/Functions/DCIM/ModuleBays/Get-NBDCIMModuleBay.ps1
@@ -28,7 +28,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .EXAMPLE
     Get-NBDCIMModuleBay
 

--- a/Functions/DCIM/ModuleBays/Get-NBDCIMModuleBay.ps1
+++ b/Functions/DCIM/ModuleBays/Get-NBDCIMModuleBay.ps1
@@ -8,6 +8,27 @@
 .PARAMETER Raw
     Return the raw API response instead of the results array.
 
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .EXAMPLE
     Get-NBDCIMModuleBay
 

--- a/Functions/DCIM/ModuleTypeProfiles/Get-NBDCIMModuleTypeProfile.ps1
+++ b/Functions/DCIM/ModuleTypeProfiles/Get-NBDCIMModuleTypeProfile.ps1
@@ -8,6 +8,27 @@
 .PARAMETER Raw
     Return the raw API response instead of the results array.
 
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .EXAMPLE
     Get-NBDCIMModuleTypeProfile
 

--- a/Functions/DCIM/ModuleTypeProfiles/Get-NBDCIMModuleTypeProfile.ps1
+++ b/Functions/DCIM/ModuleTypeProfiles/Get-NBDCIMModuleTypeProfile.ps1
@@ -28,7 +28,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .EXAMPLE
     Get-NBDCIMModuleTypeProfile
 

--- a/Functions/DCIM/ModuleTypes/Get-NBDCIMModuleType.ps1
+++ b/Functions/DCIM/ModuleTypes/Get-NBDCIMModuleType.ps1
@@ -8,6 +8,27 @@
 .PARAMETER Raw
     Return the raw API response instead of the results array.
 
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .EXAMPLE
     Get-NBDCIMModuleType
 

--- a/Functions/DCIM/ModuleTypes/Get-NBDCIMModuleType.ps1
+++ b/Functions/DCIM/ModuleTypes/Get-NBDCIMModuleType.ps1
@@ -28,7 +28,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .EXAMPLE
     Get-NBDCIMModuleType
 

--- a/Functions/DCIM/Modules/Get-NBDCIMModule.ps1
+++ b/Functions/DCIM/Modules/Get-NBDCIMModule.ps1
@@ -8,6 +8,27 @@
 .PARAMETER Raw
     Return the raw API response instead of the results array.
 
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .EXAMPLE
     Get-NBDCIMModule
 

--- a/Functions/DCIM/Modules/Get-NBDCIMModule.ps1
+++ b/Functions/DCIM/Modules/Get-NBDCIMModule.ps1
@@ -28,7 +28,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .EXAMPLE
     Get-NBDCIMModule
 

--- a/Functions/DCIM/Platforms/Get-NBDCIMPlatform.ps1
+++ b/Functions/DCIM/Platforms/Get-NBDCIMPlatform.ps1
@@ -8,6 +8,27 @@
 .PARAMETER Raw
     Return the raw API response instead of the results array.
 
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .EXAMPLE
     Get-NBDCIMPlatform
 

--- a/Functions/DCIM/Platforms/Get-NBDCIMPlatform.ps1
+++ b/Functions/DCIM/Platforms/Get-NBDCIMPlatform.ps1
@@ -28,7 +28,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .EXAMPLE
     Get-NBDCIMPlatform
 

--- a/Functions/DCIM/PowerFeeds/Get-NBDCIMPowerFeed.ps1
+++ b/Functions/DCIM/PowerFeeds/Get-NBDCIMPowerFeed.ps1
@@ -8,6 +8,27 @@
 .PARAMETER Raw
     Return the raw API response instead of the results array.
 
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .EXAMPLE
     Get-NBDCIMPowerFeed
 

--- a/Functions/DCIM/PowerFeeds/Get-NBDCIMPowerFeed.ps1
+++ b/Functions/DCIM/PowerFeeds/Get-NBDCIMPowerFeed.ps1
@@ -28,7 +28,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .EXAMPLE
     Get-NBDCIMPowerFeed
 

--- a/Functions/DCIM/PowerOutletTemplates/Get-NBDCIMPowerOutletTemplate.ps1
+++ b/Functions/DCIM/PowerOutletTemplates/Get-NBDCIMPowerOutletTemplate.ps1
@@ -28,7 +28,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .EXAMPLE
     Get-NBDCIMPowerOutletTemplate
 

--- a/Functions/DCIM/PowerOutletTemplates/Get-NBDCIMPowerOutletTemplate.ps1
+++ b/Functions/DCIM/PowerOutletTemplates/Get-NBDCIMPowerOutletTemplate.ps1
@@ -8,6 +8,27 @@
 .PARAMETER Raw
     Return the raw API response instead of the results array.
 
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .EXAMPLE
     Get-NBDCIMPowerOutletTemplate
 

--- a/Functions/DCIM/PowerOutlets/Get-NBDCIMPowerOutlet.ps1
+++ b/Functions/DCIM/PowerOutlets/Get-NBDCIMPowerOutlet.ps1
@@ -28,7 +28,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .EXAMPLE
     Get-NBDCIMPowerOutlet
 

--- a/Functions/DCIM/PowerOutlets/Get-NBDCIMPowerOutlet.ps1
+++ b/Functions/DCIM/PowerOutlets/Get-NBDCIMPowerOutlet.ps1
@@ -8,6 +8,27 @@
 .PARAMETER Raw
     Return the raw API response instead of the results array.
 
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .EXAMPLE
     Get-NBDCIMPowerOutlet
 

--- a/Functions/DCIM/PowerPanels/Get-NBDCIMPowerPanel.ps1
+++ b/Functions/DCIM/PowerPanels/Get-NBDCIMPowerPanel.ps1
@@ -8,6 +8,27 @@
 .PARAMETER Raw
     Return the raw API response instead of the results array.
 
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .EXAMPLE
     Get-NBDCIMPowerPanel
 

--- a/Functions/DCIM/PowerPanels/Get-NBDCIMPowerPanel.ps1
+++ b/Functions/DCIM/PowerPanels/Get-NBDCIMPowerPanel.ps1
@@ -28,7 +28,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .EXAMPLE
     Get-NBDCIMPowerPanel
 

--- a/Functions/DCIM/PowerPortTemplates/Get-NBDCIMPowerPortTemplate.ps1
+++ b/Functions/DCIM/PowerPortTemplates/Get-NBDCIMPowerPortTemplate.ps1
@@ -28,7 +28,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .EXAMPLE
     Get-NBDCIMPowerPortTemplate
 

--- a/Functions/DCIM/PowerPortTemplates/Get-NBDCIMPowerPortTemplate.ps1
+++ b/Functions/DCIM/PowerPortTemplates/Get-NBDCIMPowerPortTemplate.ps1
@@ -8,6 +8,27 @@
 .PARAMETER Raw
     Return the raw API response instead of the results array.
 
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .EXAMPLE
     Get-NBDCIMPowerPortTemplate
 

--- a/Functions/DCIM/PowerPorts/Get-NBDCIMPowerPort.ps1
+++ b/Functions/DCIM/PowerPorts/Get-NBDCIMPowerPort.ps1
@@ -28,7 +28,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .EXAMPLE
     Get-NBDCIMPowerPort
 

--- a/Functions/DCIM/PowerPorts/Get-NBDCIMPowerPort.ps1
+++ b/Functions/DCIM/PowerPorts/Get-NBDCIMPowerPort.ps1
@@ -8,6 +8,27 @@
 .PARAMETER Raw
     Return the raw API response instead of the results array.
 
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .EXAMPLE
     Get-NBDCIMPowerPort
 

--- a/Functions/DCIM/RackReservations/Get-NBDCIMRackReservation.ps1
+++ b/Functions/DCIM/RackReservations/Get-NBDCIMRackReservation.ps1
@@ -8,6 +8,27 @@
 .PARAMETER Raw
     Return the raw API response instead of the results array.
 
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .EXAMPLE
     Get-NBDCIMRackReservation
 

--- a/Functions/DCIM/RackReservations/Get-NBDCIMRackReservation.ps1
+++ b/Functions/DCIM/RackReservations/Get-NBDCIMRackReservation.ps1
@@ -28,7 +28,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .EXAMPLE
     Get-NBDCIMRackReservation
 

--- a/Functions/DCIM/RackRoles/Get-NBDCIMRackRole.ps1
+++ b/Functions/DCIM/RackRoles/Get-NBDCIMRackRole.ps1
@@ -8,6 +8,27 @@
 .PARAMETER Raw
     Return the raw API response instead of the results array.
 
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .EXAMPLE
     Get-NBDCIMRackRole
 

--- a/Functions/DCIM/RackRoles/Get-NBDCIMRackRole.ps1
+++ b/Functions/DCIM/RackRoles/Get-NBDCIMRackRole.ps1
@@ -28,7 +28,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .EXAMPLE
     Get-NBDCIMRackRole
 

--- a/Functions/DCIM/RackTypes/Get-NBDCIMRackType.ps1
+++ b/Functions/DCIM/RackTypes/Get-NBDCIMRackType.ps1
@@ -28,7 +28,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .EXAMPLE
     Get-NBDCIMRackType
 

--- a/Functions/DCIM/RackTypes/Get-NBDCIMRackType.ps1
+++ b/Functions/DCIM/RackTypes/Get-NBDCIMRackType.ps1
@@ -8,6 +8,27 @@
 .PARAMETER Raw
     Return the raw API response instead of the results array.
 
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .EXAMPLE
     Get-NBDCIMRackType
 

--- a/Functions/DCIM/Racks/Get-NBDCIMRack.ps1
+++ b/Functions/DCIM/Racks/Get-NBDCIMRack.ps1
@@ -71,7 +71,6 @@ function Get-NBDCIMRack {
         Specify which fields to exclude from the response.
         Requires Netbox 4.5.0 or later.
 
-
     .EXAMPLE
         Get-NBDCIMRack
 

--- a/Functions/DCIM/Racks/Get-NBDCIMRack.ps1
+++ b/Functions/DCIM/Racks/Get-NBDCIMRack.ps1
@@ -51,6 +51,27 @@ function Get-NBDCIMRack {
     .PARAMETER Raw
         Return the raw API response
 
+    .PARAMETER All
+        Automatically fetch all pages of results. Uses the API's pagination
+        to retrieve all items across multiple requests.
+
+    .PARAMETER PageSize
+        Number of items per page when using -All. Default: 100.
+        Range: 1-1000.
+
+    .PARAMETER Brief
+        Return a minimal representation of objects (id, url, display, name only).
+        Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+    .PARAMETER Fields
+        Specify which fields to include in the response.
+        Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+    .PARAMETER Omit
+        Specify which fields to exclude from the response.
+        Requires Netbox 4.5.0 or later.
+
+
     .EXAMPLE
         Get-NBDCIMRack
 

--- a/Functions/DCIM/Racks/Get-NBDCIMRackElevation.ps1
+++ b/Functions/DCIM/Racks/Get-NBDCIMRackElevation.ps1
@@ -35,7 +35,6 @@ function Get-NBDCIMRackElevation {
         Number of items per page when using -All. Default: 100.
         Range: 1-1000.
 
-
     .EXAMPLE
         Get-NBDCIMRackElevation -Id 24
 

--- a/Functions/DCIM/Racks/Get-NBDCIMRackElevation.ps1
+++ b/Functions/DCIM/Racks/Get-NBDCIMRackElevation.ps1
@@ -31,6 +31,11 @@ function Get-NBDCIMRackElevation {
     .PARAMETER Raw
         Return the raw API response
 
+    .PARAMETER PageSize
+        Number of items per page when using -All. Default: 100.
+        Range: 1-1000.
+
+
     .EXAMPLE
         Get-NBDCIMRackElevation -Id 24
 

--- a/Functions/DCIM/RearPortTemplates/Get-NBDCIMRearPortTemplate.ps1
+++ b/Functions/DCIM/RearPortTemplates/Get-NBDCIMRearPortTemplate.ps1
@@ -8,6 +8,27 @@
 .PARAMETER Raw
     Return the raw API response instead of the results array.
 
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .EXAMPLE
     Get-NBDCIMRearPortTemplate
 

--- a/Functions/DCIM/RearPortTemplates/Get-NBDCIMRearPortTemplate.ps1
+++ b/Functions/DCIM/RearPortTemplates/Get-NBDCIMRearPortTemplate.ps1
@@ -28,7 +28,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .EXAMPLE
     Get-NBDCIMRearPortTemplate
 

--- a/Functions/DCIM/RearPorts/Get-NBDCIMRearPort.ps1
+++ b/Functions/DCIM/RearPorts/Get-NBDCIMRearPort.ps1
@@ -28,7 +28,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .EXAMPLE
     Get-NBDCIMRearPort
 

--- a/Functions/DCIM/RearPorts/Get-NBDCIMRearPort.ps1
+++ b/Functions/DCIM/RearPorts/Get-NBDCIMRearPort.ps1
@@ -8,6 +8,27 @@
 .PARAMETER Raw
     Return the raw API response instead of the results array.
 
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .EXAMPLE
     Get-NBDCIMRearPort
 

--- a/Functions/DCIM/Regions/Get-NBDCIMRegion.ps1
+++ b/Functions/DCIM/Regions/Get-NBDCIMRegion.ps1
@@ -31,6 +31,27 @@ function Get-NBDCIMRegion {
     .PARAMETER Raw
         Return the raw API response
 
+    .PARAMETER All
+        Automatically fetch all pages of results. Uses the API's pagination
+        to retrieve all items across multiple requests.
+
+    .PARAMETER PageSize
+        Number of items per page when using -All. Default: 100.
+        Range: 1-1000.
+
+    .PARAMETER Brief
+        Return a minimal representation of objects (id, url, display, name only).
+        Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+    .PARAMETER Fields
+        Specify which fields to include in the response.
+        Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+    .PARAMETER Omit
+        Specify which fields to exclude from the response.
+        Requires Netbox 4.5.0 or later.
+
+
     .EXAMPLE
         Get-NBDCIMRegion
 

--- a/Functions/DCIM/Regions/Get-NBDCIMRegion.ps1
+++ b/Functions/DCIM/Regions/Get-NBDCIMRegion.ps1
@@ -51,7 +51,6 @@ function Get-NBDCIMRegion {
         Specify which fields to exclude from the response.
         Requires Netbox 4.5.0 or later.
 
-
     .EXAMPLE
         Get-NBDCIMRegion
 

--- a/Functions/DCIM/SiteGroups/Get-NBDCIMSiteGroup.ps1
+++ b/Functions/DCIM/SiteGroups/Get-NBDCIMSiteGroup.ps1
@@ -31,6 +31,27 @@ function Get-NBDCIMSiteGroup {
     .PARAMETER Raw
         Return the raw API response
 
+    .PARAMETER All
+        Automatically fetch all pages of results. Uses the API's pagination
+        to retrieve all items across multiple requests.
+
+    .PARAMETER PageSize
+        Number of items per page when using -All. Default: 100.
+        Range: 1-1000.
+
+    .PARAMETER Brief
+        Return a minimal representation of objects (id, url, display, name only).
+        Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+    .PARAMETER Fields
+        Specify which fields to include in the response.
+        Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+    .PARAMETER Omit
+        Specify which fields to exclude from the response.
+        Requires Netbox 4.5.0 or later.
+
+
     .EXAMPLE
         Get-NBDCIMSiteGroup
 

--- a/Functions/DCIM/SiteGroups/Get-NBDCIMSiteGroup.ps1
+++ b/Functions/DCIM/SiteGroups/Get-NBDCIMSiteGroup.ps1
@@ -51,7 +51,6 @@ function Get-NBDCIMSiteGroup {
         Specify which fields to exclude from the response.
         Requires Netbox 4.5.0 or later.
 
-
     .EXAMPLE
         Get-NBDCIMSiteGroup
 

--- a/Functions/DCIM/Sites/Get-NBDCIMSite.ps1
+++ b/Functions/DCIM/Sites/Get-NBDCIMSite.ps1
@@ -28,7 +28,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .EXAMPLE
     Get-NBDCIMSite
 

--- a/Functions/DCIM/Sites/Get-NBDCIMSite.ps1
+++ b/Functions/DCIM/Sites/Get-NBDCIMSite.ps1
@@ -8,6 +8,27 @@
 .PARAMETER Raw
     Return the raw API response instead of the results array.
 
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .EXAMPLE
     Get-NBDCIMSite
 

--- a/Functions/DCIM/VirtualChassis/Get-NBDCIMVirtualChassis.ps1
+++ b/Functions/DCIM/VirtualChassis/Get-NBDCIMVirtualChassis.ps1
@@ -8,6 +8,27 @@
 .PARAMETER Raw
     Return the raw API response instead of the results array.
 
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .EXAMPLE
     Get-NBDCIMVirtualChassis
 

--- a/Functions/DCIM/VirtualChassis/Get-NBDCIMVirtualChassis.ps1
+++ b/Functions/DCIM/VirtualChassis/Get-NBDCIMVirtualChassis.ps1
@@ -28,7 +28,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .EXAMPLE
     Get-NBDCIMVirtualChassis
 

--- a/Functions/DCIM/VirtualDeviceContexts/Get-NBDCIMVirtualDeviceContext.ps1
+++ b/Functions/DCIM/VirtualDeviceContexts/Get-NBDCIMVirtualDeviceContext.ps1
@@ -8,6 +8,27 @@
 .PARAMETER Raw
     Return the raw API response instead of the results array.
 
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .EXAMPLE
     Get-NBDCIMVirtualDeviceContext
 

--- a/Functions/DCIM/VirtualDeviceContexts/Get-NBDCIMVirtualDeviceContext.ps1
+++ b/Functions/DCIM/VirtualDeviceContexts/Get-NBDCIMVirtualDeviceContext.ps1
@@ -28,7 +28,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .EXAMPLE
     Get-NBDCIMVirtualDeviceContext
 

--- a/Functions/Extras/Bookmarks/Get-NBBookmark.ps1
+++ b/Functions/Extras/Bookmarks/Get-NBBookmark.ps1
@@ -26,6 +26,27 @@
 .PARAMETER Raw
     Return the raw API response.
 
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .EXAMPLE
     Get-NBBookmark
 

--- a/Functions/Extras/Bookmarks/Get-NBBookmark.ps1
+++ b/Functions/Extras/Bookmarks/Get-NBBookmark.ps1
@@ -46,7 +46,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .EXAMPLE
     Get-NBBookmark
 

--- a/Functions/Extras/ConfigContexts/Get-NBConfigContext.ps1
+++ b/Functions/Extras/ConfigContexts/Get-NBConfigContext.ps1
@@ -46,7 +46,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .EXAMPLE
     Get-NBConfigContext
 

--- a/Functions/Extras/ConfigContexts/Get-NBConfigContext.ps1
+++ b/Functions/Extras/ConfigContexts/Get-NBConfigContext.ps1
@@ -26,6 +26,27 @@
 .PARAMETER Raw
     Return the raw API response.
 
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .EXAMPLE
     Get-NBConfigContext
 

--- a/Functions/Extras/CustomFieldChoiceSets/Get-NBCustomFieldChoiceSet.ps1
+++ b/Functions/Extras/CustomFieldChoiceSets/Get-NBCustomFieldChoiceSet.ps1
@@ -23,6 +23,27 @@
 .PARAMETER Raw
     Return the raw API response.
 
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .EXAMPLE
     Get-NBCustomFieldChoiceSet
 

--- a/Functions/Extras/CustomFieldChoiceSets/Get-NBCustomFieldChoiceSet.ps1
+++ b/Functions/Extras/CustomFieldChoiceSets/Get-NBCustomFieldChoiceSet.ps1
@@ -43,7 +43,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .EXAMPLE
     Get-NBCustomFieldChoiceSet
 

--- a/Functions/Extras/CustomFields/Get-NBCustomField.ps1
+++ b/Functions/Extras/CustomFields/Get-NBCustomField.ps1
@@ -49,7 +49,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .EXAMPLE
     Get-NBCustomField
 

--- a/Functions/Extras/CustomFields/Get-NBCustomField.ps1
+++ b/Functions/Extras/CustomFields/Get-NBCustomField.ps1
@@ -29,6 +29,27 @@
 .PARAMETER Raw
     Return the raw API response.
 
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .EXAMPLE
     Get-NBCustomField
 

--- a/Functions/Extras/CustomLinks/Get-NBCustomLink.ps1
+++ b/Functions/Extras/CustomLinks/Get-NBCustomLink.ps1
@@ -26,6 +26,27 @@
 .PARAMETER Raw
     Return the raw API response.
 
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .EXAMPLE
     Get-NBCustomLink
 

--- a/Functions/Extras/CustomLinks/Get-NBCustomLink.ps1
+++ b/Functions/Extras/CustomLinks/Get-NBCustomLink.ps1
@@ -46,7 +46,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .EXAMPLE
     Get-NBCustomLink
 

--- a/Functions/Extras/EventRules/Get-NBEventRule.ps1
+++ b/Functions/Extras/EventRules/Get-NBEventRule.ps1
@@ -55,7 +55,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .EXAMPLE
     Get-NBEventRule
 

--- a/Functions/Extras/EventRules/Get-NBEventRule.ps1
+++ b/Functions/Extras/EventRules/Get-NBEventRule.ps1
@@ -35,6 +35,27 @@
 .PARAMETER Raw
     Return the raw API response.
 
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .EXAMPLE
     Get-NBEventRule
 

--- a/Functions/Extras/ExportTemplates/Get-NBExportTemplate.ps1
+++ b/Functions/Extras/ExportTemplates/Get-NBExportTemplate.ps1
@@ -26,6 +26,27 @@
 .PARAMETER Raw
     Return the raw API response.
 
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .EXAMPLE
     Get-NBExportTemplate
 

--- a/Functions/Extras/ExportTemplates/Get-NBExportTemplate.ps1
+++ b/Functions/Extras/ExportTemplates/Get-NBExportTemplate.ps1
@@ -46,7 +46,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .EXAMPLE
     Get-NBExportTemplate
 

--- a/Functions/Extras/ImageAttachments/Get-NBImageAttachment.ps1
+++ b/Functions/Extras/ImageAttachments/Get-NBImageAttachment.ps1
@@ -49,7 +49,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .EXAMPLE
     Get-NBImageAttachment
 

--- a/Functions/Extras/ImageAttachments/Get-NBImageAttachment.ps1
+++ b/Functions/Extras/ImageAttachments/Get-NBImageAttachment.ps1
@@ -29,6 +29,27 @@
 .PARAMETER Raw
     Return the raw API response.
 
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .EXAMPLE
     Get-NBImageAttachment
 

--- a/Functions/Extras/JournalEntries/Get-NBJournalEntry.ps1
+++ b/Functions/Extras/JournalEntries/Get-NBJournalEntry.ps1
@@ -52,7 +52,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .EXAMPLE
     Get-NBJournalEntry
 

--- a/Functions/Extras/JournalEntries/Get-NBJournalEntry.ps1
+++ b/Functions/Extras/JournalEntries/Get-NBJournalEntry.ps1
@@ -32,6 +32,27 @@
 .PARAMETER Raw
     Return the raw API response.
 
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .EXAMPLE
     Get-NBJournalEntry
 

--- a/Functions/Extras/SavedFilters/Get-NBSavedFilter.ps1
+++ b/Functions/Extras/SavedFilters/Get-NBSavedFilter.ps1
@@ -38,6 +38,27 @@
 .PARAMETER Raw
     Return the raw API response.
 
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .EXAMPLE
     Get-NBSavedFilter
 

--- a/Functions/Extras/SavedFilters/Get-NBSavedFilter.ps1
+++ b/Functions/Extras/SavedFilters/Get-NBSavedFilter.ps1
@@ -58,7 +58,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .EXAMPLE
     Get-NBSavedFilter
 

--- a/Functions/Extras/Tags/Get-NBTag.ps1
+++ b/Functions/Extras/Tags/Get-NBTag.ps1
@@ -8,6 +8,27 @@
 .PARAMETER Raw
     Return the raw API response instead of the results array.
 
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .EXAMPLE
     Get-NBTag
 

--- a/Functions/Extras/Tags/Get-NBTag.ps1
+++ b/Functions/Extras/Tags/Get-NBTag.ps1
@@ -28,7 +28,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .EXAMPLE
     Get-NBTag
 

--- a/Functions/Extras/Webhooks/Get-NBWebhook.ps1
+++ b/Functions/Extras/Webhooks/Get-NBWebhook.ps1
@@ -46,7 +46,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .EXAMPLE
     Get-NBWebhook
 

--- a/Functions/Extras/Webhooks/Get-NBWebhook.ps1
+++ b/Functions/Extras/Webhooks/Get-NBWebhook.ps1
@@ -26,6 +26,27 @@
 .PARAMETER Raw
     Return the raw API response.
 
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .EXAMPLE
     Get-NBWebhook
 

--- a/Functions/IPAM/ASN/Get-NBIPAMASN.ps1
+++ b/Functions/IPAM/ASN/Get-NBIPAMASN.ps1
@@ -53,7 +53,6 @@ function Get-NBIPAMASN {
         Specify which fields to exclude from the response.
         Requires Netbox 4.5.0 or later.
 
-
     .EXAMPLE
         Get-NBIPAMASN
 

--- a/Functions/IPAM/ASN/Get-NBIPAMASN.ps1
+++ b/Functions/IPAM/ASN/Get-NBIPAMASN.ps1
@@ -33,6 +33,27 @@ function Get-NBIPAMASN {
     .PARAMETER Raw
         Return the raw API response
 
+    .PARAMETER All
+        Automatically fetch all pages of results. Uses the API's pagination
+        to retrieve all items across multiple requests.
+
+    .PARAMETER PageSize
+        Number of items per page when using -All. Default: 100.
+        Range: 1-1000.
+
+    .PARAMETER Brief
+        Return a minimal representation of objects (id, url, display, name only).
+        Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+    .PARAMETER Fields
+        Specify which fields to include in the response.
+        Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+    .PARAMETER Omit
+        Specify which fields to exclude from the response.
+        Requires Netbox 4.5.0 or later.
+
+
     .EXAMPLE
         Get-NBIPAMASN
 

--- a/Functions/IPAM/ASNRange/Get-NBIPAMASNRange.ps1
+++ b/Functions/IPAM/ASNRange/Get-NBIPAMASNRange.ps1
@@ -50,7 +50,6 @@ function Get-NBIPAMASNRange {
         Specify which fields to exclude from the response.
         Requires Netbox 4.5.0 or later.
 
-
     .EXAMPLE
         Get-NBIPAMASNRange
 

--- a/Functions/IPAM/ASNRange/Get-NBIPAMASNRange.ps1
+++ b/Functions/IPAM/ASNRange/Get-NBIPAMASNRange.ps1
@@ -30,6 +30,27 @@ function Get-NBIPAMASNRange {
     .PARAMETER Raw
         Return the raw API response
 
+    .PARAMETER All
+        Automatically fetch all pages of results. Uses the API's pagination
+        to retrieve all items across multiple requests.
+
+    .PARAMETER PageSize
+        Number of items per page when using -All. Default: 100.
+        Range: 1-1000.
+
+    .PARAMETER Brief
+        Return a minimal representation of objects (id, url, display, name only).
+        Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+    .PARAMETER Fields
+        Specify which fields to include in the response.
+        Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+    .PARAMETER Omit
+        Specify which fields to exclude from the response.
+        Requires Netbox 4.5.0 or later.
+
+
     .EXAMPLE
         Get-NBIPAMASNRange
 

--- a/Functions/IPAM/Address/Get-NBIPAMAddress.ps1
+++ b/Functions/IPAM/Address/Get-NBIPAMAddress.ps1
@@ -28,7 +28,6 @@
     Specify which fields to include in the response.
     Supports nested field selection (e.g., 'site.name', 'device_type.model').
 
-
 .EXAMPLE
     Get-NBIPAMAddress
 
@@ -52,7 +51,6 @@ function Get-NBIPAMAddress {
         [switch]$Brief,
 
         [string[]]$Fields,
-
 
         [string[]]$Omit,
 

--- a/Functions/IPAM/Address/Get-NBIPAMAddress.ps1
+++ b/Functions/IPAM/Address/Get-NBIPAMAddress.ps1
@@ -12,6 +12,23 @@
 .PARAMETER Raw
     Return the raw API response instead of the results array.
 
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+
 .EXAMPLE
     Get-NBIPAMAddress
 

--- a/Functions/IPAM/Aggregate/Get-NBIPAMAggregate.ps1
+++ b/Functions/IPAM/Aggregate/Get-NBIPAMAggregate.ps1
@@ -8,6 +8,27 @@
 .PARAMETER Raw
     Return the raw API response instead of the results array.
 
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .EXAMPLE
     Get-NBIPAMAggregate
 

--- a/Functions/IPAM/Aggregate/Get-NBIPAMAggregate.ps1
+++ b/Functions/IPAM/Aggregate/Get-NBIPAMAggregate.ps1
@@ -28,7 +28,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .EXAMPLE
     Get-NBIPAMAggregate
 

--- a/Functions/IPAM/FHRPGroup/Get-NBIPAMFHRPGroup.ps1
+++ b/Functions/IPAM/FHRPGroup/Get-NBIPAMFHRPGroup.ps1
@@ -28,7 +28,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .EXAMPLE
     Get-NBIPAMFHRPGroup
 

--- a/Functions/IPAM/FHRPGroup/Get-NBIPAMFHRPGroup.ps1
+++ b/Functions/IPAM/FHRPGroup/Get-NBIPAMFHRPGroup.ps1
@@ -8,6 +8,27 @@
 .PARAMETER Raw
     Return the raw API response instead of the results array.
 
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .EXAMPLE
     Get-NBIPAMFHRPGroup
 

--- a/Functions/IPAM/FHRPGroupAssignment/Get-NBIPAMFHRPGroupAssignment.ps1
+++ b/Functions/IPAM/FHRPGroupAssignment/Get-NBIPAMFHRPGroupAssignment.ps1
@@ -28,7 +28,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .EXAMPLE
     Get-NBIPAMFHRPGroupAssignment
 

--- a/Functions/IPAM/FHRPGroupAssignment/Get-NBIPAMFHRPGroupAssignment.ps1
+++ b/Functions/IPAM/FHRPGroupAssignment/Get-NBIPAMFHRPGroupAssignment.ps1
@@ -8,6 +8,27 @@
 .PARAMETER Raw
     Return the raw API response instead of the results array.
 
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .EXAMPLE
     Get-NBIPAMFHRPGroupAssignment
 

--- a/Functions/IPAM/Prefix/Get-NBIPAMPrefix.ps1
+++ b/Functions/IPAM/Prefix/Get-NBIPAMPrefix.ps1
@@ -78,6 +78,23 @@ function Get-NBIPAMPrefix {
     .PARAMETER Raw
         Return the raw API response instead of extracting the results array.
 
+    .PARAMETER All
+        Automatically fetch all pages of results. Uses the API's pagination
+        to retrieve all items across multiple requests.
+
+    .PARAMETER PageSize
+        Number of items per page when using -All. Default: 100.
+        Range: 1-1000.
+
+    .PARAMETER Brief
+        Return a minimal representation of objects (id, url, display, name only).
+        Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+    .PARAMETER Fields
+        Specify which fields to include in the response.
+        Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+
     .EXAMPLE
         PS C:\> Get-NBIPAMPrefix
 

--- a/Functions/IPAM/Prefix/Get-NBIPAMPrefix.ps1
+++ b/Functions/IPAM/Prefix/Get-NBIPAMPrefix.ps1
@@ -94,7 +94,6 @@ function Get-NBIPAMPrefix {
         Specify which fields to include in the response.
         Supports nested field selection (e.g., 'site.name', 'device_type.model').
 
-
     .EXAMPLE
         PS C:\> Get-NBIPAMPrefix
 
@@ -115,7 +114,6 @@ function Get-NBIPAMPrefix {
         [switch]$Brief,
 
         [string[]]$Fields,
-
 
         [string[]]$Omit,
 

--- a/Functions/IPAM/RIR/Get-NBIPAMRIR.ps1
+++ b/Functions/IPAM/RIR/Get-NBIPAMRIR.ps1
@@ -8,6 +8,27 @@
 .PARAMETER Raw
     Return the raw API response instead of the results array.
 
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .EXAMPLE
     Get-NBIPAMRIR
 

--- a/Functions/IPAM/RIR/Get-NBIPAMRIR.ps1
+++ b/Functions/IPAM/RIR/Get-NBIPAMRIR.ps1
@@ -28,7 +28,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .EXAMPLE
     Get-NBIPAMRIR
 

--- a/Functions/IPAM/Range/Get-NBIPAMAddressRange.ps1
+++ b/Functions/IPAM/Range/Get-NBIPAMAddressRange.ps1
@@ -28,7 +28,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .EXAMPLE
     Get-NBIPAMAddressRange
 

--- a/Functions/IPAM/Range/Get-NBIPAMAddressRange.ps1
+++ b/Functions/IPAM/Range/Get-NBIPAMAddressRange.ps1
@@ -8,6 +8,27 @@
 .PARAMETER Raw
     Return the raw API response instead of the results array.
 
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .EXAMPLE
     Get-NBIPAMAddressRange
 

--- a/Functions/IPAM/Role/Get-NBIPAMRole.ps1
+++ b/Functions/IPAM/Role/Get-NBIPAMRole.ps1
@@ -47,7 +47,6 @@ function Get-NBIPAMRole {
         Specify which fields to exclude from the response.
         Requires Netbox 4.5.0 or later.
 
-
     .EXAMPLE
         PS C:\> Get-NBIPAMRole
 
@@ -65,7 +64,6 @@ function Get-NBIPAMRole {
         [switch]$Brief,
 
         [string[]]$Fields,
-
 
         [string[]]$Omit,
 

--- a/Functions/IPAM/Role/Get-NBIPAMRole.ps1
+++ b/Functions/IPAM/Role/Get-NBIPAMRole.ps1
@@ -31,6 +31,23 @@ function Get-NBIPAMRole {
     .PARAMETER Raw
         Return the raw API response instead of extracting the results array.
 
+    .PARAMETER All
+        Automatically fetch all pages of results. Uses the API's pagination
+        to retrieve all items across multiple requests.
+
+    .PARAMETER PageSize
+        Number of items per page when using -All. Default: 100.
+        Range: 1-1000.
+
+    .PARAMETER Fields
+        Specify which fields to include in the response.
+        Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+    .PARAMETER Omit
+        Specify which fields to exclude from the response.
+        Requires Netbox 4.5.0 or later.
+
+
     .EXAMPLE
         PS C:\> Get-NBIPAMRole
 

--- a/Functions/IPAM/RouteTarget/Get-NBIPAMRouteTarget.ps1
+++ b/Functions/IPAM/RouteTarget/Get-NBIPAMRouteTarget.ps1
@@ -37,6 +37,27 @@ function Get-NBIPAMRouteTarget {
     .PARAMETER Raw
         Return the raw API response
 
+    .PARAMETER All
+        Automatically fetch all pages of results. Uses the API's pagination
+        to retrieve all items across multiple requests.
+
+    .PARAMETER PageSize
+        Number of items per page when using -All. Default: 100.
+        Range: 1-1000.
+
+    .PARAMETER Brief
+        Return a minimal representation of objects (id, url, display, name only).
+        Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+    .PARAMETER Fields
+        Specify which fields to include in the response.
+        Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+    .PARAMETER Omit
+        Specify which fields to exclude from the response.
+        Requires Netbox 4.5.0 or later.
+
+
     .EXAMPLE
         Get-NBIPAMRouteTarget
 

--- a/Functions/IPAM/RouteTarget/Get-NBIPAMRouteTarget.ps1
+++ b/Functions/IPAM/RouteTarget/Get-NBIPAMRouteTarget.ps1
@@ -57,7 +57,6 @@ function Get-NBIPAMRouteTarget {
         Specify which fields to exclude from the response.
         Requires Netbox 4.5.0 or later.
 
-
     .EXAMPLE
         Get-NBIPAMRouteTarget
 

--- a/Functions/IPAM/Service/Get-NBIPAMService.ps1
+++ b/Functions/IPAM/Service/Get-NBIPAMService.ps1
@@ -37,6 +37,27 @@ function Get-NBIPAMService {
     .PARAMETER Raw
         Return the raw API response
 
+    .PARAMETER All
+        Automatically fetch all pages of results. Uses the API's pagination
+        to retrieve all items across multiple requests.
+
+    .PARAMETER PageSize
+        Number of items per page when using -All. Default: 100.
+        Range: 1-1000.
+
+    .PARAMETER Brief
+        Return a minimal representation of objects (id, url, display, name only).
+        Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+    .PARAMETER Fields
+        Specify which fields to include in the response.
+        Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+    .PARAMETER Omit
+        Specify which fields to exclude from the response.
+        Requires Netbox 4.5.0 or later.
+
+
     .EXAMPLE
         Get-NBIPAMService
 

--- a/Functions/IPAM/Service/Get-NBIPAMService.ps1
+++ b/Functions/IPAM/Service/Get-NBIPAMService.ps1
@@ -57,7 +57,6 @@ function Get-NBIPAMService {
         Specify which fields to exclude from the response.
         Requires Netbox 4.5.0 or later.
 
-
     .EXAMPLE
         Get-NBIPAMService
 

--- a/Functions/IPAM/ServiceTemplate/Get-NBIPAMServiceTemplate.ps1
+++ b/Functions/IPAM/ServiceTemplate/Get-NBIPAMServiceTemplate.ps1
@@ -51,7 +51,6 @@ function Get-NBIPAMServiceTemplate {
         Specify which fields to exclude from the response.
         Requires Netbox 4.5.0 or later.
 
-
     .EXAMPLE
         Get-NBIPAMServiceTemplate
 

--- a/Functions/IPAM/ServiceTemplate/Get-NBIPAMServiceTemplate.ps1
+++ b/Functions/IPAM/ServiceTemplate/Get-NBIPAMServiceTemplate.ps1
@@ -31,6 +31,27 @@ function Get-NBIPAMServiceTemplate {
     .PARAMETER Raw
         Return the raw API response
 
+    .PARAMETER All
+        Automatically fetch all pages of results. Uses the API's pagination
+        to retrieve all items across multiple requests.
+
+    .PARAMETER PageSize
+        Number of items per page when using -All. Default: 100.
+        Range: 1-1000.
+
+    .PARAMETER Brief
+        Return a minimal representation of objects (id, url, display, name only).
+        Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+    .PARAMETER Fields
+        Specify which fields to include in the response.
+        Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+    .PARAMETER Omit
+        Specify which fields to exclude from the response.
+        Requires Netbox 4.5.0 or later.
+
+
     .EXAMPLE
         Get-NBIPAMServiceTemplate
 

--- a/Functions/IPAM/VLAN/Get-NBIPAMVLAN.ps1
+++ b/Functions/IPAM/VLAN/Get-NBIPAMVLAN.ps1
@@ -8,6 +8,27 @@
 .PARAMETER Raw
     Return the raw API response instead of the results array.
 
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .EXAMPLE
     Get-NBIPAMVLAN
 

--- a/Functions/IPAM/VLAN/Get-NBIPAMVLAN.ps1
+++ b/Functions/IPAM/VLAN/Get-NBIPAMVLAN.ps1
@@ -28,7 +28,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .EXAMPLE
     Get-NBIPAMVLAN
 

--- a/Functions/IPAM/VLANGroup/Get-NBIPAMVLANGroup.ps1
+++ b/Functions/IPAM/VLANGroup/Get-NBIPAMVLANGroup.ps1
@@ -28,7 +28,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .EXAMPLE
     Get-NBIPAMVLANGroup
 

--- a/Functions/IPAM/VLANGroup/Get-NBIPAMVLANGroup.ps1
+++ b/Functions/IPAM/VLANGroup/Get-NBIPAMVLANGroup.ps1
@@ -8,6 +8,27 @@
 .PARAMETER Raw
     Return the raw API response instead of the results array.
 
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .EXAMPLE
     Get-NBIPAMVLANGroup
 

--- a/Functions/IPAM/VLANTranslationPolicy/Get-NBIPAMVLANTranslationPolicy.ps1
+++ b/Functions/IPAM/VLANTranslationPolicy/Get-NBIPAMVLANTranslationPolicy.ps1
@@ -8,6 +8,27 @@
 .PARAMETER Raw
     Return the raw API response instead of the results array.
 
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .EXAMPLE
     Get-NBIPAMVLANTranslationPolicy
 

--- a/Functions/IPAM/VLANTranslationPolicy/Get-NBIPAMVLANTranslationPolicy.ps1
+++ b/Functions/IPAM/VLANTranslationPolicy/Get-NBIPAMVLANTranslationPolicy.ps1
@@ -28,7 +28,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .EXAMPLE
     Get-NBIPAMVLANTranslationPolicy
 

--- a/Functions/IPAM/VLANTranslationRule/Get-NBIPAMVLANTranslationRule.ps1
+++ b/Functions/IPAM/VLANTranslationRule/Get-NBIPAMVLANTranslationRule.ps1
@@ -8,6 +8,27 @@
 .PARAMETER Raw
     Return the raw API response instead of the results array.
 
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .EXAMPLE
     Get-NBIPAMVLANTranslationRule
 

--- a/Functions/IPAM/VLANTranslationRule/Get-NBIPAMVLANTranslationRule.ps1
+++ b/Functions/IPAM/VLANTranslationRule/Get-NBIPAMVLANTranslationRule.ps1
@@ -28,7 +28,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .EXAMPLE
     Get-NBIPAMVLANTranslationRule
 

--- a/Functions/IPAM/VRF/Get-NBIPAMVRF.ps1
+++ b/Functions/IPAM/VRF/Get-NBIPAMVRF.ps1
@@ -56,7 +56,6 @@ function Get-NBIPAMVRF {
         Specify which fields to exclude from the response.
         Requires Netbox 4.5.0 or later.
 
-
     .EXAMPLE
         Get-NBIPAMVRF
 

--- a/Functions/IPAM/VRF/Get-NBIPAMVRF.ps1
+++ b/Functions/IPAM/VRF/Get-NBIPAMVRF.ps1
@@ -36,6 +36,27 @@ function Get-NBIPAMVRF {
     .PARAMETER Raw
         Return the raw API response
 
+    .PARAMETER All
+        Automatically fetch all pages of results. Uses the API's pagination
+        to retrieve all items across multiple requests.
+
+    .PARAMETER PageSize
+        Number of items per page when using -All. Default: 100.
+        Range: 1-1000.
+
+    .PARAMETER Brief
+        Return a minimal representation of objects (id, url, display, name only).
+        Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+    .PARAMETER Fields
+        Specify which fields to include in the response.
+        Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+    .PARAMETER Omit
+        Specify which fields to exclude from the response.
+        Requires Netbox 4.5.0 or later.
+
+
     .EXAMPLE
         Get-NBIPAMVRF
 

--- a/Functions/Plugins/Branching/Branch/Get-NBBranch.ps1
+++ b/Functions/Plugins/Branching/Branch/Get-NBBranch.ps1
@@ -36,6 +36,19 @@
 .PARAMETER Raw
     Return the raw API response.
 
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .OUTPUTS
     [PSCustomObject] Branch object(s).
 

--- a/Functions/Plugins/Branching/Branch/Get-NBBranch.ps1
+++ b/Functions/Plugins/Branching/Branch/Get-NBBranch.ps1
@@ -48,7 +48,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .OUTPUTS
     [PSCustomObject] Branch object(s).
 

--- a/Functions/Plugins/Branching/BranchEvent/Get-NBBranchEvent.ps1
+++ b/Functions/Plugins/Branching/BranchEvent/Get-NBBranchEvent.ps1
@@ -27,6 +27,19 @@
 .PARAMETER Raw
     Return the raw API response.
 
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .OUTPUTS
     [PSCustomObject] Branch event object(s).
 

--- a/Functions/Plugins/Branching/BranchEvent/Get-NBBranchEvent.ps1
+++ b/Functions/Plugins/Branching/BranchEvent/Get-NBBranchEvent.ps1
@@ -39,7 +39,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .OUTPUTS
     [PSCustomObject] Branch event object(s).
 

--- a/Functions/Plugins/Branching/ChangeDiff/Get-NBChangeDiff.ps1
+++ b/Functions/Plugins/Branching/ChangeDiff/Get-NBChangeDiff.ps1
@@ -33,6 +33,19 @@
 .PARAMETER Raw
     Return the raw API response.
 
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .OUTPUTS
     [PSCustomObject] Change diff object(s).
 

--- a/Functions/Plugins/Branching/ChangeDiff/Get-NBChangeDiff.ps1
+++ b/Functions/Plugins/Branching/ChangeDiff/Get-NBChangeDiff.ps1
@@ -45,7 +45,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .OUTPUTS
     [PSCustomObject] Change diff object(s).
 

--- a/Functions/Setup/Support/Get-NBContentType.ps1
+++ b/Functions/Setup/Support/Get-NBContentType.ps1
@@ -29,6 +29,27 @@ function Get-NBContentType {
     .PARAMETER Raw
         Return the unparsed data from the HTTP request
 
+    .PARAMETER All
+        Automatically fetch all pages of results. Uses the API's pagination
+        to retrieve all items across multiple requests.
+
+    .PARAMETER PageSize
+        Number of items per page when using -All. Default: 100.
+        Range: 1-1000.
+
+    .PARAMETER Brief
+        Return a minimal representation of objects (id, url, display, name only).
+        Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+    .PARAMETER Fields
+        Specify which fields to include in the response.
+        Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+    .PARAMETER Omit
+        Specify which fields to exclude from the response.
+        Requires Netbox 4.5.0 or later.
+
+
     .EXAMPLE
         PS C:\> Get-NBContentType -App_Label 'dcim'
         Get all DCIM content types

--- a/Functions/Setup/Support/Get-NBContentType.ps1
+++ b/Functions/Setup/Support/Get-NBContentType.ps1
@@ -49,7 +49,6 @@ function Get-NBContentType {
         Specify which fields to exclude from the response.
         Requires Netbox 4.5.0 or later.
 
-
     .EXAMPLE
         PS C:\> Get-NBContentType -App_Label 'dcim'
         Get all DCIM content types

--- a/Functions/Tenancy/ContactAssignment/Get-NBContactAssignment.ps1
+++ b/Functions/Tenancy/ContactAssignment/Get-NBContactAssignment.ps1
@@ -38,6 +38,27 @@ function Get-NBContactAssignment {
     .PARAMETER Raw
         Return the unparsed data from the HTTP request
 
+    .PARAMETER All
+        Automatically fetch all pages of results. Uses the API's pagination
+        to retrieve all items across multiple requests.
+
+    .PARAMETER PageSize
+        Number of items per page when using -All. Default: 100.
+        Range: 1-1000.
+
+    .PARAMETER Brief
+        Return a minimal representation of objects (id, url, display, name only).
+        Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+    .PARAMETER Fields
+        Specify which fields to include in the response.
+        Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+    .PARAMETER Omit
+        Specify which fields to exclude from the response.
+        Requires Netbox 4.5.0 or later.
+
+
     .EXAMPLE
         PS C:\> Get-NBContactAssignment
 

--- a/Functions/Tenancy/ContactAssignment/Get-NBContactAssignment.ps1
+++ b/Functions/Tenancy/ContactAssignment/Get-NBContactAssignment.ps1
@@ -58,7 +58,6 @@ function Get-NBContactAssignment {
         Specify which fields to exclude from the response.
         Requires Netbox 4.5.0 or later.
 
-
     .EXAMPLE
         PS C:\> Get-NBContactAssignment
 

--- a/Functions/Tenancy/ContactRoles/Get-NBContactRole.ps1
+++ b/Functions/Tenancy/ContactRoles/Get-NBContactRole.ps1
@@ -26,6 +26,27 @@ function Get-NBContactRole {
     .PARAMETER Raw
         Return the unparsed data from the HTTP request
 
+    .PARAMETER All
+        Automatically fetch all pages of results. Uses the API's pagination
+        to retrieve all items across multiple requests.
+
+    .PARAMETER PageSize
+        Number of items per page when using -All. Default: 100.
+        Range: 1-1000.
+
+    .PARAMETER Brief
+        Return a minimal representation of objects (id, url, display, name only).
+        Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+    .PARAMETER Fields
+        Specify which fields to include in the response.
+        Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+    .PARAMETER Omit
+        Specify which fields to exclude from the response.
+        Requires Netbox 4.5.0 or later.
+
+
     .EXAMPLE
         PS C:\> Get-NBContactRole
 

--- a/Functions/Tenancy/ContactRoles/Get-NBContactRole.ps1
+++ b/Functions/Tenancy/ContactRoles/Get-NBContactRole.ps1
@@ -46,7 +46,6 @@ function Get-NBContactRole {
         Specify which fields to exclude from the response.
         Requires Netbox 4.5.0 or later.
 
-
     .EXAMPLE
         PS C:\> Get-NBContactRole
 

--- a/Functions/Tenancy/Contacts/Get-NBContact.ps1
+++ b/Functions/Tenancy/Contacts/Get-NBContact.ps1
@@ -43,6 +43,27 @@ function Get-NBContact {
     .PARAMETER Raw
         Return the unparsed data from the HTTP request
 
+    .PARAMETER All
+        Automatically fetch all pages of results. Uses the API's pagination
+        to retrieve all items across multiple requests.
+
+    .PARAMETER PageSize
+        Number of items per page when using -All. Default: 100.
+        Range: 1-1000.
+
+    .PARAMETER Brief
+        Return a minimal representation of objects (id, url, display, name only).
+        Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+    .PARAMETER Fields
+        Specify which fields to include in the response.
+        Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+    .PARAMETER Omit
+        Specify which fields to exclude from the response.
+        Requires Netbox 4.5.0 or later.
+
+
     .EXAMPLE
         PS C:\> Get-NBContact
 

--- a/Functions/Tenancy/Contacts/Get-NBContact.ps1
+++ b/Functions/Tenancy/Contacts/Get-NBContact.ps1
@@ -63,7 +63,6 @@ function Get-NBContact {
         Specify which fields to exclude from the response.
         Requires Netbox 4.5.0 or later.
 
-
     .EXAMPLE
         PS C:\> Get-NBContact
 

--- a/Functions/Tenancy/TenantGroups/Get-NBTenantGroup.ps1
+++ b/Functions/Tenancy/TenantGroups/Get-NBTenantGroup.ps1
@@ -33,6 +33,27 @@
 .PARAMETER Raw
     Return the raw API response instead of the results array.
 
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .EXAMPLE
     Get-NBTenantGroup
 

--- a/Functions/Tenancy/TenantGroups/Get-NBTenantGroup.ps1
+++ b/Functions/Tenancy/TenantGroups/Get-NBTenantGroup.ps1
@@ -53,7 +53,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .EXAMPLE
     Get-NBTenantGroup
 

--- a/Functions/Tenancy/Tenants/Get-NBTenant.ps1
+++ b/Functions/Tenancy/Tenants/Get-NBTenant.ps1
@@ -38,6 +38,27 @@ function Get-NBTenant {
     .PARAMETER Raw
         Return the unparsed data from the HTTP request
 
+    .PARAMETER All
+        Automatically fetch all pages of results. Uses the API's pagination
+        to retrieve all items across multiple requests.
+
+    .PARAMETER PageSize
+        Number of items per page when using -All. Default: 100.
+        Range: 1-1000.
+
+    .PARAMETER Brief
+        Return a minimal representation of objects (id, url, display, name only).
+        Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+    .PARAMETER Fields
+        Specify which fields to include in the response.
+        Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+    .PARAMETER Omit
+        Specify which fields to exclude from the response.
+        Requires Netbox 4.5.0 or later.
+
+
     .EXAMPLE
         PS C:\> Get-NBTenant
 

--- a/Functions/Tenancy/Tenants/Get-NBTenant.ps1
+++ b/Functions/Tenancy/Tenants/Get-NBTenant.ps1
@@ -58,7 +58,6 @@ function Get-NBTenant {
         Specify which fields to exclude from the response.
         Requires Netbox 4.5.0 or later.
 
-
     .EXAMPLE
         PS C:\> Get-NBTenant
 

--- a/Functions/Users/Groups/Get-NBGroup.ps1
+++ b/Functions/Users/Groups/Get-NBGroup.ps1
@@ -23,6 +23,27 @@
 .PARAMETER Raw
     Return the raw API response.
 
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .EXAMPLE
     Get-NBGroup
 

--- a/Functions/Users/Groups/Get-NBGroup.ps1
+++ b/Functions/Users/Groups/Get-NBGroup.ps1
@@ -43,7 +43,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .EXAMPLE
     Get-NBGroup
 

--- a/Functions/Users/OwnerGroups/Get-NBOwnerGroup.ps1
+++ b/Functions/Users/OwnerGroups/Get-NBOwnerGroup.ps1
@@ -43,7 +43,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .EXAMPLE
     Get-NBOwnerGroup
 

--- a/Functions/Users/OwnerGroups/Get-NBOwnerGroup.ps1
+++ b/Functions/Users/OwnerGroups/Get-NBOwnerGroup.ps1
@@ -31,6 +31,19 @@
 .PARAMETER Raw
     Return the raw API response.
 
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .EXAMPLE
     Get-NBOwnerGroup
 

--- a/Functions/Users/Owners/Get-NBOwner.ps1
+++ b/Functions/Users/Owners/Get-NBOwner.ps1
@@ -49,7 +49,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .EXAMPLE
     Get-NBOwner
 

--- a/Functions/Users/Owners/Get-NBOwner.ps1
+++ b/Functions/Users/Owners/Get-NBOwner.ps1
@@ -37,6 +37,19 @@
 .PARAMETER Raw
     Return the raw API response.
 
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .EXAMPLE
     Get-NBOwner
 

--- a/Functions/Users/Permissions/Get-NBPermission.ps1
+++ b/Functions/Users/Permissions/Get-NBPermission.ps1
@@ -35,6 +35,27 @@
 .PARAMETER Raw
     Return the raw API response.
 
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .EXAMPLE
     Get-NBPermission
 

--- a/Functions/Users/Permissions/Get-NBPermission.ps1
+++ b/Functions/Users/Permissions/Get-NBPermission.ps1
@@ -55,7 +55,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .EXAMPLE
     Get-NBPermission
 

--- a/Functions/Users/Tokens/Get-NBToken.ps1
+++ b/Functions/Users/Tokens/Get-NBToken.ps1
@@ -29,6 +29,27 @@
 .PARAMETER Raw
     Return the raw API response.
 
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .EXAMPLE
     Get-NBToken
 

--- a/Functions/Users/Tokens/Get-NBToken.ps1
+++ b/Functions/Users/Tokens/Get-NBToken.ps1
@@ -49,7 +49,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .EXAMPLE
     Get-NBToken
 

--- a/Functions/Users/Users/Get-NBUser.ps1
+++ b/Functions/Users/Users/Get-NBUser.ps1
@@ -64,7 +64,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .EXAMPLE
     Get-NBUser
 

--- a/Functions/Users/Users/Get-NBUser.ps1
+++ b/Functions/Users/Users/Get-NBUser.ps1
@@ -44,6 +44,27 @@
 .PARAMETER Raw
     Return the raw API response.
 
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .EXAMPLE
     Get-NBUser
 

--- a/Functions/VPN/IKEPolicy/Get-NBVPNIKEPolicy.ps1
+++ b/Functions/VPN/IKEPolicy/Get-NBVPNIKEPolicy.ps1
@@ -21,6 +21,15 @@
 .PARAMETER Raw
     Return the raw API response instead of the results array.
 
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+
 .EXAMPLE
     Get-NBVPNIKEPolicy
 

--- a/Functions/VPN/IKEPolicy/Get-NBVPNIKEPolicy.ps1
+++ b/Functions/VPN/IKEPolicy/Get-NBVPNIKEPolicy.ps1
@@ -17,7 +17,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .PARAMETER Raw
     Return the raw API response instead of the results array.
 
@@ -28,7 +27,6 @@
 .PARAMETER PageSize
     Number of items per page when using -All. Default: 100.
     Range: 1-1000.
-
 
 .EXAMPLE
     Get-NBVPNIKEPolicy

--- a/Functions/VPN/IKEProposal/Get-NBVPNIKEProposal.ps1
+++ b/Functions/VPN/IKEProposal/Get-NBVPNIKEProposal.ps1
@@ -21,6 +21,15 @@
 .PARAMETER Raw
     Return the raw API response instead of the results array.
 
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+
 .EXAMPLE
     Get-NBVPNIKEProposal
 

--- a/Functions/VPN/IKEProposal/Get-NBVPNIKEProposal.ps1
+++ b/Functions/VPN/IKEProposal/Get-NBVPNIKEProposal.ps1
@@ -17,7 +17,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .PARAMETER Raw
     Return the raw API response instead of the results array.
 
@@ -28,7 +27,6 @@
 .PARAMETER PageSize
     Number of items per page when using -All. Default: 100.
     Range: 1-1000.
-
 
 .EXAMPLE
     Get-NBVPNIKEProposal

--- a/Functions/VPN/IPSecPolicy/Get-NBVPNIPSecPolicy.ps1
+++ b/Functions/VPN/IPSecPolicy/Get-NBVPNIPSecPolicy.ps1
@@ -17,7 +17,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .PARAMETER Raw
     Return the raw API response instead of the results array.
 
@@ -28,7 +27,6 @@
 .PARAMETER PageSize
     Number of items per page when using -All. Default: 100.
     Range: 1-1000.
-
 
 .EXAMPLE
     Get-NBVPNIPSecPolicy

--- a/Functions/VPN/IPSecPolicy/Get-NBVPNIPSecPolicy.ps1
+++ b/Functions/VPN/IPSecPolicy/Get-NBVPNIPSecPolicy.ps1
@@ -21,6 +21,15 @@
 .PARAMETER Raw
     Return the raw API response instead of the results array.
 
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+
 .EXAMPLE
     Get-NBVPNIPSecPolicy
 

--- a/Functions/VPN/IPSecProfile/Get-NBVPNIPSecProfile.ps1
+++ b/Functions/VPN/IPSecProfile/Get-NBVPNIPSecProfile.ps1
@@ -17,7 +17,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .PARAMETER Raw
     Return the raw API response instead of the results array.
 
@@ -28,7 +27,6 @@
 .PARAMETER PageSize
     Number of items per page when using -All. Default: 100.
     Range: 1-1000.
-
 
 .EXAMPLE
     Get-NBVPNIPSecProfile

--- a/Functions/VPN/IPSecProfile/Get-NBVPNIPSecProfile.ps1
+++ b/Functions/VPN/IPSecProfile/Get-NBVPNIPSecProfile.ps1
@@ -21,6 +21,15 @@
 .PARAMETER Raw
     Return the raw API response instead of the results array.
 
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+
 .EXAMPLE
     Get-NBVPNIPSecProfile
 

--- a/Functions/VPN/IPSecProposal/Get-NBVPNIPSecProposal.ps1
+++ b/Functions/VPN/IPSecProposal/Get-NBVPNIPSecProposal.ps1
@@ -17,7 +17,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .PARAMETER Raw
     Return the raw API response instead of the results array.
 
@@ -28,7 +27,6 @@
 .PARAMETER PageSize
     Number of items per page when using -All. Default: 100.
     Range: 1-1000.
-
 
 .EXAMPLE
     Get-NBVPNIPSecProposal

--- a/Functions/VPN/IPSecProposal/Get-NBVPNIPSecProposal.ps1
+++ b/Functions/VPN/IPSecProposal/Get-NBVPNIPSecProposal.ps1
@@ -21,6 +21,15 @@
 .PARAMETER Raw
     Return the raw API response instead of the results array.
 
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+
 .EXAMPLE
     Get-NBVPNIPSecProposal
 

--- a/Functions/VPN/L2VPN/Get-NBVPNL2VPN.ps1
+++ b/Functions/VPN/L2VPN/Get-NBVPNL2VPN.ps1
@@ -21,6 +21,15 @@
 .PARAMETER Raw
     Return the raw API response instead of the results array.
 
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+
 .EXAMPLE
     Get-NBVPNL2VPN
 

--- a/Functions/VPN/L2VPN/Get-NBVPNL2VPN.ps1
+++ b/Functions/VPN/L2VPN/Get-NBVPNL2VPN.ps1
@@ -17,7 +17,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .PARAMETER Raw
     Return the raw API response instead of the results array.
 
@@ -28,7 +27,6 @@
 .PARAMETER PageSize
     Number of items per page when using -All. Default: 100.
     Range: 1-1000.
-
 
 .EXAMPLE
     Get-NBVPNL2VPN

--- a/Functions/VPN/L2VPNTermination/Get-NBVPNL2VPNTermination.ps1
+++ b/Functions/VPN/L2VPNTermination/Get-NBVPNL2VPNTermination.ps1
@@ -21,6 +21,15 @@
 .PARAMETER Raw
     Return the raw API response instead of the results array.
 
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+
 .EXAMPLE
     Get-NBVPNL2VPNTermination
 

--- a/Functions/VPN/L2VPNTermination/Get-NBVPNL2VPNTermination.ps1
+++ b/Functions/VPN/L2VPNTermination/Get-NBVPNL2VPNTermination.ps1
@@ -17,7 +17,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .PARAMETER Raw
     Return the raw API response instead of the results array.
 
@@ -28,7 +27,6 @@
 .PARAMETER PageSize
     Number of items per page when using -All. Default: 100.
     Range: 1-1000.
-
 
 .EXAMPLE
     Get-NBVPNL2VPNTermination

--- a/Functions/VPN/Tunnel/Get-NBVPNTunnel.ps1
+++ b/Functions/VPN/Tunnel/Get-NBVPNTunnel.ps1
@@ -8,6 +8,27 @@
 .PARAMETER Raw
     Return the raw API response instead of the results array.
 
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .EXAMPLE
     Get-NBVPNTunnel
 

--- a/Functions/VPN/Tunnel/Get-NBVPNTunnel.ps1
+++ b/Functions/VPN/Tunnel/Get-NBVPNTunnel.ps1
@@ -28,7 +28,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .EXAMPLE
     Get-NBVPNTunnel
 

--- a/Functions/VPN/TunnelGroup/Get-NBVPNTunnelGroup.ps1
+++ b/Functions/VPN/TunnelGroup/Get-NBVPNTunnelGroup.ps1
@@ -21,6 +21,15 @@
 .PARAMETER Raw
     Return the raw API response instead of the results array.
 
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+
 .EXAMPLE
     Get-NBVPNTunnelGroup
 

--- a/Functions/VPN/TunnelGroup/Get-NBVPNTunnelGroup.ps1
+++ b/Functions/VPN/TunnelGroup/Get-NBVPNTunnelGroup.ps1
@@ -17,7 +17,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .PARAMETER Raw
     Return the raw API response instead of the results array.
 
@@ -28,7 +27,6 @@
 .PARAMETER PageSize
     Number of items per page when using -All. Default: 100.
     Range: 1-1000.
-
 
 .EXAMPLE
     Get-NBVPNTunnelGroup

--- a/Functions/VPN/TunnelTermination/Get-NBVPNTunnelTermination.ps1
+++ b/Functions/VPN/TunnelTermination/Get-NBVPNTunnelTermination.ps1
@@ -21,6 +21,15 @@
 .PARAMETER Raw
     Return the raw API response instead of the results array.
 
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+
 .EXAMPLE
     Get-NBVPNTunnelTermination
 

--- a/Functions/VPN/TunnelTermination/Get-NBVPNTunnelTermination.ps1
+++ b/Functions/VPN/TunnelTermination/Get-NBVPNTunnelTermination.ps1
@@ -17,7 +17,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .PARAMETER Raw
     Return the raw API response instead of the results array.
 
@@ -28,7 +27,6 @@
 .PARAMETER PageSize
     Number of items per page when using -All. Default: 100.
     Range: 1-1000.
-
 
 .EXAMPLE
     Get-NBVPNTunnelTermination

--- a/Functions/Virtualization/VirtualMachine/Get-NBVirtualMachine.ps1
+++ b/Functions/Virtualization/VirtualMachine/Get-NBVirtualMachine.ps1
@@ -126,7 +126,6 @@ function Get-NBVirtualMachine {
 
         [string[]]$Fields,
 
-
         [string[]]$Omit,
 
         [switch]$IncludeConfigContext,

--- a/Functions/Virtualization/VirtualMachineInterface/Get-NBVirtualMachineInterface.ps1
+++ b/Functions/Virtualization/VirtualMachineInterface/Get-NBVirtualMachineInterface.ps1
@@ -57,7 +57,6 @@ function Get-NBVirtualMachineInterface {
         Specify which fields to exclude from the response.
         Requires Netbox 4.5.0 or later.
 
-
     .EXAMPLE
         PS C:\> Get-NBVirtualMachineInterface
 #>

--- a/Functions/Virtualization/VirtualMachineInterface/Get-NBVirtualMachineInterface.ps1
+++ b/Functions/Virtualization/VirtualMachineInterface/Get-NBVirtualMachineInterface.ps1
@@ -37,6 +37,27 @@ function Get-NBVirtualMachineInterface {
     .PARAMETER Raw
         Return the raw API response instead of extracting the results array.
 
+    .PARAMETER All
+        Automatically fetch all pages of results. Uses the API's pagination
+        to retrieve all items across multiple requests.
+
+    .PARAMETER PageSize
+        Number of items per page when using -All. Default: 100.
+        Range: 1-1000.
+
+    .PARAMETER Brief
+        Return a minimal representation of objects (id, url, display, name only).
+        Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+    .PARAMETER Fields
+        Specify which fields to include in the response.
+        Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+    .PARAMETER Omit
+        Specify which fields to exclude from the response.
+        Requires Netbox 4.5.0 or later.
+
+
     .EXAMPLE
         PS C:\> Get-NBVirtualMachineInterface
 #>

--- a/Functions/Virtualization/VirtualizationCluster/Get-NBVirtualizationCluster.ps1
+++ b/Functions/Virtualization/VirtualizationCluster/Get-NBVirtualizationCluster.ps1
@@ -63,7 +63,6 @@ function Get-NBVirtualizationCluster {
         Specify which fields to exclude from the response.
         Requires Netbox 4.5.0 or later.
 
-
     .EXAMPLE
         PS C:\> Get-NBVirtualizationCluster
 #>

--- a/Functions/Virtualization/VirtualizationCluster/Get-NBVirtualizationCluster.ps1
+++ b/Functions/Virtualization/VirtualizationCluster/Get-NBVirtualizationCluster.ps1
@@ -43,6 +43,27 @@ function Get-NBVirtualizationCluster {
     .PARAMETER Raw
         Return the raw API response instead of extracting the results array.
 
+    .PARAMETER All
+        Automatically fetch all pages of results. Uses the API's pagination
+        to retrieve all items across multiple requests.
+
+    .PARAMETER PageSize
+        Number of items per page when using -All. Default: 100.
+        Range: 1-1000.
+
+    .PARAMETER Brief
+        Return a minimal representation of objects (id, url, display, name only).
+        Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+    .PARAMETER Fields
+        Specify which fields to include in the response.
+        Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+    .PARAMETER Omit
+        Specify which fields to exclude from the response.
+        Requires Netbox 4.5.0 or later.
+
+
     .EXAMPLE
         PS C:\> Get-NBVirtualizationCluster
 #>

--- a/Functions/Virtualization/VirtualizationCluster/Get-NBVirtualizationClusterGroup.ps1
+++ b/Functions/Virtualization/VirtualizationCluster/Get-NBVirtualizationClusterGroup.ps1
@@ -8,6 +8,27 @@
 .PARAMETER Raw
     Return the raw API response instead of the results array.
 
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .EXAMPLE
     Get-NBVirtualizationClusterGroup
 

--- a/Functions/Virtualization/VirtualizationCluster/Get-NBVirtualizationClusterGroup.ps1
+++ b/Functions/Virtualization/VirtualizationCluster/Get-NBVirtualizationClusterGroup.ps1
@@ -28,7 +28,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .EXAMPLE
     Get-NBVirtualizationClusterGroup
 

--- a/Functions/Virtualization/VirtualizationClusterType/Get-NBVirtualizationClusterType.ps1
+++ b/Functions/Virtualization/VirtualizationClusterType/Get-NBVirtualizationClusterType.ps1
@@ -30,6 +30,27 @@
 .PARAMETER Raw
     Return the raw API response instead of the results array.
 
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .EXAMPLE
     Get-NBVirtualizationClusterType
 

--- a/Functions/Virtualization/VirtualizationClusterType/Get-NBVirtualizationClusterType.ps1
+++ b/Functions/Virtualization/VirtualizationClusterType/Get-NBVirtualizationClusterType.ps1
@@ -50,7 +50,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .EXAMPLE
     Get-NBVirtualizationClusterType
 

--- a/Functions/Wireless/WirelessLAN/Get-NBWirelessLAN.ps1
+++ b/Functions/Wireless/WirelessLAN/Get-NBWirelessLAN.ps1
@@ -8,6 +8,27 @@
 .PARAMETER Raw
     Return the raw API response instead of the results array.
 
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .EXAMPLE
     Get-NBWirelessLAN
 

--- a/Functions/Wireless/WirelessLAN/Get-NBWirelessLAN.ps1
+++ b/Functions/Wireless/WirelessLAN/Get-NBWirelessLAN.ps1
@@ -28,7 +28,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .EXAMPLE
     Get-NBWirelessLAN
 

--- a/Functions/Wireless/WirelessLANGroup/Get-NBWirelessLANGroup.ps1
+++ b/Functions/Wireless/WirelessLANGroup/Get-NBWirelessLANGroup.ps1
@@ -8,6 +8,27 @@
 .PARAMETER Raw
     Return the raw API response instead of the results array.
 
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .EXAMPLE
     Get-NBWirelessLANGroup
 

--- a/Functions/Wireless/WirelessLANGroup/Get-NBWirelessLANGroup.ps1
+++ b/Functions/Wireless/WirelessLANGroup/Get-NBWirelessLANGroup.ps1
@@ -28,7 +28,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .EXAMPLE
     Get-NBWirelessLANGroup
 

--- a/Functions/Wireless/WirelessLink/Get-NBWirelessLink.ps1
+++ b/Functions/Wireless/WirelessLink/Get-NBWirelessLink.ps1
@@ -28,7 +28,6 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-
 .EXAMPLE
     Get-NBWirelessLink
 

--- a/Functions/Wireless/WirelessLink/Get-NBWirelessLink.ps1
+++ b/Functions/Wireless/WirelessLink/Get-NBWirelessLink.ps1
@@ -8,6 +8,27 @@
 .PARAMETER Raw
     Return the raw API response instead of the results array.
 
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+
 .EXAMPLE
     Get-NBWirelessLink
 


### PR DESCRIPTION
## Summary
- Adds missing `.PARAMETER` documentation for `All`, `PageSize`, `Brief`, `Fields`, and `Omit` across 123 Get functions
- Ensures indentation consistency matches existing parameter documentation style per file
- No functional changes — documentation only

## Details
Per PowerShell best practices (PoshCode/PowerShellPracticeAndStyle), all parameters should have `.PARAMETER` documentation in comment-based help. The 5 common pagination/filtering parameters were added programmatically to all Get functions but were missing help docs.

## Test plan
- [ ] All existing tests pass (no functional changes)
- [ ] Lint checks pass
- [ ] Verify `Get-Help Get-NBDCIMDevice -Parameter All` returns documentation

Closes #345