### PR TITLE
ci: cache PowerShell modules for faster CI

### DIFF
--- a/.github/workflows/pssa.yml
+++ b/.github/workflows/pssa.yml
@@ -23,7 +23,15 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Cache PSScriptAnalyzer
+        uses: actions/cache@v4
+        id: ps-cache
+        with:
+          path: ~/.local/share/powershell/Modules
+          key: ps-modules-ubuntu-pssa-v1
+
       - name: Install PSScriptAnalyzer
+        if: steps.ps-cache.outputs.cache-hit != 'true'
         shell: pwsh
         run: |
           Set-PSRepository PSGallery -InstallationPolicy Trusted

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,8 +25,15 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Cache PowerShell modules
+        uses: actions/cache@v4
+        id: ps-cache
+        with:
+          path: ${{ runner.os != 'Windows' && '~/.local/share/powershell/Modules' || (matrix.pwsh && '~/Documents/PowerShell/Modules' || '~/Documents/WindowsPowerShell/Modules') }}
+          key: ps-modules-${{ matrix.os }}-${{ matrix.pwsh }}-v1
+
       - name: Install dependencies (pwsh)
-        if: matrix.pwsh
+        if: matrix.pwsh && steps.ps-cache.outputs.cache-hit != 'true'
         shell: pwsh
         run: |
           # Register PSGallery if not present (required for Windows Server 2025)
@@ -38,7 +45,7 @@ jobs:
           Install-Module PSScriptAnalyzer -Force -Scope CurrentUser
 
       - name: Install dependencies (powershell)
-        if: '!matrix.pwsh'
+        if: "!matrix.pwsh && steps.ps-cache.outputs.cache-hit != 'true'"
         shell: powershell
         run: |
           # Register PSGallery if not present (required for Windows Server 2025)


### PR DESCRIPTION
## Summary

- Cache Pester + PSScriptAnalyzer modules using `actions/cache@v4` in test.yml (4 jobs) and pssa.yml (1 job)
- Skip `Install-Module` entirely on cache hit
- Cache key per OS + shell type with manual version suffix (`v1`) for forced invalidation

## Expected impact

| Job | Before | After (cached) | Saved |
|-----|--------|----------------|-------|
| Ubuntu PS 7 | 14s install | ~2s restore | ~12s |
| macOS PS 7 | 13s install | ~2s restore | ~11s |
| Windows PS 7 | 34s install | ~3s restore | ~31s |
| **Windows PS 5.1** | **180s install** | **~3s restore** | **~177s** |
| PSSA lint | 10s install | ~2s restore | ~8s |

First run per cache key will be normal speed (cache miss → install → save). Subsequent runs restore from cache.

## Cache invalidation

Bump the version suffix in the cache key (`v1` → `v2`) to force fresh module installation. GitHub also auto-evicts caches unused for 7 days.

## Test plan

- [ ] First CI run: cache miss, installs normally, saves cache
- [ ] Verify all 4 test jobs + PSSA lint pass
- [ ] Subsequent runs should show cache hit and skip Install-Module steps
