### PR TITLE
Add -Label/-Parent filters and -Tags on all cmdlets

### DIFF
--- a/Functions/Circuits/CircuitGroupAssignments/New-NBCircuitGroupAssignment.ps1
+++ b/Functions/Circuits/CircuitGroupAssignments/New-NBCircuitGroupAssignment.ps1
@@ -41,6 +41,9 @@ function New-NBCircuitGroupAssignment {
 
         [hashtable]$Custom_Fields,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/Circuits/CircuitGroupAssignments/Set-NBCircuitGroupAssignment.ps1
+++ b/Functions/Circuits/CircuitGroupAssignments/Set-NBCircuitGroupAssignment.ps1
@@ -45,6 +45,9 @@ function Set-NBCircuitGroupAssignment {
 
         [hashtable]$Custom_Fields,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/Circuits/CircuitGroups/New-NBCircuitGroup.ps1
+++ b/Functions/Circuits/CircuitGroups/New-NBCircuitGroup.ps1
@@ -45,6 +45,9 @@ function New-NBCircuitGroup {
 
         [hashtable]$Custom_Fields,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/Circuits/CircuitGroups/Set-NBCircuitGroup.ps1
+++ b/Functions/Circuits/CircuitGroups/Set-NBCircuitGroup.ps1
@@ -49,6 +49,9 @@ function Set-NBCircuitGroup {
 
         [hashtable]$Custom_Fields,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/Circuits/Circuits/New-NBCircuit.ps1
+++ b/Functions/Circuits/Circuits/New-NBCircuit.ps1
@@ -57,6 +57,9 @@ function New-NBCircuit {
 
         [switch]$Force,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/Circuits/Circuits/Set-NBCircuit.ps1
+++ b/Functions/Circuits/Circuits/Set-NBCircuit.ps1
@@ -80,6 +80,9 @@ function Set-NBCircuit {
 
         [hashtable]$Custom_Fields,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/Circuits/ProviderAccounts/New-NBCircuitProviderAccount.ps1
+++ b/Functions/Circuits/ProviderAccounts/New-NBCircuitProviderAccount.ps1
@@ -51,6 +51,9 @@ function New-NBCircuitProviderAccount {
 
         [hashtable]$Custom_Fields,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/Circuits/ProviderAccounts/Set-NBCircuitProviderAccount.ps1
+++ b/Functions/Circuits/ProviderAccounts/Set-NBCircuitProviderAccount.ps1
@@ -54,6 +54,9 @@ function Set-NBCircuitProviderAccount {
 
         [hashtable]$Custom_Fields,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/Circuits/ProviderNetworks/New-NBCircuitProviderNetwork.ps1
+++ b/Functions/Circuits/ProviderNetworks/New-NBCircuitProviderNetwork.ps1
@@ -51,6 +51,9 @@ function New-NBCircuitProviderNetwork {
 
         [hashtable]$Custom_Fields,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/Circuits/ProviderNetworks/Set-NBCircuitProviderNetwork.ps1
+++ b/Functions/Circuits/ProviderNetworks/Set-NBCircuitProviderNetwork.ps1
@@ -54,6 +54,9 @@ function Set-NBCircuitProviderNetwork {
 
         [hashtable]$Custom_Fields,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/Circuits/Providers/New-NBCircuitProvider.ps1
+++ b/Functions/Circuits/Providers/New-NBCircuitProvider.ps1
@@ -45,6 +45,9 @@ function New-NBCircuitProvider {
 
         [hashtable]$Custom_Fields,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/Circuits/Providers/Set-NBCircuitProvider.ps1
+++ b/Functions/Circuits/Providers/Set-NBCircuitProvider.ps1
@@ -49,6 +49,9 @@ function Set-NBCircuitProvider {
 
         [hashtable]$Custom_Fields,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/Circuits/Terminations/New-NBCircuitTermination.ps1
+++ b/Functions/Circuits/Terminations/New-NBCircuitTermination.ps1
@@ -76,6 +76,9 @@ function New-NBCircuitTermination {
 
         [hashtable]$Custom_Fields,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/Circuits/Terminations/Set-NBCircuitTermination.ps1
+++ b/Functions/Circuits/Terminations/Set-NBCircuitTermination.ps1
@@ -80,6 +80,9 @@ function Set-NBCircuitTermination {
 
         [hashtable]$Custom_Fields,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/Circuits/Types/New-NBCircuitType.ps1
+++ b/Functions/Circuits/Types/New-NBCircuitType.ps1
@@ -51,6 +51,9 @@ function New-NBCircuitType {
 
         [hashtable]$Custom_Fields,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/Circuits/Types/Set-NBCircuitType.ps1
+++ b/Functions/Circuits/Types/Set-NBCircuitType.ps1
@@ -55,6 +55,9 @@ function Set-NBCircuitType {
 
         [hashtable]$Custom_Fields,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/Circuits/VirtualCircuitTerminations/New-NBVirtualCircuitTermination.ps1
+++ b/Functions/Circuits/VirtualCircuitTerminations/New-NBVirtualCircuitTermination.ps1
@@ -46,6 +46,9 @@ function New-NBVirtualCircuitTermination {
 
         [hashtable]$Custom_Fields,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/Circuits/VirtualCircuitTerminations/Set-NBVirtualCircuitTermination.ps1
+++ b/Functions/Circuits/VirtualCircuitTerminations/Set-NBVirtualCircuitTermination.ps1
@@ -50,6 +50,9 @@ function Set-NBVirtualCircuitTermination {
 
         [hashtable]$Custom_Fields,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/Circuits/VirtualCircuitTypes/New-NBVirtualCircuitType.ps1
+++ b/Functions/Circuits/VirtualCircuitTypes/New-NBVirtualCircuitType.ps1
@@ -46,6 +46,9 @@ function New-NBVirtualCircuitType {
 
         [hashtable]$Custom_Fields,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/Circuits/VirtualCircuitTypes/Set-NBVirtualCircuitType.ps1
+++ b/Functions/Circuits/VirtualCircuitTypes/Set-NBVirtualCircuitType.ps1
@@ -50,6 +50,9 @@ function Set-NBVirtualCircuitType {
 
         [hashtable]$Custom_Fields,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/Circuits/VirtualCircuits/New-NBVirtualCircuit.ps1
+++ b/Functions/Circuits/VirtualCircuits/New-NBVirtualCircuit.ps1
@@ -68,6 +68,9 @@ function New-NBVirtualCircuit {
 
         [hashtable]$Custom_Fields,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/Circuits/VirtualCircuits/Set-NBVirtualCircuit.ps1
+++ b/Functions/Circuits/VirtualCircuits/Set-NBVirtualCircuit.ps1
@@ -70,6 +70,9 @@ function Set-NBVirtualCircuit {
 
         [hashtable]$Custom_Fields,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/Core/DataSources/New-NBDataSource.ps1
+++ b/Functions/Core/DataSources/New-NBDataSource.ps1
@@ -62,6 +62,9 @@ function New-NBDataSource {
 
         [string]$Comments,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/Core/DataSources/Set-NBDataSource.ps1
+++ b/Functions/Core/DataSources/Set-NBDataSource.ps1
@@ -65,6 +65,9 @@ function Set-NBDataSource {
 
         [string]$Comments,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/DCIM/ConsolePortTemplates/New-NBDCIMConsolePortTemplate.ps1
+++ b/Functions/DCIM/ConsolePortTemplates/New-NBDCIMConsolePortTemplate.ps1
@@ -27,6 +27,9 @@ function New-NBDCIMConsolePortTemplate {
         [string]$Label,
         [string]$Type,
         [string]$Description,
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
     process {

--- a/Functions/DCIM/ConsolePortTemplates/Set-NBDCIMConsolePortTemplate.ps1
+++ b/Functions/DCIM/ConsolePortTemplates/Set-NBDCIMConsolePortTemplate.ps1
@@ -28,6 +28,9 @@ function Set-NBDCIMConsolePortTemplate {
         [string]$Label,
         [string]$Type,
         [string]$Description,
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
     process {

--- a/Functions/DCIM/ConsoleServerPortTemplates/New-NBDCIMConsoleServerPortTemplate.ps1
+++ b/Functions/DCIM/ConsoleServerPortTemplates/New-NBDCIMConsoleServerPortTemplate.ps1
@@ -27,6 +27,9 @@ function New-NBDCIMConsoleServerPortTemplate {
         [string]$Label,
         [string]$Type,
         [string]$Description,
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
     process {

--- a/Functions/DCIM/ConsoleServerPortTemplates/Set-NBDCIMConsoleServerPortTemplate.ps1
+++ b/Functions/DCIM/ConsoleServerPortTemplates/Set-NBDCIMConsoleServerPortTemplate.ps1
@@ -28,6 +28,9 @@ function Set-NBDCIMConsoleServerPortTemplate {
         [string]$Label,
         [string]$Type,
         [string]$Description,
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
     process {

--- a/Functions/DCIM/DeviceBayTemplates/New-NBDCIMDeviceBayTemplate.ps1
+++ b/Functions/DCIM/DeviceBayTemplates/New-NBDCIMDeviceBayTemplate.ps1
@@ -25,6 +25,9 @@ function New-NBDCIMDeviceBayTemplate {
         [Parameter(Mandatory = $true)][string]$Name,
         [string]$Label,
         [string]$Description,
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
     process {

--- a/Functions/DCIM/DeviceBayTemplates/Set-NBDCIMDeviceBayTemplate.ps1
+++ b/Functions/DCIM/DeviceBayTemplates/Set-NBDCIMDeviceBayTemplate.ps1
@@ -26,6 +26,9 @@ function Set-NBDCIMDeviceBayTemplate {
         [string]$Name,
         [string]$Label,
         [string]$Description,
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
     process {

--- a/Functions/DCIM/Devices/New-NBDCIMDevice.ps1
+++ b/Functions/DCIM/Devices/New-NBDCIMDevice.ps1
@@ -157,6 +157,9 @@ function New-NBDCIMDevice {
 
         # Common parameters
         [Parameter()]
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/DCIM/Devices/Set-NBDCIMDevice.ps1
+++ b/Functions/DCIM/Devices/Set-NBDCIMDevice.ps1
@@ -188,6 +188,9 @@ function Set-NBDCIMDevice {
         [switch]$Force,
 
         [Parameter()]
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/DCIM/FrontPortTemplates/New-NBDCIMFrontPortTemplate.ps1
+++ b/Functions/DCIM/FrontPortTemplates/New-NBDCIMFrontPortTemplate.ps1
@@ -30,6 +30,9 @@ function New-NBDCIMFrontPortTemplate {
         [Parameter(Mandatory = $true)][uint64]$Rear_Port,
         [uint16]$Rear_Port_Position,
         [string]$Description,
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
     process {

--- a/Functions/DCIM/FrontPortTemplates/Set-NBDCIMFrontPortTemplate.ps1
+++ b/Functions/DCIM/FrontPortTemplates/Set-NBDCIMFrontPortTemplate.ps1
@@ -31,6 +31,9 @@ function Set-NBDCIMFrontPortTemplate {
         [uint64]$Rear_Port,
         [uint16]$Rear_Port_Position,
         [string]$Description,
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
     process {

--- a/Functions/DCIM/InterfaceTemplates/New-NBDCIMInterfaceTemplate.ps1
+++ b/Functions/DCIM/InterfaceTemplates/New-NBDCIMInterfaceTemplate.ps1
@@ -32,6 +32,9 @@ function New-NBDCIMInterfaceTemplate {
         [string]$Poe_Mode,
         [string]$Poe_Type,
         [string]$Rf_Role,
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
     process {

--- a/Functions/DCIM/InterfaceTemplates/Set-NBDCIMInterfaceTemplate.ps1
+++ b/Functions/DCIM/InterfaceTemplates/Set-NBDCIMInterfaceTemplate.ps1
@@ -33,6 +33,9 @@ function Set-NBDCIMInterfaceTemplate {
         [string]$Poe_Mode,
         [string]$Poe_Type,
         [string]$Rf_Role,
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
     process {

--- a/Functions/DCIM/Interfaces/Get-NBDCIMInterface.ps1
+++ b/Functions/DCIM/Interfaces/Get-NBDCIMInterface.ps1
@@ -91,6 +91,9 @@ function Get-NBDCIMInterface {
         [Parameter(ParameterSetName = 'Query')]
         [string]$MAC_Address,
 
+        [Parameter(ParameterSetName = 'Query')]
+        [string]$Label,
+
         [switch]$Raw
     )
 

--- a/Functions/DCIM/Interfaces/New-NBDCIMInterface.ps1
+++ b/Functions/DCIM/Interfaces/New-NBDCIMInterface.ps1
@@ -148,6 +148,9 @@ function New-NBDCIMInterface {
 
         # Common parameters
         [Parameter()]
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/DCIM/Interfaces/New-NBDCIMInterfaceConnection.ps1
+++ b/Functions/DCIM/Interfaces/New-NBDCIMInterfaceConnection.ps1
@@ -59,6 +59,9 @@ function New-NBDCIMInterfaceConnection {
         [ValidateSet('connected', 'planned', IgnoreCase = $true)]
         [string]$Connection_Status,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/DCIM/Interfaces/Set-NBDCIMInterface.ps1
+++ b/Functions/DCIM/Interfaces/Set-NBDCIMInterface.ps1
@@ -55,6 +55,9 @@ function Set-NBDCIMInterface {
 
         [switch]$Force,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/DCIM/Interfaces/Set-NBDCIMInterfaceConnection.ps1
+++ b/Functions/DCIM/Interfaces/Set-NBDCIMInterfaceConnection.ps1
@@ -44,6 +44,9 @@ function Set-NBDCIMInterfaceConnection {
 
         [switch]$Force,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/DCIM/InventoryItemTemplates/New-NBDCIMInventoryItemTemplate.ps1
+++ b/Functions/DCIM/InventoryItemTemplates/New-NBDCIMInventoryItemTemplate.ps1
@@ -31,6 +31,9 @@ function New-NBDCIMInventoryItemTemplate {
         [string]$Description,
         [uint64]$Component_Type,
         [string]$Component_Name,
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
     process {

--- a/Functions/DCIM/InventoryItemTemplates/Set-NBDCIMInventoryItemTemplate.ps1
+++ b/Functions/DCIM/InventoryItemTemplates/Set-NBDCIMInventoryItemTemplate.ps1
@@ -32,6 +32,9 @@ function Set-NBDCIMInventoryItemTemplate {
         [string]$Description,
         [uint64]$Component_Type,
         [string]$Component_Name,
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
     process {

--- a/Functions/DCIM/Locations/New-NBDCIMLocation.ps1
+++ b/Functions/DCIM/Locations/New-NBDCIMLocation.ps1
@@ -81,6 +81,9 @@ function New-NBDCIMLocation {
 
         [hashtable]$Custom_Fields,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/DCIM/Locations/Set-NBDCIMLocation.ps1
+++ b/Functions/DCIM/Locations/Set-NBDCIMLocation.ps1
@@ -81,6 +81,9 @@ function Set-NBDCIMLocation {
 
         [hashtable]$Custom_Fields,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/DCIM/Manufacturers/New-NBDCIMManufacturer.ps1
+++ b/Functions/DCIM/Manufacturers/New-NBDCIMManufacturer.ps1
@@ -48,6 +48,9 @@ function New-NBDCIMManufacturer {
 
         [hashtable]$Custom_Fields,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/DCIM/Manufacturers/Set-NBDCIMManufacturer.ps1
+++ b/Functions/DCIM/Manufacturers/Set-NBDCIMManufacturer.ps1
@@ -49,6 +49,9 @@ function Set-NBDCIMManufacturer {
 
         [switch]$Force,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/DCIM/ModuleBayTemplates/New-NBDCIMModuleBayTemplate.ps1
+++ b/Functions/DCIM/ModuleBayTemplates/New-NBDCIMModuleBayTemplate.ps1
@@ -26,6 +26,9 @@ function New-NBDCIMModuleBayTemplate {
         [string]$Label,
         [string]$Position,
         [string]$Description,
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
     process {

--- a/Functions/DCIM/ModuleBayTemplates/Set-NBDCIMModuleBayTemplate.ps1
+++ b/Functions/DCIM/ModuleBayTemplates/Set-NBDCIMModuleBayTemplate.ps1
@@ -27,6 +27,9 @@ function Set-NBDCIMModuleBayTemplate {
         [string]$Label,
         [string]$Position,
         [string]$Description,
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
     process {

--- a/Functions/DCIM/PowerOutletTemplates/New-NBDCIMPowerOutletTemplate.ps1
+++ b/Functions/DCIM/PowerOutletTemplates/New-NBDCIMPowerOutletTemplate.ps1
@@ -30,6 +30,9 @@ function New-NBDCIMPowerOutletTemplate {
         [string]$Feed_Leg,
         [string]$Description,
         [string]$Color,
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
     process {

--- a/Functions/DCIM/PowerOutletTemplates/Set-NBDCIMPowerOutletTemplate.ps1
+++ b/Functions/DCIM/PowerOutletTemplates/Set-NBDCIMPowerOutletTemplate.ps1
@@ -31,6 +31,9 @@ function Set-NBDCIMPowerOutletTemplate {
         [string]$Feed_Leg,
         [string]$Description,
         [string]$Color,
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
     process {

--- a/Functions/DCIM/PowerPortTemplates/New-NBDCIMPowerPortTemplate.ps1
+++ b/Functions/DCIM/PowerPortTemplates/New-NBDCIMPowerPortTemplate.ps1
@@ -29,6 +29,9 @@ function New-NBDCIMPowerPortTemplate {
         [uint16]$Maximum_Draw,
         [uint16]$Allocated_Draw,
         [string]$Description,
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
     process {

--- a/Functions/DCIM/PowerPortTemplates/Set-NBDCIMPowerPortTemplate.ps1
+++ b/Functions/DCIM/PowerPortTemplates/Set-NBDCIMPowerPortTemplate.ps1
@@ -30,6 +30,9 @@ function Set-NBDCIMPowerPortTemplate {
         [uint16]$Maximum_Draw,
         [uint16]$Allocated_Draw,
         [string]$Description,
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
     process {

--- a/Functions/DCIM/Racks/New-NBDCIMRack.ps1
+++ b/Functions/DCIM/Racks/New-NBDCIMRack.ps1
@@ -152,6 +152,9 @@ function New-NBDCIMRack {
 
         [uint64]$Owner,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/DCIM/Racks/Set-NBDCIMRack.ps1
+++ b/Functions/DCIM/Racks/Set-NBDCIMRack.ps1
@@ -154,6 +154,9 @@ function Set-NBDCIMRack {
 
         [switch]$Force,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/DCIM/RearPortTemplates/New-NBDCIMRearPortTemplate.ps1
+++ b/Functions/DCIM/RearPortTemplates/New-NBDCIMRearPortTemplate.ps1
@@ -29,6 +29,9 @@ function New-NBDCIMRearPortTemplate {
         [string]$Color,
         [uint16]$Positions,
         [string]$Description,
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
     process {

--- a/Functions/DCIM/RearPortTemplates/Set-NBDCIMRearPortTemplate.ps1
+++ b/Functions/DCIM/RearPortTemplates/Set-NBDCIMRearPortTemplate.ps1
@@ -30,6 +30,9 @@ function Set-NBDCIMRearPortTemplate {
         [string]$Color,
         [uint16]$Positions,
         [string]$Description,
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
     process {

--- a/Functions/DCIM/Regions/New-NBDCIMRegion.ps1
+++ b/Functions/DCIM/Regions/New-NBDCIMRegion.ps1
@@ -59,6 +59,9 @@ function New-NBDCIMRegion {
 
         [hashtable]$Custom_Fields,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/DCIM/Regions/Set-NBDCIMRegion.ps1
+++ b/Functions/DCIM/Regions/Set-NBDCIMRegion.ps1
@@ -60,6 +60,9 @@ function Set-NBDCIMRegion {
 
         [hashtable]$Custom_Fields,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/DCIM/SiteGroups/New-NBDCIMSiteGroup.ps1
+++ b/Functions/DCIM/SiteGroups/New-NBDCIMSiteGroup.ps1
@@ -59,6 +59,9 @@ function New-NBDCIMSiteGroup {
 
         [hashtable]$Custom_Fields,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/DCIM/SiteGroups/Set-NBDCIMSiteGroup.ps1
+++ b/Functions/DCIM/SiteGroups/Set-NBDCIMSiteGroup.ps1
@@ -60,6 +60,9 @@ function Set-NBDCIMSiteGroup {
 
         [hashtable]$Custom_Fields,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/DCIM/Sites/New-NBDCIMSite.ps1
+++ b/Functions/DCIM/Sites/New-NBDCIMSite.ps1
@@ -67,6 +67,9 @@ function New-NBDCIMSite {
 
         [uint64]$Owner,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/DCIM/Sites/Set-NBDCIMSite.ps1
+++ b/Functions/DCIM/Sites/Set-NBDCIMSite.ps1
@@ -110,6 +110,9 @@ function Set-NBDCIMSite {
 
         [switch]$Force,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/Extras/Bookmarks/New-NBBookmark.ps1
+++ b/Functions/Extras/Bookmarks/New-NBBookmark.ps1
@@ -31,6 +31,9 @@ function New-NBBookmark {
         [Parameter(Mandatory = $true)]
         [uint64]$Object_Id,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/Extras/CustomFieldChoiceSets/New-NBCustomFieldChoiceSet.ps1
+++ b/Functions/Extras/CustomFieldChoiceSets/New-NBCustomFieldChoiceSet.ps1
@@ -45,6 +45,9 @@ function New-NBCustomFieldChoiceSet {
 
         [bool]$Order_Alphabetically,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/Extras/CustomFieldChoiceSets/Set-NBCustomFieldChoiceSet.ps1
+++ b/Functions/Extras/CustomFieldChoiceSets/Set-NBCustomFieldChoiceSet.ps1
@@ -49,6 +49,9 @@ function Set-NBCustomFieldChoiceSet {
 
         [bool]$Order_Alphabetically,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/Extras/CustomFields/New-NBCustomField.ps1
+++ b/Functions/Extras/CustomFields/New-NBCustomField.ps1
@@ -117,6 +117,9 @@ function New-NBCustomField {
 
         [uint64]$Choice_Set,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/Extras/CustomFields/Set-NBCustomField.ps1
+++ b/Functions/Extras/CustomFields/Set-NBCustomField.ps1
@@ -119,6 +119,9 @@ function Set-NBCustomField {
 
         [uint64]$Choice_Set,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/Extras/CustomLinks/New-NBCustomLink.ps1
+++ b/Functions/Extras/CustomLinks/New-NBCustomLink.ps1
@@ -71,6 +71,9 @@ function New-NBCustomLink {
 
         [bool]$New_Window,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/Extras/CustomLinks/Set-NBCustomLink.ps1
+++ b/Functions/Extras/CustomLinks/Set-NBCustomLink.ps1
@@ -70,6 +70,9 @@ function Set-NBCustomLink {
 
         [bool]$New_Window,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/Extras/EventRules/New-NBEventRule.ps1
+++ b/Functions/Extras/EventRules/New-NBEventRule.ps1
@@ -93,6 +93,9 @@ function New-NBEventRule {
 
         [hashtable]$Custom_Fields,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/Extras/EventRules/Set-NBEventRule.ps1
+++ b/Functions/Extras/EventRules/Set-NBEventRule.ps1
@@ -95,6 +95,9 @@ function Set-NBEventRule {
 
         [hashtable]$Custom_Fields,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/Extras/ExportTemplates/New-NBExportTemplate.ps1
+++ b/Functions/Extras/ExportTemplates/New-NBExportTemplate.ps1
@@ -66,6 +66,9 @@ function New-NBExportTemplate {
 
         [uint64]$Data_File,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/Extras/ExportTemplates/Set-NBExportTemplate.ps1
+++ b/Functions/Extras/ExportTemplates/Set-NBExportTemplate.ps1
@@ -69,6 +69,9 @@ function Set-NBExportTemplate {
 
         [uint64]$Data_File,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/Extras/JournalEntries/New-NBJournalEntry.ps1
+++ b/Functions/Extras/JournalEntries/New-NBJournalEntry.ps1
@@ -49,6 +49,9 @@ function New-NBJournalEntry {
 
         [hashtable]$Custom_Fields,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/Extras/JournalEntries/Set-NBJournalEntry.ps1
+++ b/Functions/Extras/JournalEntries/Set-NBJournalEntry.ps1
@@ -50,6 +50,9 @@ function Set-NBJournalEntry {
 
         [hashtable]$Custom_Fields,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/Extras/SavedFilters/New-NBSavedFilter.ps1
+++ b/Functions/Extras/SavedFilters/New-NBSavedFilter.ps1
@@ -64,6 +64,9 @@ function New-NBSavedFilter {
         [Parameter(Mandatory = $true)]
         [hashtable]$Parameters,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/Extras/SavedFilters/Set-NBSavedFilter.ps1
+++ b/Functions/Extras/SavedFilters/Set-NBSavedFilter.ps1
@@ -64,6 +64,9 @@ function Set-NBSavedFilter {
 
         [hashtable]$Parameters,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/Extras/Webhooks/New-NBWebhook.ps1
+++ b/Functions/Extras/Webhooks/New-NBWebhook.ps1
@@ -81,6 +81,9 @@ function New-NBWebhook {
 
         [hashtable]$Custom_Fields,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/Extras/Webhooks/Set-NBWebhook.ps1
+++ b/Functions/Extras/Webhooks/Set-NBWebhook.ps1
@@ -81,6 +81,9 @@ function Set-NBWebhook {
 
         [hashtable]$Custom_Fields,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/IPAM/ASN/New-NBIPAMASN.ps1
+++ b/Functions/IPAM/ASN/New-NBIPAMASN.ps1
@@ -56,6 +56,9 @@ function New-NBIPAMASN {
 
         [hashtable]$Custom_Fields,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/IPAM/ASN/Set-NBIPAMASN.ps1
+++ b/Functions/IPAM/ASN/Set-NBIPAMASN.ps1
@@ -56,6 +56,9 @@ function Set-NBIPAMASN {
 
         [hashtable]$Custom_Fields,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/IPAM/ASNRange/New-NBIPAMASNRange.ps1
+++ b/Functions/IPAM/ASNRange/New-NBIPAMASNRange.ps1
@@ -68,6 +68,9 @@ function New-NBIPAMASNRange {
 
         [hashtable]$Custom_Fields,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/IPAM/ASNRange/Set-NBIPAMASNRange.ps1
+++ b/Functions/IPAM/ASNRange/Set-NBIPAMASNRange.ps1
@@ -67,6 +67,9 @@ function Set-NBIPAMASNRange {
 
         [hashtable]$Custom_Fields,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/IPAM/Address/New-NBIPAMAddress.ps1
+++ b/Functions/IPAM/Address/New-NBIPAMAddress.ps1
@@ -156,6 +156,9 @@ function New-NBIPAMAddress {
 
         # Common parameters
         [Parameter()]
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/IPAM/Address/Set-NBIPAMAddress.ps1
+++ b/Functions/IPAM/Address/Set-NBIPAMAddress.ps1
@@ -149,6 +149,9 @@ function Set-NBIPAMAddress {
         [switch]$Force,
 
         [Parameter()]
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/IPAM/FHRPGroupAssignment/New-NBIPAMFHRPGroupAssignment.ps1
+++ b/Functions/IPAM/FHRPGroupAssignment/New-NBIPAMFHRPGroupAssignment.ps1
@@ -25,6 +25,9 @@ function New-NBIPAMFHRPGroupAssignment {
         [Parameter(Mandatory = $true)][string]$Interface_Type,
         [Parameter(Mandatory = $true)][uint64]$Interface_Id,
         [uint16]$Priority,
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
     process {

--- a/Functions/IPAM/FHRPGroupAssignment/Set-NBIPAMFHRPGroupAssignment.ps1
+++ b/Functions/IPAM/FHRPGroupAssignment/Set-NBIPAMFHRPGroupAssignment.ps1
@@ -26,6 +26,9 @@ function Set-NBIPAMFHRPGroupAssignment {
         [string]$Interface_Type,
         [uint64]$Interface_Id,
         [uint16]$Priority,
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
     process {

--- a/Functions/IPAM/Prefix/New-NBIPAMPrefix.ps1
+++ b/Functions/IPAM/Prefix/New-NBIPAMPrefix.ps1
@@ -148,6 +148,9 @@ function New-NBIPAMPrefix {
 
         # Common parameters
         [Parameter()]
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/IPAM/Prefix/Set-NBIPAMPrefix.ps1
+++ b/Functions/IPAM/Prefix/Set-NBIPAMPrefix.ps1
@@ -56,6 +56,9 @@ function Set-NBIPAMPrefix {
 
         [switch]$Force,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/IPAM/Range/Get-NBIPAMAddressRange.ps1
+++ b/Functions/IPAM/Range/Get-NBIPAMAddressRange.ps1
@@ -83,6 +83,9 @@ function Get-NBIPAMAddressRange {
         [Parameter(ParameterSetName = 'Query')]
         [string]$Role,
 
+        [Parameter(ParameterSetName = 'Query')]
+        [string]$Parent,
+
         [ValidateRange(1, 1000)]
         [uint16]$Limit,
 

--- a/Functions/IPAM/RouteTarget/New-NBIPAMRouteTarget.ps1
+++ b/Functions/IPAM/RouteTarget/New-NBIPAMRouteTarget.ps1
@@ -52,6 +52,9 @@ function New-NBIPAMRouteTarget {
 
         [hashtable]$Custom_Fields,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/IPAM/RouteTarget/Set-NBIPAMRouteTarget.ps1
+++ b/Functions/IPAM/RouteTarget/Set-NBIPAMRouteTarget.ps1
@@ -55,6 +55,9 @@ function Set-NBIPAMRouteTarget {
 
         [hashtable]$Custom_Fields,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/IPAM/Service/New-NBIPAMService.ps1
+++ b/Functions/IPAM/Service/New-NBIPAMService.ps1
@@ -74,6 +74,8 @@ function New-NBIPAMService {
 
         [hashtable]$Custom_Fields,
 
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/IPAM/Service/Set-NBIPAMService.ps1
+++ b/Functions/IPAM/Service/Set-NBIPAMService.ps1
@@ -61,6 +61,9 @@ function Set-NBIPAMService {
 
         [hashtable]$Custom_Fields,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/IPAM/ServiceTemplate/New-NBIPAMServiceTemplate.ps1
+++ b/Functions/IPAM/ServiceTemplate/New-NBIPAMServiceTemplate.ps1
@@ -59,6 +59,9 @@ function New-NBIPAMServiceTemplate {
 
         [hashtable]$Custom_Fields,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/IPAM/ServiceTemplate/Set-NBIPAMServiceTemplate.ps1
+++ b/Functions/IPAM/ServiceTemplate/Set-NBIPAMServiceTemplate.ps1
@@ -56,6 +56,9 @@ function Set-NBIPAMServiceTemplate {
 
         [hashtable]$Custom_Fields,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/IPAM/VLAN/New-NBIPAMVLAN.ps1
+++ b/Functions/IPAM/VLAN/New-NBIPAMVLAN.ps1
@@ -129,6 +129,9 @@ function New-NBIPAMVLAN {
 
         # Common parameters
         [Parameter()]
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/IPAM/VRF/New-NBIPAMVRF.ps1
+++ b/Functions/IPAM/VRF/New-NBIPAMVRF.ps1
@@ -71,6 +71,9 @@ function New-NBIPAMVRF {
 
         [hashtable]$Custom_Fields,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/IPAM/VRF/Set-NBIPAMVRF.ps1
+++ b/Functions/IPAM/VRF/Set-NBIPAMVRF.ps1
@@ -75,6 +75,9 @@ function Set-NBIPAMVRF {
 
         [hashtable]$Custom_Fields,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/Tenancy/ContactAssignment/New-NBContactAssignment.ps1
+++ b/Functions/Tenancy/ContactAssignment/New-NBContactAssignment.ps1
@@ -54,6 +54,9 @@ function New-NBContactAssignment {
         [ValidateSet('primary', 'secondary', 'tertiary', 'inactive', IgnoreCase = $true)]
         [string]$Priority,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/Tenancy/ContactAssignment/Set-NBContactAssignment.ps1
+++ b/Functions/Tenancy/ContactAssignment/Set-NBContactAssignment.ps1
@@ -55,6 +55,9 @@ function Set-NBContactAssignment {
         [ValidateSet('primary', 'secondary', 'tertiary', 'inactive', IgnoreCase = $true)]
         [string]$Priority,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/Tenancy/ContactRoles/New-NBContactRole.ps1
+++ b/Functions/Tenancy/ContactRoles/New-NBContactRole.ps1
@@ -46,6 +46,9 @@ function New-NBContactRole {
 
         [hashtable]$Custom_Fields,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/Tenancy/ContactRoles/Set-NBContactRole.ps1
+++ b/Functions/Tenancy/ContactRoles/Set-NBContactRole.ps1
@@ -48,6 +48,9 @@ function Set-NBContactRole {
 
         [hashtable]$Custom_Fields,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/Tenancy/Contacts/New-NBContact.ps1
+++ b/Functions/Tenancy/Contacts/New-NBContact.ps1
@@ -73,6 +73,9 @@ function New-NBContact {
 
         [hashtable]$Custom_Fields,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/Tenancy/Contacts/Set-NBContact.ps1
+++ b/Functions/Tenancy/Contacts/Set-NBContact.ps1
@@ -89,6 +89,9 @@ function Set-NBContact {
 
         [switch]$Force,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/Tenancy/Tenants/New-NBTenant.ps1
+++ b/Functions/Tenancy/Tenants/New-NBTenant.ps1
@@ -47,6 +47,9 @@ function New-NBTenant {
 
         [hashtable]$Custom_Fields,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/Users/Groups/New-NBGroup.ps1
+++ b/Functions/Users/Groups/New-NBGroup.ps1
@@ -30,6 +30,9 @@ function New-NBGroup {
 
         [uint64[]]$Permissions,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/Users/Groups/Set-NBGroup.ps1
+++ b/Functions/Users/Groups/Set-NBGroup.ps1
@@ -39,6 +39,9 @@ function Set-NBGroup {
 
         [uint64[]]$Permissions,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/Users/OwnerGroups/New-NBOwnerGroup.ps1
+++ b/Functions/Users/OwnerGroups/New-NBOwnerGroup.ps1
@@ -35,6 +35,9 @@ function New-NBOwnerGroup {
 
         [string]$Description,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/Users/OwnerGroups/Set-NBOwnerGroup.ps1
+++ b/Functions/Users/OwnerGroups/Set-NBOwnerGroup.ps1
@@ -42,6 +42,9 @@ function Set-NBOwnerGroup {
 
         [string]$Description,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/Users/Owners/New-NBOwner.ps1
+++ b/Functions/Users/Owners/New-NBOwner.ps1
@@ -53,6 +53,9 @@ function New-NBOwner {
 
         [uint64[]]$Users,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/Users/Owners/Set-NBOwner.ps1
+++ b/Functions/Users/Owners/Set-NBOwner.ps1
@@ -57,6 +57,9 @@ function Set-NBOwner {
 
         [uint64[]]$Users,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/Users/Permissions/New-NBPermission.ps1
+++ b/Functions/Users/Permissions/New-NBPermission.ps1
@@ -63,6 +63,9 @@ function New-NBPermission {
 
         [uint64[]]$Users,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/Users/Permissions/Set-NBPermission.ps1
+++ b/Functions/Users/Permissions/Set-NBPermission.ps1
@@ -65,6 +65,9 @@ function Set-NBPermission {
 
         [uint64[]]$Users,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/Users/Tokens/New-NBToken.ps1
+++ b/Functions/Users/Tokens/New-NBToken.ps1
@@ -54,6 +54,9 @@ function New-NBToken {
 
         [bool]$Enabled,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/Users/Tokens/Set-NBToken.ps1
+++ b/Functions/Users/Tokens/Set-NBToken.ps1
@@ -54,6 +54,9 @@ function Set-NBToken {
 
         [bool]$Enabled,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/Users/Users/New-NBUser.ps1
+++ b/Functions/Users/Users/New-NBUser.ps1
@@ -68,6 +68,8 @@ function New-NBUser {
 
         [uint64[]]$Groups,
 
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/Users/Users/Set-NBUser.ps1
+++ b/Functions/Users/Users/Set-NBUser.ps1
@@ -70,6 +70,8 @@ function Set-NBUser {
 
         [uint64[]]$Groups,
 
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/VPN/IKEPolicy/New-NBVPNIKEPolicy.ps1
+++ b/Functions/VPN/IKEPolicy/New-NBVPNIKEPolicy.ps1
@@ -61,6 +61,9 @@ function New-NBVPNIKEPolicy {
 
         [hashtable]$Custom_Fields,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/VPN/IKEPolicy/Set-NBVPNIKEPolicy.ps1
+++ b/Functions/VPN/IKEPolicy/Set-NBVPNIKEPolicy.ps1
@@ -21,7 +21,7 @@ function Set-NBVPNIKEPolicy {
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
     [OutputType([PSCustomObject])]
     param([Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)][uint64]$Id,
-        [string]$Name,[uint16]$Version,[string]$Mode,[uint64[]]$Proposals,[securestring]$Preshared_Key,[string]$Description,[string]$Comments,[hashtable]$Custom_Fields,[switch]$Raw)
+        [string]$Name,[uint16]$Version,[string]$Mode,[uint64[]]$Proposals,[securestring]$Preshared_Key,[string]$Description,[string]$Comments,[hashtable]$Custom_Fields,[object[]]$Tags,[switch]$Raw)
     process {
         Write-Verbose "Updating VPN IKE Policy"
         $s = [System.Collections.ArrayList]::new(@('vpn','ike-policies',$Id)); $u = BuildURIComponents -URISegments $s.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id','Raw','Preshared_Key'

--- a/Functions/VPN/IKEProposal/New-NBVPNIKEProposal.ps1
+++ b/Functions/VPN/IKEProposal/New-NBVPNIKEProposal.ps1
@@ -72,6 +72,9 @@ function New-NBVPNIKEProposal {
 
         [hashtable]$Custom_Fields,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/VPN/IKEProposal/Set-NBVPNIKEProposal.ps1
+++ b/Functions/VPN/IKEProposal/Set-NBVPNIKEProposal.ps1
@@ -21,7 +21,7 @@ function Set-NBVPNIKEProposal {
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
     [OutputType([PSCustomObject])]
     param([Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)][uint64]$Id,[string]$Name,
-        [string]$Authentication_Method,[string]$Encryption_Algorithm,[string]$Authentication_Algorithm,[uint16]$Group,[uint32]$SA_Lifetime,[string]$Description,[string]$Comments,[hashtable]$Custom_Fields,[switch]$Raw)
+        [string]$Authentication_Method,[string]$Encryption_Algorithm,[string]$Authentication_Algorithm,[uint16]$Group,[uint32]$SA_Lifetime,[string]$Description,[string]$Comments,[hashtable]$Custom_Fields,[object[]]$Tags,[switch]$Raw)
     process {
         Write-Verbose "Updating VPN IKE Proposal"
         $s = [System.Collections.ArrayList]::new(@('vpn','ike-proposals',$Id)); $u = BuildURIComponents -URISegments $s.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id','Raw'

--- a/Functions/VPN/IPSecPolicy/New-NBVPNIPSecPolicy.ps1
+++ b/Functions/VPN/IPSecPolicy/New-NBVPNIPSecPolicy.ps1
@@ -51,6 +51,9 @@ function New-NBVPNIPSecPolicy {
 
         [hashtable]$Custom_Fields,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/VPN/IPSecPolicy/Set-NBVPNIPSecPolicy.ps1
+++ b/Functions/VPN/IPSecPolicy/Set-NBVPNIPSecPolicy.ps1
@@ -20,7 +20,7 @@
 function Set-NBVPNIPSecPolicy {
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
     [OutputType([PSCustomObject])]
-    param([Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)][uint64]$Id,[string]$Name,[uint64[]]$Proposals,[bool]$Pfs_Group,[string]$Description,[string]$Comments,[hashtable]$Custom_Fields,[switch]$Raw)
+    param([Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)][uint64]$Id,[string]$Name,[uint64[]]$Proposals,[bool]$Pfs_Group,[string]$Description,[string]$Comments,[hashtable]$Custom_Fields,[object[]]$Tags,[switch]$Raw)
     process {
         Write-Verbose "Updating VPN IPSec Policy"
         $s = [System.Collections.ArrayList]::new(@('vpn','ipsec-policies',$Id)); $u = BuildURIComponents -URISegments $s.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id','Raw'

--- a/Functions/VPN/IPSecProfile/New-NBVPNIPSecProfile.ps1
+++ b/Functions/VPN/IPSecProfile/New-NBVPNIPSecProfile.ps1
@@ -59,6 +59,9 @@ function New-NBVPNIPSecProfile {
 
         [hashtable]$Custom_Fields,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/VPN/IPSecProfile/Set-NBVPNIPSecProfile.ps1
+++ b/Functions/VPN/IPSecProfile/Set-NBVPNIPSecProfile.ps1
@@ -20,7 +20,7 @@
 function Set-NBVPNIPSecProfile {
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
     [OutputType([PSCustomObject])]
-    param([Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)][uint64]$Id,[string]$Name,[string]$Mode,[uint64]$IKE_Policy,[uint64]$IPSec_Policy,[string]$Description,[string]$Comments,[hashtable]$Custom_Fields,[switch]$Raw)
+    param([Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)][uint64]$Id,[string]$Name,[string]$Mode,[uint64]$IKE_Policy,[uint64]$IPSec_Policy,[string]$Description,[string]$Comments,[hashtable]$Custom_Fields,[object[]]$Tags,[switch]$Raw)
     process {
         Write-Verbose "Updating VPN IPSec Profile"
         $s = [System.Collections.ArrayList]::new(@('vpn','ipsec-profiles',$Id)); $u = BuildURIComponents -URISegments $s.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id','Raw'

--- a/Functions/VPN/IPSecProposal/New-NBVPNIPSecProposal.ps1
+++ b/Functions/VPN/IPSecProposal/New-NBVPNIPSecProposal.ps1
@@ -63,6 +63,9 @@ function New-NBVPNIPSecProposal {
 
         [hashtable]$Custom_Fields,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/VPN/IPSecProposal/Set-NBVPNIPSecProposal.ps1
+++ b/Functions/VPN/IPSecProposal/Set-NBVPNIPSecProposal.ps1
@@ -20,7 +20,7 @@
 function Set-NBVPNIPSecProposal {
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
     [OutputType([PSCustomObject])]
-    param([Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)][uint64]$Id,[string]$Name,[string]$Encryption_Algorithm,[string]$Authentication_Algorithm,[uint32]$SA_Lifetime_Seconds,[uint32]$SA_Lifetime_Data,[string]$Description,[string]$Comments,[hashtable]$Custom_Fields,[switch]$Raw)
+    param([Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)][uint64]$Id,[string]$Name,[string]$Encryption_Algorithm,[string]$Authentication_Algorithm,[uint32]$SA_Lifetime_Seconds,[uint32]$SA_Lifetime_Data,[string]$Description,[string]$Comments,[hashtable]$Custom_Fields,[object[]]$Tags,[switch]$Raw)
     process {
         Write-Verbose "Updating VPN IPSec Proposal"
         $s = [System.Collections.ArrayList]::new(@('vpn','ipsec-proposals',$Id)); $u = BuildURIComponents -URISegments $s.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id','Raw'

--- a/Functions/VPN/L2VPN/New-NBVPNL2VPN.ps1
+++ b/Functions/VPN/L2VPN/New-NBVPNL2VPN.ps1
@@ -22,7 +22,7 @@ function New-NBVPNL2VPN {
     [OutputType([PSCustomObject])]
     param([Parameter(Mandatory = $true)][string]$Name,[Parameter(Mandatory = $true)][string]$Slug,
         [uint64]$Identifier,[string]$Type,[string]$Status,[uint64]$Tenant,[string]$Description,[string]$Comments,
-        [uint64[]]$Import_Targets,[uint64[]]$Export_Targets,[hashtable]$Custom_Fields,[switch]$Raw)
+        [uint64[]]$Import_Targets,[uint64[]]$Export_Targets,[hashtable]$Custom_Fields,[object[]]$Tags,[switch]$Raw)
     process {
         Write-Verbose "Creating VPN L2VPN"
         $s = [System.Collections.ArrayList]::new(@('vpn','l2vpns')); $u = BuildURIComponents -URISegments $s.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw'

--- a/Functions/VPN/L2VPN/Set-NBVPNL2VPN.ps1
+++ b/Functions/VPN/L2VPN/Set-NBVPNL2VPN.ps1
@@ -22,7 +22,7 @@ function Set-NBVPNL2VPN {
     [OutputType([PSCustomObject])]
     param([Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)][uint64]$Id,
         [string]$Name,[string]$Slug,[uint64]$Identifier,[string]$Type,[string]$Status,[uint64]$Tenant,
-        [string]$Description,[string]$Comments,[uint64[]]$Import_Targets,[uint64[]]$Export_Targets,[hashtable]$Custom_Fields,[switch]$Raw)
+        [string]$Description,[string]$Comments,[uint64[]]$Import_Targets,[uint64[]]$Export_Targets,[hashtable]$Custom_Fields,[object[]]$Tags,[switch]$Raw)
     process {
         Write-Verbose "Updating VPN L2VPN"
         $s = [System.Collections.ArrayList]::new(@('vpn','l2vpns',$Id)); $u = BuildURIComponents -URISegments $s.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id','Raw'

--- a/Functions/VPN/L2VPNTermination/New-NBVPNL2VPNTermination.ps1
+++ b/Functions/VPN/L2VPNTermination/New-NBVPNL2VPNTermination.ps1
@@ -20,7 +20,7 @@
 function New-NBVPNL2VPNTermination {
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Low')]
     [OutputType([PSCustomObject])]
-    param([Parameter(Mandatory = $true)][uint64]$L2VPN,[Parameter(Mandatory = $true)][string]$Assigned_Object_Type,[Parameter(Mandatory = $true)][uint64]$Assigned_Object_Id,[hashtable]$Custom_Fields,[switch]$Raw)
+    param([Parameter(Mandatory = $true)][uint64]$L2VPN,[Parameter(Mandatory = $true)][string]$Assigned_Object_Type,[Parameter(Mandatory = $true)][uint64]$Assigned_Object_Id,[hashtable]$Custom_Fields,[object[]]$Tags,[switch]$Raw)
     process {
         Write-Verbose "Creating VPN L2VPN Termination"
         $s = [System.Collections.ArrayList]::new(@('vpn','l2vpn-terminations')); $u = BuildURIComponents -URISegments $s.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw'

--- a/Functions/VPN/L2VPNTermination/Set-NBVPNL2VPNTermination.ps1
+++ b/Functions/VPN/L2VPNTermination/Set-NBVPNL2VPNTermination.ps1
@@ -20,7 +20,7 @@
 function Set-NBVPNL2VPNTermination {
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
     [OutputType([PSCustomObject])]
-    param([Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)][uint64]$Id,[uint64]$L2VPN,[string]$Assigned_Object_Type,[uint64]$Assigned_Object_Id,[hashtable]$Custom_Fields,[switch]$Raw)
+    param([Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)][uint64]$Id,[uint64]$L2VPN,[string]$Assigned_Object_Type,[uint64]$Assigned_Object_Id,[hashtable]$Custom_Fields,[object[]]$Tags,[switch]$Raw)
     process {
         Write-Verbose "Updating VPN L2VPN Termination"
         $s = [System.Collections.ArrayList]::new(@('vpn','l2vpn-terminations',$Id)); $u = BuildURIComponents -URISegments $s.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id','Raw'

--- a/Functions/VPN/Tunnel/New-NBVPNTunnel.ps1
+++ b/Functions/VPN/Tunnel/New-NBVPNTunnel.ps1
@@ -75,6 +75,9 @@ function New-NBVPNTunnel {
 
         [hashtable]$Custom_Fields,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/VPN/Tunnel/Set-NBVPNTunnel.ps1
+++ b/Functions/VPN/Tunnel/Set-NBVPNTunnel.ps1
@@ -32,6 +32,9 @@ function Set-NBVPNTunnel {
         [string]$Description,
         [string]$Comments,
         [hashtable]$Custom_Fields,
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
     process {

--- a/Functions/VPN/TunnelGroup/New-NBVPNTunnelGroup.ps1
+++ b/Functions/VPN/TunnelGroup/New-NBVPNTunnelGroup.ps1
@@ -41,6 +41,9 @@ function New-NBVPNTunnelGroup {
 
         [hashtable]$Custom_Fields,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/VPN/TunnelGroup/Set-NBVPNTunnelGroup.ps1
+++ b/Functions/VPN/TunnelGroup/Set-NBVPNTunnelGroup.ps1
@@ -20,7 +20,7 @@
 function Set-NBVPNTunnelGroup {
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
     [OutputType([PSCustomObject])]
-    param([Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)][uint64]$Id,[string]$Name,[string]$Slug,[string]$Description,[hashtable]$Custom_Fields,[switch]$Raw)
+    param([Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)][uint64]$Id,[string]$Name,[string]$Slug,[string]$Description,[hashtable]$Custom_Fields,[object[]]$Tags,[switch]$Raw)
     process {
         Write-Verbose "Updating VPN Tunnel Group"
         $s = [System.Collections.ArrayList]::new(@('vpn','tunnel-groups',$Id)); $u = BuildURIComponents -URISegments $s.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id','Raw'

--- a/Functions/VPN/TunnelTermination/New-NBVPNTunnelTermination.ps1
+++ b/Functions/VPN/TunnelTermination/New-NBVPNTunnelTermination.ps1
@@ -21,7 +21,7 @@ function New-NBVPNTunnelTermination {
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Low')]
     [OutputType([PSCustomObject])]
     param([Parameter(Mandatory = $true)][uint64]$Tunnel,[Parameter(Mandatory = $true)][ValidateSet('peer', 'hub', 'spoke')][string]$Role,
-        [string]$Termination_Type,[uint64]$Termination_Id,[uint64]$Outside_IP,[hashtable]$Custom_Fields,[switch]$Raw)
+        [string]$Termination_Type,[uint64]$Termination_Id,[uint64]$Outside_IP,[hashtable]$Custom_Fields,[object[]]$Tags,[switch]$Raw)
     process {
         Write-Verbose "Creating VPN Tunnel Termination"
         $s = [System.Collections.ArrayList]::new(@('vpn','tunnel-terminations')); $u = BuildURIComponents -URISegments $s.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw'

--- a/Functions/VPN/TunnelTermination/Set-NBVPNTunnelTermination.ps1
+++ b/Functions/VPN/TunnelTermination/Set-NBVPNTunnelTermination.ps1
@@ -20,7 +20,7 @@
 function Set-NBVPNTunnelTermination {
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
     [OutputType([PSCustomObject])]
-    param([Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)][uint64]$Id,[uint64]$Tunnel,[ValidateSet('peer', 'hub', 'spoke')][string]$Role,[string]$Termination_Type,[uint64]$Termination_Id,[uint64]$Outside_IP,[hashtable]$Custom_Fields,[switch]$Raw)
+    param([Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)][uint64]$Id,[uint64]$Tunnel,[ValidateSet('peer', 'hub', 'spoke')][string]$Role,[string]$Termination_Type,[uint64]$Termination_Id,[uint64]$Outside_IP,[hashtable]$Custom_Fields,[object[]]$Tags,[switch]$Raw)
     process {
         Write-Verbose "Updating VPN Tunnel Termination"
         $s = [System.Collections.ArrayList]::new(@('vpn','tunnel-terminations',$Id)); $u = BuildURIComponents -URISegments $s.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id','Raw'

--- a/Functions/Virtualization/VirtualMachine/New-NBVirtualMachine.ps1
+++ b/Functions/Virtualization/VirtualMachine/New-NBVirtualMachine.ps1
@@ -162,6 +162,9 @@ function New-NBVirtualMachine {
 
         # Common parameters
         [Parameter()]
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/Virtualization/VirtualMachine/Set-NBVirtualMachine.ps1
+++ b/Functions/Virtualization/VirtualMachine/Set-NBVirtualMachine.ps1
@@ -160,6 +160,9 @@ function Set-NBVirtualMachine {
         [switch]$Force,
 
         [Parameter()]
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/Virtualization/VirtualMachineInterface/Set-NBVirtualMachineInterface.ps1
+++ b/Functions/Virtualization/VirtualMachineInterface/Set-NBVirtualMachineInterface.ps1
@@ -42,6 +42,9 @@ function Set-NBVirtualMachineInterface {
 
         [switch]$Force,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/Wireless/WirelessLAN/New-NBWirelessLAN.ps1
+++ b/Functions/Wireless/WirelessLAN/New-NBWirelessLAN.ps1
@@ -76,6 +76,9 @@ function New-NBWirelessLAN {
 
         [hashtable]$Custom_Fields,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/Wireless/WirelessLAN/Set-NBWirelessLAN.ps1
+++ b/Functions/Wireless/WirelessLAN/Set-NBWirelessLAN.ps1
@@ -21,7 +21,7 @@ function Set-NBWirelessLAN {
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
     [OutputType([PSCustomObject])]
     param([Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)][uint64]$Id,[string]$SSID,[uint64]$Group,[string]$Status,[uint64]$VLAN,[uint64]$Tenant,
-        [string]$Auth_Type,[string]$Auth_Cipher,[securestring]$Auth_PSK,[string]$Description,[string]$Comments,[hashtable]$Custom_Fields,[switch]$Raw)
+        [string]$Auth_Type,[string]$Auth_Cipher,[securestring]$Auth_PSK,[string]$Description,[string]$Comments,[hashtable]$Custom_Fields,[object[]]$Tags,[switch]$Raw)
     process {
         Write-Verbose "Updating Wireless LAN"
         $s = [System.Collections.ArrayList]::new(@('wireless','wireless-lans',$Id)); $u = BuildURIComponents -URISegments $s.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id','Raw','Auth_PSK'

--- a/Functions/Wireless/WirelessLANGroup/New-NBWirelessLANGroup.ps1
+++ b/Functions/Wireless/WirelessLANGroup/New-NBWirelessLANGroup.ps1
@@ -47,6 +47,9 @@ function New-NBWirelessLANGroup {
 
         [hashtable]$Custom_Fields,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/Wireless/WirelessLANGroup/Set-NBWirelessLANGroup.ps1
+++ b/Functions/Wireless/WirelessLANGroup/Set-NBWirelessLANGroup.ps1
@@ -20,7 +20,7 @@
 function Set-NBWirelessLANGroup {
     [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
     [OutputType([PSCustomObject])]
-    param([Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)][uint64]$Id,[string]$Name,[string]$Slug,[uint64]$Parent,[string]$Description,[hashtable]$Custom_Fields,[switch]$Raw)
+    param([Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)][uint64]$Id,[string]$Name,[string]$Slug,[uint64]$Parent,[string]$Description,[hashtable]$Custom_Fields,[object[]]$Tags,[switch]$Raw)
     process {
         Write-Verbose "Updating Wireless LANGroup"
         $s = [System.Collections.ArrayList]::new(@('wireless','wireless-lan-groups',$Id)); $u = BuildURIComponents -URISegments $s.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id','Raw'

--- a/Functions/Wireless/WirelessLink/New-NBWirelessLink.ps1
+++ b/Functions/Wireless/WirelessLink/New-NBWirelessLink.ps1
@@ -77,6 +77,9 @@ function New-NBWirelessLink {
 
         [hashtable]$Custom_Fields,
 
+
+        [object[]]$Tags,
+
         [switch]$Raw
     )
 

--- a/Functions/Wireless/WirelessLink/Set-NBWirelessLink.ps1
+++ b/Functions/Wireless/WirelessLink/Set-NBWirelessLink.ps1
@@ -22,7 +22,7 @@ function Set-NBWirelessLink {
     [OutputType([PSCustomObject])]
     param([Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)][uint64]$Id,[uint64]$Interface_A,[uint64]$Interface_B,
         [string]$SSID,[string]$Status,[uint64]$Tenant,[string]$Auth_Type,[string]$Auth_Cipher,[securestring]$Auth_PSK,
-        [string]$Description,[string]$Comments,[hashtable]$Custom_Fields,[switch]$Raw)
+        [string]$Description,[string]$Comments,[hashtable]$Custom_Fields,[object[]]$Tags,[switch]$Raw)
     process {
         Write-Verbose "Updating Wireless Link"
         $s = [System.Collections.ArrayList]::new(@('wireless','wireless-links',$Id)); $u = BuildURIComponents -URISegments $s.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id','Raw','Auth_PSK'

--- a/Tests/DCIM.Interfaces.Tests.ps1
+++ b/Tests/DCIM.Interfaces.Tests.ps1
@@ -57,6 +57,11 @@ Describe "DCIM Interfaces Tests" -Tag 'DCIM', 'Interfaces' {
             $Result.Uri | Should -Match 'type=10gbase-t'
         }
 
+        It "Should request with a label filter" {
+            $Result = Get-NBDCIMInterface -Label "mgmt"
+            $Result.Uri | Should -Match 'label=mgmt'
+        }
+
         It "Should throw for invalid type" {
             # Type parameter has ValidateSet - invalid values throw at parameter binding
             { Get-NBDCIMInterface -Type 'Fake' } | Should -Throw

--- a/Tests/IPAM.Tests.ps1
+++ b/Tests/IPAM.Tests.ps1
@@ -778,6 +778,11 @@ Describe "IPAM tests" -Tag 'Ipam' {
             $Result = Get-NBIPAMAddressRange -Id 6
             $Result.Uri | Should -Match '/api/ipam/ip.ranges/6/'
         }
+
+        It "Should request address ranges by parent prefix" {
+            $Result = Get-NBIPAMAddressRange -Parent '10.0.0.0/24'
+            $Result.Uri | Should -Match 'parent=10\.0\.0\.0'
+        }
     }
 
     Context "New-NBIPAMAddressRange" {


### PR DESCRIPTION
## Summary

- **#362**: Add `-Label` query filter to `Get-NBDCIMInterface`
- **#363**: Add `-Parent` query filter to `Get-NBIPAMAddressRange` (filter by containing prefix)
- **#364**: Add `[object[]]$Tags` parameter to **146 New/Set functions** — all 227 New/Set cmdlets now support tags

### Tags implementation details

- Type: `[object[]]` (flexible — accepts tag names, IDs, or tag objects)
- Standard pattern functions: Tags passes through `BuildURIComponents` automatically
- Special pattern functions (User, IPAMService): Tags included via `$PSBoundParameters` iteration
- 78 pre-existing functions already had Tags with mixed types (`[string[]]`, `[uint64[]]`) — left as-is for backward compatibility

Closes #362, closes #363, closes #364

## Test plan

- [x] 2119 unit tests pass (0 failures)
- [x] 77 interface tests pass (including new Label test)
- [x] 243 IPAM tests pass (including new Parent test)
- [x] All 230 New/Set files parse without syntax errors
- [x] Tags parameter present on 227/227 New/Set functions
- [x] Tags parameter always positioned before `$Raw`
- [ ] CI: Ubuntu + Windows PS 5.1 + PS 7
- [ ] Integration tests on Netbox 4.5.4