### PR TITLE
Security hardening: logging, CI/CD, SSL, input validation

### DIFF
--- a/.github/workflows/branching-integration.yml
+++ b/.github/workflows/branching-integration.yml
@@ -45,6 +45,9 @@ on:
 env:
   COMPOSE_PROJECT_NAME: "powernetbox-branching"
 
+permissions:
+  contents: read
+
 jobs:
   branching-integration:
     name: Branching Tests (Netbox ${{ matrix.netbox_short }})
@@ -72,7 +75,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
 
       # ----------------------------------------------------------
       # Build Custom Image with Branching Plugin

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -32,6 +32,9 @@ env:
   NETBOX_TOKEN: "0123456789abcdef0123456789abcdef01234567"
   COMPOSE_PROJECT_NAME: "powernetbox"
 
+permissions:
+  contents: read
+
 jobs:
   # ============================================================
   # Compatibility Matrix Tests
@@ -77,7 +80,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
 
       - name: Start Netbox ${{ matrix.netbox_short }}
         run: |
@@ -153,6 +156,7 @@ jobs:
 
             if [ -n "$TOKEN_OUTPUT" ] && [[ "$TOKEN_OUTPUT" == nbt_* ]]; then
               echo "Created v2 token: ${TOKEN_OUTPUT:0:20}..."
+              echo "::add-mask::$TOKEN_OUTPUT"
               echo "token=$TOKEN_OUTPUT" >> $GITHUB_OUTPUT
               echo "auth_header=Bearer $TOKEN_OUTPUT" >> $GITHUB_OUTPUT
             else

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -41,6 +41,9 @@ env:
   # Docker Compose project name (for predictable container names)
   COMPOSE_PROJECT_NAME: "powernetbox"
 
+permissions:
+  contents: read
+
 jobs:
   # ============================================================
   # Integration Tests - Matrix of Netbox versions
@@ -89,7 +92,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
 
       # ----------------------------------------------------------
       # Start Netbox Stack
@@ -368,6 +371,7 @@ jobs:
 
             if [ -n "$TOKEN_OUTPUT" ] && [[ "$TOKEN_OUTPUT" == nbt_* ]]; then
               echo "Created v2 token: ${TOKEN_OUTPUT:0:20}..."
+              echo "::add-mask::$TOKEN_OUTPUT"
               echo "token=$TOKEN_OUTPUT" >> $GITHUB_OUTPUT
               echo "token_type=v2" >> $GITHUB_OUTPUT
             else

--- a/.github/workflows/pre-release-validation.yml
+++ b/.github/workflows/pre-release-validation.yml
@@ -41,6 +41,9 @@ env:
   NETBOX_TOKEN: "0123456789abcdef0123456789abcdef01234567"
   COMPOSE_PROJECT_NAME: "powernetbox"
 
+permissions:
+  contents: read
+
 jobs:
   # ============================================================
   # Stage 1: Unit Tests - Full Platform Matrix
@@ -622,7 +625,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
 
       - name: Start Netbox ${{ matrix.netbox_short }}
         run: |
@@ -698,6 +701,7 @@ jobs:
 
             if [ -n "$TOKEN_OUTPUT" ] && [[ "$TOKEN_OUTPUT" == nbt_* ]]; then
               echo "Created v2 token: ${TOKEN_OUTPUT:0:20}..."
+              echo "::add-mask::$TOKEN_OUTPUT"
               echo "token=$TOKEN_OUTPUT" >> $GITHUB_OUTPUT
             else
               echo "WARNING: Failed to create v2 token, using v1 fallback"

--- a/.github/workflows/pssa.yml
+++ b/.github/workflows/pssa.yml
@@ -14,6 +14,9 @@ on:
       - '*.ps1'
       - '*.psm1'
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: PSScriptAnalyzer

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Pre-release Tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,10 +6,16 @@ on:
   pull_request:
     branches: [dev, main, master]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Pester Tests (${{ matrix.os }}, ${{ matrix.pwsh && 'PS 7.x' || 'PS 5.1' }})
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+      issues: write
 
     strategy:
       fail-fast: false
