### PR TITLE
ci: skip integration tests on pull requests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -9,18 +9,20 @@
 # - Only runs on ubuntu (Docker required)
 #
 # Triggers:
-# - Push to dev/main/beta branches
-# - Pull requests to dev/main
+# - Push to dev/main/beta branches (post-merge validation)
 # - Manual dispatch with custom Netbox version
 # - Weekly scheduled run (catch upstream changes)
+#
+# NOTE: Intentionally not triggered on pull_request. Integration tests
+# take ~5 min (mostly Docker/Netbox startup) and are not required checks.
+# Unit tests (2350+) provide sufficient pre-merge coverage. Integration
+# runs post-merge on push to catch any regressions immediately.
 
 name: Integration Tests
 
 on:
   push:
     branches: [dev, main, beta]
-  pull_request:
-    branches: [dev, main]
   # Allow manual trigger with custom version
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
## Summary

- Remove `pull_request` trigger from integration test workflow
- Integration tests still run on push to dev/main/beta, weekly schedule, and manual dispatch

## Rationale

Integration tests take ~5.5 min per run (mostly Docker/Netbox startup overhead — actual tests run in ~20s). They are **not required checks** for merge. Historical data: 29/30 runs passed (97%), with the one failure caught by a PR that specifically changed version-dependent endpoint routing.

With 2350+ unit tests at 70% coverage, pre-merge validation is well-covered. Integration runs post-merge on push to dev, catching regressions immediately.

**Savings**: ~15 min runner-time per PR (3 Netbox versions x ~5 min each).

## Test plan

- [ ] Verify integration workflow no longer triggers on this PR
- [ ] Verify integration still triggers on push to dev after merge
