### PR TITLE
fix: replace Site with Scope_Type/Scope_Id on Prefix functions

### DIFF
--- a/Functions/IPAM/Prefix/Get-NBIPAMPrefix.ps1
+++ b/Functions/IPAM/Prefix/Get-NBIPAMPrefix.ps1
@@ -50,11 +50,11 @@ function Get-NBIPAMPrefix {
     .PARAMETER Tenant_Id
         Filter by tenant database ID.
 
-    .PARAMETER Site
-        Filter by site name.
+    .PARAMETER Scope_Type
+        Filter by scope type (e.g., 'dcim.site', 'dcim.region', 'dcim.sitegroup', 'dcim.location').
 
-    .PARAMETER Site_Id
-        Filter by site database ID.
+    .PARAMETER Scope_Id
+        Filter by scope object database ID.
 
     .PARAMETER Vlan_VId
         Filter by VLAN ID number.
@@ -161,10 +161,11 @@ function Get-NBIPAMPrefix {
         [uint64]$Tenant_Id,
 
         [Parameter(ParameterSetName = 'Query')]
-        [string]$Site,
+        [ValidateSet('dcim.region', 'dcim.sitegroup', 'dcim.site', 'dcim.location', IgnoreCase = $true)]
+        [string]$Scope_Type,
 
         [Parameter(ParameterSetName = 'Query')]
-        [uint64]$Site_Id,
+        [uint64]$Scope_Id,
 
         [Parameter(ParameterSetName = 'Query')]
         [string]$Vlan_VId,

--- a/Functions/IPAM/Prefix/New-NBIPAMPrefix.ps1
+++ b/Functions/IPAM/Prefix/New-NBIPAMPrefix.ps1
@@ -28,8 +28,13 @@
 .PARAMETER Description
     A description of the prefix.
 
-.PARAMETER Site
-    The site ID where this prefix is used.
+.PARAMETER Scope_Type
+    The scope type for this prefix. Defines what kind of object the prefix is scoped to.
+    Valid values: dcim.region, dcim.sitegroup, dcim.site, dcim.location.
+    Must be used together with -Scope_Id.
+
+.PARAMETER Scope_Id
+    The database ID of the scope object. Must be used together with -Scope_Type.
 
 .PARAMETER VRF
     The VRF ID for this prefix.
@@ -58,13 +63,18 @@
     Return the raw API response instead of the results array.
 
 .EXAMPLE
-    New-NBIPAMPrefix -Prefix "10.0.0.0/24" -Status "active" -Site 1
+    New-NBIPAMPrefix -Prefix "10.0.0.0/24" -Status "active" -Scope_Type "dcim.site" -Scope_Id 1
 
-    Creates a single prefix.
+    Creates a single prefix scoped to site ID 1.
+
+.EXAMPLE
+    New-NBIPAMPrefix -Prefix "10.0.0.0/24" -Scope_Type "dcim.location" -Scope_Id 5
+
+    Creates a prefix scoped to location ID 5.
 
 .EXAMPLE
     $prefixes = 1..50 | ForEach-Object {
-        [PSCustomObject]@{Prefix="10.$_.0.0/24"; Status="active"; Site=1}
+        [PSCustomObject]@{Prefix="10.$_.0.0/24"; Status="active"; Scope_Type="dcim.site"; Scope_Id=1}
     }
     $prefixes | New-NBIPAMPrefix -BatchSize 50 -Force
 
@@ -107,7 +117,11 @@ function New-NBIPAMPrefix {
         [string]$Description,
 
         [Parameter(ParameterSetName = 'Single')]
-        [uint64]$Site,
+        [ValidateSet('dcim.region', 'dcim.sitegroup', 'dcim.site', 'dcim.location', IgnoreCase = $true)]
+        [string]$Scope_Type,
+
+        [Parameter(ParameterSetName = 'Single')]
+        [uint64]$Scope_Id,
 
         [Parameter(ParameterSetName = 'Single')]
         [uint64]$VRF,
@@ -165,9 +179,17 @@ function New-NBIPAMPrefix {
                     # Handle property name mappings
                     switch ($key) {
                         'ispool' { $key = 'is_pool' }
+                        'site' {
+                            # Backward compat: translate site to scope_type + scope_id
+                            $item['scope_type'] = 'dcim.site'
+                            $item['scope_id'] = $value
+                            $key = $null
+                        }
                     }
 
-                    $item[$key] = $value
+                    if ($null -ne $key) {
+                        $item[$key] = $value
+                    }
                 }
                 [void]$bulkItems.Add([PSCustomObject]$item)
             }

--- a/Functions/IPAM/Prefix/Set-NBIPAMPrefix.ps1
+++ b/Functions/IPAM/Prefix/Set-NBIPAMPrefix.ps1
@@ -35,7 +35,10 @@ function Set-NBIPAMPrefix {
 
         [uint64]$Tenant,
 
-        [uint64]$Site,
+        [ValidateSet('dcim.region', 'dcim.sitegroup', 'dcim.site', 'dcim.location', IgnoreCase = $true)]
+        [string]$Scope_Type,
+
+        [uint64]$Scope_Id,
 
         [uint64]$VRF,
 


### PR DESCRIPTION
## Summary

- **Breaking change fix**: Netbox 4.2+ replaced the `site` foreign key on `ipam.Prefix` with a generic `scope` foreign key (`scope_type` + `scope_id`)
- Replaces `-Site` parameter with `-Scope_Type` (ValidateSet: `dcim.region`, `dcim.sitegroup`, `dcim.site`, `dcim.location`) and `-Scope_Id` on `New-NBIPAMPrefix`, `Set-NBIPAMPrefix`, and `Get-NBIPAMPrefix`
- Adds backward-compatible `site` → `scope_type`/`scope_id` translation in bulk pipeline mode
- Adds 14 unit tests covering all scope type combinations and parameter validation

## Test plan

- [x] All 238 IPAM unit tests pass (including 14 new scope tests)
- [x] Full unit test suite: 2075 passed, 0 failed
- [x] PSScriptAnalyzer clean on all 3 modified source files
- [x] Verified API schema against Netbox 4.3.7, 4.4.10, and 4.5.2
- [ ] CI: PSSA + Ubuntu/Windows unit tests

Closes #356