@@ -192,6 +198,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: test
     if: success() && github.event_name == 'push'
+    permissions:
+      contents: read
+      issues: write
 
     steps:
       - name: Close test-failure issues

--- a/Functions/Extras/ImageAttachments/New-NBImageAttachment.ps1
+++ b/Functions/Extras/ImageAttachments/New-NBImageAttachment.ps1
@@ -49,6 +49,7 @@ function New-NBImageAttachment {
     param (
         [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
+        [ValidatePattern('^[a-z]+\.[a-z_]+$')]
         [string]$Object_Type,
 
         [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
@@ -82,6 +83,18 @@ function New-NBImageAttachment {
         # Resolve the full path
         $FullPath = Resolve-Path -Path $ImagePath
         $FileName = Split-Path -Path $FullPath -Leaf
+
+        # Security: Check file size (max 10 MB)
+        $fileInfo = Get-Item -Path $FullPath
+        if ($fileInfo.Length -gt 10MB) {
+            throw "Image file '$FileName' is $([math]::Round($fileInfo.Length / 1MB, 1)) MB. Maximum supported upload size is 10 MB."
+        }
+
+        # Security: Warn about SVG files (potential XSS vector)
+        $fileExtension = [System.IO.Path]::GetExtension($FileName).ToLower()
+        if ($fileExtension -eq '.svg') {
+            Write-Warning "SVG files may contain embedded scripts. Ensure the source file is trusted before uploading to Netbox."
+        }
 
         Write-Verbose "Uploading image: $FileName"
 
@@ -175,6 +188,7 @@ function New-NBImageAttachment {
                     }
 
                     $HttpClient = New-Object System.Net.Http.HttpClient($Handler)
+                    $HttpClient.Timeout = [System.TimeSpan]::FromSeconds((Get-NBTimeout))
                     $HttpClient.DefaultRequestHeaders.Add('Authorization', (Get-NBRequestHeaders).Authorization)
 
                     # Send request

--- a/Functions/Helpers/BuildURIComponents.ps1
+++ b/Functions/Helpers/BuildURIComponents.ps1
@@ -75,8 +75,11 @@ function BuildURIComponents {
 
             'CustomFields' {
                 Write-Verbose " Adding custom field query parameters"
+                $cfSensitivePatterns = @('secret', 'password', 'key', 'token', 'psk')
                 foreach ($field in $ParametersDictionary[$CmdletParameterName].GetEnumerator()) {
-                    Write-Verbose "  Adding parameter 'cf_$($field.Key) = $($field.Value)"
+                    $cfIsSensitive = $cfSensitivePatterns | Where-Object { $field.Key -match $_ }
+                    $cfDisplayValue = if ($cfIsSensitive) { '***REDACTED***' } else { $field.Value }
+                    Write-Verbose "  Adding parameter 'cf_$($field.Key) = $cfDisplayValue"
                     $URIParameters["cf_$($field.Key.ToLower())"] = $field.Value
                 }
 

--- a/Functions/Helpers/InvokeNetboxRequest.ps1
+++ b/Functions/Helpers/InvokeNetboxRequest.ps1
@@ -63,7 +63,7 @@ function InvokeNetboxRequest {
 
         [Hashtable]$Headers = @{},
 
-        [pscustomobject]$Body = $null,
+        [object]$Body = $null,
 
         [ValidateRange(1, 65535)]
         [uint16]$Timeout = (Get-NBTimeout),
@@ -185,26 +185,32 @@ function InvokeNetboxRequest {
         'TimeoutSec'  = $Timeout
         'ContentType' = 'application/json'
         'ErrorAction' = 'Stop'
-        'Verbose'     = $VerbosePreference
     }
 
     $splat += Get-NBInvokeParams
 
     if ($Body) {
-        # Sanitize sensitive fields before logging (handles both hashtables and PSCustomObjects)
-        $sensitivePatterns = @('secret', 'password', 'key', 'token', 'psk')
-        $sanitizedBody = @{}
-        foreach ($prop in $Body.PSObject.Properties) {
-            $isSensitive = $prop.Value -and ($sensitivePatterns | Where-Object { $prop.Name -match $_ })
-            if ($isSensitive) {
-                $sanitizedBody[$prop.Name] = '***REDACTED***'
-            }
-            else {
-                $sanitizedBody[$prop.Name] = $prop.Value
-            }
+        if ($Body -is [array]) {
+            # Bulk array: suppress field-level logging to avoid leaking sensitive values
+            Write-Verbose "BODY: [bulk array of $($Body.Count) items]"
+            $null = $splat.Add('Body', ($Body | ConvertTo-Json -Compress -Depth 10))
         }
-        Write-Verbose "BODY: $($sanitizedBody | ConvertTo-Json -Compress)"
-        $null = $splat.Add('Body', ($Body | ConvertTo-Json -Compress -Depth 10))
+        else {
+            # Sanitize sensitive fields before logging
+            $sensitivePatterns = @('secret', 'password', 'key', 'token', 'psk')
+            $sanitizedBody = @{}
+            foreach ($prop in $Body.PSObject.Properties) {
+                $isSensitive = $sensitivePatterns | Where-Object { $prop.Name -match $_ }
+                if ($isSensitive) {
+                    $sanitizedBody[$prop.Name] = '***REDACTED***'
+                }
+                else {
+                    $sanitizedBody[$prop.Name] = $prop.Value
+                }
+            }
+            Write-Verbose "BODY: $($sanitizedBody | ConvertTo-Json -Compress)"
+            $null = $splat.Add('Body', ($Body | ConvertTo-Json -Compress -Depth 10))
+        }
     }
 
     $attempt = 0

--- a/Functions/Helpers/Send-NBBulkRequest.ps1
+++ b/Functions/Helpers/Send-NBBulkRequest.ps1
@@ -53,6 +53,9 @@ function Send-NBBulkRequest {
         [ValidateRange(1, 1000)]
         [int]$BatchSize = 100,
 
+        [ValidateRange(1, 100000)]
+        [int]$MaxItems = 10000,
+
         [switch]$ShowProgress,
 
         [string]$ActivityName = 'Bulk operation'
@@ -63,6 +66,10 @@ function Send-NBBulkRequest {
     if ($Items.Count -eq 0) {
         $result.Complete()
         return $result
+    }
+
+    if ($Items.Count -gt $MaxItems) {
+        throw "Item count $($Items.Count) exceeds maximum allowed $MaxItems. Use -MaxItems to override."
     }
 
     # Split items into batches

--- a/Functions/Setup/Connect-NBAPI.ps1
+++ b/Functions/Setup/Connect-NBAPI.ps1
@@ -102,7 +102,7 @@ function Connect-NBAPI {
     $psVersion = $PSVersionTable.PSVersion
     if ($SkipCertificateCheck -and $psVersion -ge [version]'7.4') {
         $invokeParams['AllowInsecureRedirect'] = $true
-        Write-Verbose "AllowInsecureRedirect enabled (SkipCertificateCheck is set)"
+        Write-Warning "AllowInsecureRedirect enabled alongside SkipCertificateCheck. HTTP redirects from HTTPS will be followed."
     }
 
     # For PowerShell Desktop (5.1), configure TLS and certificate handling
@@ -126,6 +126,10 @@ function Connect-NBAPI {
                 throw "URI appears to be invalid. Must be in format [host.name], [scheme://host.name], or [scheme://host.name:port]"
             }
         }
+    }
+
+    if ($uriBuilder.Scheme -eq 'http') {
+        Write-Warning "Connecting via HTTP. Your API token will be transmitted in plaintext. Use HTTPS in production."
     }
 
     $null = Set-NBHostName -Hostname $uriBuilder.Host

--- a/Functions/Setup/Invoke-NBGraphQL.ps1
+++ b/Functions/Setup/Invoke-NBGraphQL.ps1
@@ -147,6 +147,7 @@ function Invoke-NBGraphQL {
     param(
         [Parameter(Mandatory, Position = 0, ValueFromPipeline)]
         [ValidateNotNullOrEmpty()]
+        [ValidateLength(1, 65535)]
         [string]$Query,
 
         [Parameter()]

--- a/Functions/Users/Tokens/New-NBToken.ps1
+++ b/Functions/Users/Tokens/New-NBToken.ps1
@@ -46,7 +46,7 @@ function New-NBToken {
 
         [datetime]$Expires,
 
-        [string]$Key,
+        [securestring]$Key,
 
         [bool]$Write_Enabled,
 
@@ -63,7 +63,10 @@ function New-NBToken {
     process {
         Write-Verbose "Creating Token"
         $Segments = [System.Collections.ArrayList]::new(@('users', 'tokens'))
-        $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw'
+        $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'Key'
+        if ($PSBoundParameters.ContainsKey('Key')) {
+            $URIComponents.Parameters['key'] = [System.Net.NetworkCredential]::new('', $Key).Password
+        }
         $URI = BuildNewURI -Segments $URIComponents.Segments
 
         if ($PSCmdlet.ShouldProcess("User $User", 'Create Token')) {

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -118,9 +118,9 @@ services:
       # Security Settings (CI/CD only!)
       # ----------------------------------------------------------------------
       # WARNING: These are insecure defaults for testing only!
-      SECRET_KEY: "ci-test-secret-key-not-for-production-use-$(openssl rand -hex 32)"
-      ALLOWED_HOSTS: "*"
-      CORS_ORIGIN_ALLOW_ALL: "true"
+      SECRET_KEY: "ci-test-secret-key-not-for-production-use-only-do-not-reuse-ever-minimum-50-chars-required"
+      ALLOWED_HOSTS: "localhost,127.0.0.1"
+      CORS_ORIGIN_ALLOW_ALL: "false"
 
       # Netbox 4.5.0+ requires pepper for v2 token HMAC validation (min 50 chars)
       API_TOKEN_PEPPER_1: "ci-pepper-not-for-production-use-only-for-testing-must-be-at-least-50-characters"


### PR DESCRIPTION
## Summary

Comprehensive security hardening based on automated security review (4 parallel agents + AgentShield scan).

### Verbose logging leak prevention (#372)
- Remove `Verbose=$VerbosePreference` from `Invoke-RestMethod` splat — prevented Authorization header from leaking to verbose stream
- Change `$Body` param from `[pscustomobject]` to `[object]` — fixes bulk array body sanitization
- Fix redaction null short-circuit — sensitive fields with null values now redacted
- Add sensitive-field redaction to `BuildURIComponents` custom field logging

### CI/CD hardening (#373)
- Add `permissions: contents: read` to all 7 workflows (least-privilege)
- Pin `docker/setup-buildx-action` to commit SHA
- Add `::add-mask::` for dynamically created CI tokens (3 workflows)
- Fix non-functional `$(openssl rand)` in SECRET_KEY
- Tighten `ALLOWED_HOSTS` to `localhost,127.0.0.1`

### SSL/TLS hardening (#374)
- Add HTTP plaintext warning to `Connect-NBAPI`
- Upgrade `AllowInsecureRedirect` from `Write-Verbose` to `Write-Warning`

### Input validation (#375)
- `New-NBToken -Key`: `[string]` → `[securestring]`
- `New-NBImageAttachment`: `ValidatePattern` on Object_Type, 10MB file limit, SVG XSS warning
- `Invoke-NBGraphQL`: `ValidateLength(1, 65535)` on Query
- `Send-NBBulkRequest`: `MaxItems` param (default 10,000)

### PS 5.1 image upload (#376)
- Set `HttpClient.Timeout` from `Get-NBTimeout`

Closes #372, closes #373, closes #374, closes #375, closes #376

## Test plan
- [x] 2119 unit tests pass (0 failures)
- [ ] CI: all 4 platforms green
- [ ] Verify `permissions:` blocks don't break issue creation workflow