### PR TITLE
fix: Include branch context in 401/403 error messages (#382)

### DIFF
--- a/Functions/Helpers/InvokeNetboxRequest.ps1
+++ b/Functions/Helpers/InvokeNetboxRequest.ps1
@@ -407,26 +407,32 @@ function BuildDetailedErrorMessage {
 
     $troubleshooting = switch ($StatusCode) {
         401 {
-            $tips = [System.Collections.Generic.List[string]]::new()
-            $tips.Add("- Verify your API token is correct and not expired")
-            $tips.Add("- Check token in Netbox: Admin > API Tokens")
-            $tips.Add("- Ensure token has not been revoked")
+            $tips = @(
+                "- Verify your API token is correct and not expired"
+                "- Check token in Netbox: Admin > API Tokens"
+                "- Ensure token has not been revoked"
+            )
             if ($branchHint) {
-                $tips.Add("- Active branch context: $branchHint")
-                $tips.Add("- Verify the token user has access to this branch")
+                $tips += @(
+                    "- Active branch context: $branchHint"
+                    "- Verify the token user has access to this branch"
+                )
             }
             $tips -join "`n"
         }
         403 {
-            $tips = [System.Collections.Generic.List[string]]::new()
-            $tips.Add("- Verify your API token has permission for this operation")
-            $tips.Add("- Check object-level permissions in Netbox")
-            $tips.Add("- Ensure the token user has the required role")
+            $tips = @(
+                "- Verify your API token has permission for this operation"
+                "- Check object-level permissions in Netbox"
+                "- Ensure the token user has the required role"
+            )
             if ($branchHint) {
-                $tips.Add("- Active branch context: $branchHint")
-                $tips.Add("- Verify write permissions apply within the branch schema")
-                $tips.Add("- Confirm the branch is not merged, archived, or read-only")
-                $tips.Add("- Use Exit-NBBranch to test if the operation succeeds in main context")
+                $tips += @(
+                    "- Active branch context: $branchHint"
+                    "- Verify write permissions apply within the branch schema"
+                    "- Confirm the branch is not merged, archived, or read-only"
+                    "- Use Exit-NBBranch to test if the operation succeeds in main context"
+                )
             }
             $tips -join "`n"
         }

--- a/Functions/Helpers/InvokeNetboxRequest.ps1
+++ b/Functions/Helpers/InvokeNetboxRequest.ps1
@@ -392,20 +392,43 @@ function BuildDetailedErrorMessage {
         [string]$ErrorMessage
     )
 
+    # Detect active branch context (if any) so auth failures can hint at
+    # branch-specific permission issues. See issue #382.
+    $branchHint = $null
+    if ($script:NetboxConfig.BranchStack -and $script:NetboxConfig.BranchStack.Count -gt 0) {
+        $currentBranch = $script:NetboxConfig.BranchStack.Peek()
+        $branchHint = if ($currentBranch -is [PSCustomObject] -and $currentBranch.Name) {
+            "$($currentBranch.Name) (schema_id: $($currentBranch.SchemaId))"
+        }
+        else {
+            [string]$currentBranch
+        }
+    }
+
     $troubleshooting = switch ($StatusCode) {
         401 {
-            @(
-                "- Verify your API token is correct and not expired"
-                "- Check token in Netbox: Admin > API Tokens"
-                "- Ensure token has not been revoked"
-            ) -join "`n"
+            $tips = [System.Collections.Generic.List[string]]::new()
+            $tips.Add("- Verify your API token is correct and not expired")
+            $tips.Add("- Check token in Netbox: Admin > API Tokens")
+            $tips.Add("- Ensure token has not been revoked")
+            if ($branchHint) {
+                $tips.Add("- Active branch context: $branchHint")
+                $tips.Add("- Verify the token user has access to this branch")
+            }
+            $tips -join "`n"
         }
         403 {
-            @(
-                "- Verify your API token has permission for this operation"
-                "- Check object-level permissions in Netbox"
-                "- Ensure the token user has the required role"
-            ) -join "`n"
+            $tips = [System.Collections.Generic.List[string]]::new()
+            $tips.Add("- Verify your API token has permission for this operation")
+            $tips.Add("- Check object-level permissions in Netbox")
+            $tips.Add("- Ensure the token user has the required role")
+            if ($branchHint) {
+                $tips.Add("- Active branch context: $branchHint")
+                $tips.Add("- Verify write permissions apply within the branch schema")
+                $tips.Add("- Confirm the branch is not merged, archived, or read-only")
+                $tips.Add("- Use Exit-NBBranch to test if the operation succeeds in main context")
+            }
+            $tips -join "`n"
         }
         404 {
             @(

--- a/Tests/ErrorHandling.Tests.ps1
+++ b/Tests/ErrorHandling.Tests.ps1
@@ -846,6 +846,9 @@ Describe "BuildDetailedErrorMessage Helper" -Tag 'ErrorHandling', 'Helper' {
 
         It "Should provide 403 Forbidden troubleshooting hints" {
             InModuleScope -ModuleName 'PowerNetbox' {
+                # Ensure no branch context leaks in from other tests
+                $script:NetboxConfig.BranchStack = $null
+
                 $result = BuildDetailedErrorMessage -StatusCode 403 -StatusName "Forbidden" `
                     -Method "DELETE" -Endpoint "/api/dcim/devices/123/" -ErrorMessage "Permission denied"
 
@@ -853,6 +856,58 @@ Describe "BuildDetailedErrorMessage Helper" -Tag 'ErrorHandling', 'Helper' {
                 $result | Should -Match "DELETE /api/dcim/devices/123/"
                 $result | Should -Match "token has permission"
                 $result | Should -Match "object-level permissions"
+                # When no branch context is active, branching hints must NOT appear
+                $result | Should -Not -Match "Active branch context"
+                $result | Should -Not -Match "Exit-NBBranch"
+            }
+        }
+
+        It "Should include branch context hints for 403 errors when a branch is active (#382)" {
+            InModuleScope -ModuleName 'PowerNetbox' {
+                # Simulate an Enter-NBBranch context
+                $script:NetboxConfig.BranchStack = [System.Collections.Generic.Stack[object]]::new()
+                $script:NetboxConfig.BranchStack.Push([PSCustomObject]@{
+                    Name     = 'feature/new-datacenter'
+                    SchemaId = 'nbs_abc123'
+                    Id       = 42
+                })
+
+                try {
+                    $result = BuildDetailedErrorMessage -StatusCode 403 -StatusName "Forbidden" `
+                        -Method "PATCH" -Endpoint "/api/dcim/interfaces/382/" -ErrorMessage "Permission denied"
+
+                    $result | Should -Match "403 Forbidden"
+                    $result | Should -Match "Active branch context: feature/new-datacenter"
+                    $result | Should -Match "nbs_abc123"
+                    $result | Should -Match "write permissions apply within the branch schema"
+                    $result | Should -Match "Exit-NBBranch"
+                }
+                finally {
+                    $script:NetboxConfig.BranchStack = $null
+                }
+            }
+        }
+
+        It "Should include branch context hints for 401 errors when a branch is active (#382)" {
+            InModuleScope -ModuleName 'PowerNetbox' {
+                $script:NetboxConfig.BranchStack = [System.Collections.Generic.Stack[object]]::new()
+                $script:NetboxConfig.BranchStack.Push([PSCustomObject]@{
+                    Name     = 'feature/test'
+                    SchemaId = 'nbs_xyz789'
+                    Id       = 7
+                })
+
+                try {
+                    $result = BuildDetailedErrorMessage -StatusCode 401 -StatusName "Unauthorized" `
+                        -Method "GET" -Endpoint "/api/dcim/interfaces/382/" -ErrorMessage "Auth failed"
+
+                    $result | Should -Match "401 Unauthorized"
+                    $result | Should -Match "Active branch context: feature/test"
+                    $result | Should -Match "token user has access to this branch"
+                }
+                finally {
+                    $script:NetboxConfig.BranchStack = $null
+                }
             }
         }
 


### PR DESCRIPTION
## Summary

Addresses #382, where a user hit `HTTP 403 Forbidden` on `Set-NBDCIMInterface` while inside an `Enter-NBBranch` context. The same request replayed via the Swagger UI (without a branch) succeeded, which strongly suggests a branch-scoped permission issue rather than a module bug.

To make this class of problem diagnosable without guesswork, `BuildDetailedErrorMessage` now detects an active branch context and appends branch-aware hints to 401/403 error messages.

### Before
```
Netbox API Error: 403 Forbidden
Endpoint: PATCH https://netbox.example.com/api/dcim/interfaces/382/
Message: Response status code does not indicate success: 403 (Forbidden).

Troubleshooting:
- Verify your API token has permission for this operation
- Check object-level permissions in Netbox
- Ensure the token user has the required role
```

### After (when inside an `Enter-NBBranch` context)
```
Netbox API Error: 403 Forbidden
Endpoint: PATCH https://netbox.example.com/api/dcim/interfaces/382/
Message: Response status code does not indicate success: 403 (Forbidden).

Troubleshooting:
- Verify your API token has permission for this operation
- Check object-level permissions in Netbox
- Ensure the token user has the required role
- Active branch context: feature/new-datacenter (schema_id: nbs_abc123)
- Verify write permissions apply within the branch schema
- Confirm the branch is not merged, archived, or read-only
- Use Exit-NBBranch to test if the operation succeeds in main context
```

No change in behavior when no branch context is active.

## Scope

- `Functions/Helpers/InvokeNetboxRequest.ps1` — `BuildDetailedErrorMessage` now reads `$script:NetboxConfig.BranchStack` and appends branch hints for 401 and 403 only
- `Tests/ErrorHandling.Tests.ps1` — two new tests (#382), and the existing 403 test now asserts that branch hints are absent when no branch is active (prevents stack bleed between tests)

## Test plan

- [x] `Invoke-Pester ./Tests/ErrorHandling.Tests.ps1` — 70 passed, 0 failed
- [x] `Invoke-Pester ./Tests/Branching.Tests.ps1` — 67 passed, 0 failed
- [x] Manual inspection: 404, 429, 500, 503 paths untouched
- [x] Verified that `BuildDetailedErrorMessage` runs inside the module scope so `$script:NetboxConfig` is accessible

## Notes for the reporter

Separately from this fix, the verbose output in #382 (`"Updating D CI MI nt er fa ce"`, a pre-PATCH GET call, and the `ReadAsStringAsync ... Cannot access a disposed object` warning) is code that was removed in PR #170, #178 and #226 — all shipped before 4.5.0.2. The installed PowerNetbox on the reporter's machine therefore appears to be older than the claimed 4.5.6.0. I'll ask them to re-import and re-test in the issue.

Closes part of #382 (diagnostics). The underlying 403 is almost certainly a NetBox-side branch permission issue, not a PowerNetbox bug, but the improved error message will help the reporter confirm that quickly.