### PR TITLE
Update CI matrix to Netbox 4.5.4

### DIFF
--- a/.github/workflows/branching-integration.yml
+++ b/.github/workflows/branching-integration.yml
@@ -34,7 +34,7 @@ on:
       netbox_version:
         description: 'Netbox Docker image tag (e.g., v4.5.0-3.4.2)'
         required: false
-        default: 'v4.5.3-4.0.1'
+        default: 'v4.5.4-4.0.1'
         type: string
       branching_version:
         description: 'Branching plugin version (e.g., 0.8.0)'
@@ -55,8 +55,8 @@ jobs:
       matrix:
         include:
           # Netbox 4.5.x with branching 0.8.0 (netbox-docker 4.0.1)
-          - netbox: "v4.5.3-4.0.1"
-            netbox_short: "4.5.3"
+          - netbox: "v4.5.4-4.0.1"
+            netbox_short: "4.5.4"
             branching: "0.8.0"
 
     env:

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -20,7 +20,7 @@ on:
       test_versions:
         description: 'Netbox versions to test (comma-separated)'
         required: false
-        default: '4.3.7,4.4.10,4.5.3'
+        default: '4.3.7,4.4.10,4.5.4'
         type: string
       include_beta:
         description: 'Include beta/pre-release versions'
@@ -63,8 +63,8 @@ jobs:
           # - New: cable-profiles, authentication-check (#103, #105)
           # - New fields: VM.interface_count, Token.allowed_ips (#106)
           # Docker 4.0.1: Granian web server, PostgreSQL 18, Valkey 9
-          - netbox: "v4.5.3-4.0.1"
-            netbox_short: "4.5.3"
+          - netbox: "v4.5.4-4.0.1"
+            netbox_short: "4.5.4"
             is_beta: false
             expected_failures: []
 
@@ -455,11 +455,11 @@ jobs:
           echo "" >> compatibility-report.md
           echo "Generated: $(date -u '+%Y-%m-%d %H:%M:%S UTC')" >> compatibility-report.md
           echo "" >> compatibility-report.md
-          echo "| Test | 4.3.7 | 4.4.10 | 4.5.3 |" >> compatibility-report.md
+          echo "| Test | 4.3.7 | 4.4.10 | 4.5.4 |" >> compatibility-report.md
           echo "|------|-------|--------|-------|" >> compatibility-report.md
 
           # Parse results from each version
-          for version in 4.3.7 4.4.10 4.5.3; do
+          for version in 4.3.7 4.4.10 4.5.4; do
             if [ -f "results/compatibility-$version/compatibility-results-$version.json" ]; then
               echo "Found results for $version"
               cat "results/compatibility-$version/compatibility-results-$version.json"

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -27,9 +27,9 @@ on:
   workflow_dispatch:
     inputs:
       netbox_version:
-        description: 'Netbox Docker image tag (e.g., v4.5.3-4.0.1)'
+        description: 'Netbox Docker image tag (e.g., v4.5.4-4.0.1)'
         required: false
-        default: 'v4.5.3-4.0.1'
+        default: 'v4.5.4-4.0.1'
         type: string
   # Run weekly to catch upstream Netbox changes
   schedule:
@@ -71,10 +71,10 @@ jobs:
             experimental: false
 
           # ----------------------------------------------------------
-          # Latest version - Netbox 4.5.3 (netbox-docker 4.0.1)
+          # Latest version - Netbox 4.5.4 (netbox-docker 4.0.1)
           # ----------------------------------------------------------
-          - netbox: "v4.5.3-4.0.1"
-            netbox_short: "4.5.3"
+          - netbox: "v4.5.4-4.0.1"
+            netbox_short: "4.5.4"
             experimental: false
 
     env:

--- a/.github/workflows/pre-release-validation.yml
+++ b/.github/workflows/pre-release-validation.yml
@@ -610,8 +610,8 @@ jobs:
           - netbox: "v4.4.10-3.4.2"
             netbox_short: "4.4.10"
           # Latest version (netbox-docker 4.0.1)
-          - netbox: "v4.5.3-4.0.1"
-            netbox_short: "4.5.3"
+          - netbox: "v4.5.4-4.0.1"
+            netbox_short: "4.5.4"
 
     env:
       NETBOX_VERSION: ${{ matrix.netbox }}
@@ -939,7 +939,7 @@ jobs:
           $nbStatus = if ($skipIntegration) { 'SKIP' } elseif ($integration -eq 'success') { 'OK' } else { '?' }
           [void]$sb.AppendLine("| 4.3.7 | $nbStatus |")
           [void]$sb.AppendLine("| 4.4.10 | $nbStatus |")
-          [void]$sb.AppendLine("| 4.5.3 | $nbStatus |")
+          [void]$sb.AppendLine("| 4.5.4 | $nbStatus |")
           [void]$sb.AppendLine("")
           [void]$sb.AppendLine("---")
           [void]$sb.AppendLine("")


### PR DESCRIPTION
## Summary

- Updated Docker image tag from `v4.5.3-4.0.1` to `v4.5.4-4.0.1` in all 4 CI workflows
- Affected: `integration.yml`, `compatibility.yml`, `branching-integration.yml`, `pre-release-validation.yml`
- zulu-how test instance already upgraded to 4.5.4

Closes #367

## Test plan

- [ ] Integration tests pass with `v4.5.4-4.0.1` Docker image
- [ ] All 3 Netbox versions (4.3.7, 4.4.10, 4.5.4) pass in CI matrix