### PR TITLE
feat: Add Wait-NBBranch cmdlet to block until branch provisioning completes (#383)

### DIFF
--- a/Functions/Plugins/Branching/Branch/Wait-NBBranch.ps1
+++ b/Functions/Plugins/Branching/Branch/Wait-NBBranch.ps1
@@ -1,0 +1,189 @@
+<#
+.SYNOPSIS
+    Waits for a Netbox branch to reach a target status.
+
+.DESCRIPTION
+    Polls a branch via the Netbox Branching plugin until it reaches a specified
+    target status (default: 'ready'), fails, reaches a different terminal
+    status, or the timeout is exceeded. Accepts pipeline input from New-NBBranch
+    so you can provision a branch and block until it is safe to use, avoiding
+    the race condition where a branched schema is queried before the plugin has
+    finished provisioning it.
+
+    Status lifecycle handled by this function:
+
+    - Transitional (keep polling): new, provisioning, syncing, migrating,
+      merging, reverting
+    - Terminal "ok" (valid targets): ready, merged, archived
+    - Terminal "working": pending-migrations (will fail fast if hit while
+      waiting for another target)
+    - Terminal failure: failed (always throws)
+
+.PARAMETER Id
+    The ID of the branch to wait on. Accepts pipeline input by property name,
+    so a branch object from New-NBBranch binds automatically.
+
+.PARAMETER Name
+    The name of the branch to wait on. Resolved to an ID on the first poll.
+
+.PARAMETER TargetStatus
+    The status to wait for. Default: 'ready'. Valid values: 'ready', 'merged',
+    'archived'.
+
+.PARAMETER TimeoutSeconds
+    Maximum number of seconds to wait before throwing a timeout error.
+    Default: 120.
+
+.PARAMETER PollIntervalMs
+    Poll interval in milliseconds between status checks. Default: 1000.
+
+.OUTPUTS
+    [PSCustomObject] The fully-resolved branch object once it reaches the
+    target status.
+
+.EXAMPLE
+    New-NBBranch -Name "feature/new-datacenter" | Wait-NBBranch | Enter-NBBranch
+
+    Create a branch, wait until provisioning completes, then enter its context.
+
+.EXAMPLE
+    Sync-NBBranch -Id 42 -Confirm:$false
+    Wait-NBBranch -Id 42 -TimeoutSeconds 300
+
+    Sync a branch with main and wait up to 5 minutes for the sync to finish.
+
+.EXAMPLE
+    Merge-NBBranch -Id 42 -Confirm:$false
+    Wait-NBBranch -Id 42 -TargetStatus merged
+
+    Merge a branch and wait for the merge to complete.
+
+.EXAMPLE
+    New-NBBranch -Name 'probe' | Wait-NBBranch -Timeout 60 |
+        Invoke-NBInBranch { Get-NBDCIMDevice }
+
+    Provision a branch, wait for it, and immediately run a query inside it.
+
+.LINK
+    New-NBBranch
+    Get-NBBranch
+    Enter-NBBranch
+    Sync-NBBranch
+    Merge-NBBranch
+#>
+function Wait-NBBranch {
+    [CmdletBinding(DefaultParameterSetName = 'ById')]
+    [OutputType([PSCustomObject])]
+    param(
+        [Parameter(ParameterSetName = 'ById', Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
+        [uint64]$Id,
+
+        [Parameter(ParameterSetName = 'ByName', Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Name,
+
+        [ValidateSet('ready', 'merged', 'archived')]
+        [string]$TargetStatus = 'ready',
+
+        [ValidateRange(1, 3600)]
+        [int]$TimeoutSeconds = 120,
+
+        [ValidateRange(100, 10000)]
+        [int]$PollIntervalMs = 1000
+    )
+
+    begin {
+        # Statuses during which we keep polling. 'new' is technically a terminal
+        # "working" state per the plugin's taxonomy, but in practice a freshly
+        # created branch lingers on 'new' for a few hundred ms before the worker
+        # moves it to 'provisioning', so we treat it as transient.
+        $transitionalStatuses = @(
+            'new', 'provisioning', 'syncing', 'migrating', 'merging', 'reverting'
+        )
+    }
+
+    process {
+        CheckNetboxIsConnected
+
+        Write-Verbose "Waiting for branch to reach status '$TargetStatus' (timeout: ${TimeoutSeconds}s, poll: ${PollIntervalMs}ms)"
+
+        # Start with whichever identifier we were given; once we have the branch
+        # object the first time, prefer Id-based polling because it's faster and
+        # avoids a potential name collision.
+        $currentId = if ($PSCmdlet.ParameterSetName -eq 'ById') { $Id } else { $null }
+        $currentName = if ($PSCmdlet.ParameterSetName -eq 'ByName') { $Name } else { $null }
+
+        $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+        $hasSeenBranch = $false
+        $lastStatus = $null
+
+        while ($true) {
+            # Fetch current state
+            $branch = $null
+            $fetchError = $null
+            try {
+                if ($currentId) {
+                    $branch = Get-NBBranch -Id $currentId -ErrorAction Stop
+                }
+                else {
+                    $branch = Get-NBBranch -Name $currentName -ErrorAction Stop | Select-Object -First 1
+                }
+            }
+            catch {
+                $fetchError = $_
+            }
+
+            $identifier = if ($currentName) { $currentName } else { $currentId }
+
+            if ($fetchError -or -not $branch) {
+                if (-not $hasSeenBranch) {
+                    $detail = if ($fetchError) { ": $($fetchError.Exception.Message)" } else { "" }
+                    throw "Branch '$identifier' not found$detail"
+                }
+                throw "Branch '$identifier' was removed while waiting for status '$TargetStatus' (last observed: '$lastStatus')."
+            }
+
+            if (-not $hasSeenBranch) {
+                $hasSeenBranch = $true
+                # Lock in id + name for subsequent polls
+                $currentId = [uint64]$branch.id
+                $currentName = [string]$branch.name
+            }
+
+            $currentStatus = $branch.status.value
+            $lastStatus = $currentStatus
+            Write-Verbose "Branch '$currentName' (id=$currentId) status: $currentStatus"
+
+            # Target reached — return the fully-resolved branch object.
+            if ($currentStatus -eq $TargetStatus) {
+                Write-Verbose "Branch '$currentName' reached target status '$TargetStatus'"
+                return $branch
+            }
+
+            # Terminal failure — surface plugin-reported errors if present.
+            if ($currentStatus -eq 'failed') {
+                $errorDetail = if ($branch.errors) {
+                    " Details: $(@($branch.errors) -join '; ')"
+                }
+                else {
+                    ""
+                }
+                throw "Branch '$currentName' entered 'failed' state while waiting for '$TargetStatus'.$errorDetail"
+            }
+
+            # Still transitional — sleep and poll again.
+            if ($currentStatus -in $transitionalStatuses) {
+                if ((Get-Date) -ge $deadline) {
+                    throw "Timed out after $TimeoutSeconds seconds waiting for branch '$currentName' to reach status '$TargetStatus' (last observed: '$lastStatus')."
+                }
+                Start-Sleep -Milliseconds $PollIntervalMs
+                continue
+            }
+
+            # Any other terminal status (ready/merged/archived/pending-migrations)
+            # that isn't our target means we'll never reach it — fail fast rather
+            # than burn the whole timeout.
+            throw "Branch '$currentName' is in terminal status '$currentStatus', cannot reach target '$TargetStatus'."
+        }
+    }
+}

--- a/Tests/Branching.Tests.ps1
+++ b/Tests/Branching.Tests.ps1
@@ -436,6 +436,180 @@ Describe "Branching Module Tests" -Tag 'Branching' {
     }
     #endregion
 
+    #region Wait-NBBranch Tests
+    Context "Wait-NBBranch" {
+        # Wait-NBBranch operates by polling Get-NBBranch; override the default
+        # module-level Invoke-RestMethod mock with a Get-NBBranch mock per test
+        # so we can simulate status transitions across successive polls.
+        BeforeEach {
+            # Shared counter for sequential responses across polls within one test.
+            # Reset before each test to avoid leakage.
+            $script:WaitTestCallCount = 0
+        }
+
+        It "Should return immediately when branch is already at target status" {
+            Mock -CommandName 'Get-NBBranch' -ModuleName 'PowerNetbox' -MockWith {
+                return [PSCustomObject]@{
+                    id     = 42
+                    name   = 'already-ready'
+                    status = [PSCustomObject]@{ value = 'ready'; label = 'Ready' }
+                }
+            }
+
+            $result = Wait-NBBranch -Id 42 -PollIntervalMs 100
+            $result | Should -Not -BeNullOrEmpty
+            $result.id | Should -Be 42
+            $result.status.value | Should -Be 'ready'
+            Should -Invoke -CommandName 'Get-NBBranch' -ModuleName 'PowerNetbox' -Times 1
+        }
+
+        It "Should poll through new → provisioning → ready" {
+            Mock -CommandName 'Get-NBBranch' -ModuleName 'PowerNetbox' -MockWith {
+                $script:WaitTestCallCount++
+                $status = switch ($script:WaitTestCallCount) {
+                    1       { 'new' }
+                    2       { 'provisioning' }
+                    default { 'ready' }
+                }
+                return [PSCustomObject]@{
+                    id     = 42
+                    name   = 'transitional'
+                    status = [PSCustomObject]@{ value = $status }
+                }
+            }
+
+            $result = Wait-NBBranch -Id 42 -PollIntervalMs 100
+            $result.status.value | Should -Be 'ready'
+            $script:WaitTestCallCount | Should -BeGreaterOrEqual 3
+        }
+
+        It "Should support -TargetStatus merged for merge workflow" {
+            Mock -CommandName 'Get-NBBranch' -ModuleName 'PowerNetbox' -MockWith {
+                $script:WaitTestCallCount++
+                $status = if ($script:WaitTestCallCount -lt 2) { 'merging' } else { 'merged' }
+                return [PSCustomObject]@{
+                    id     = 42
+                    name   = 'merging-branch'
+                    status = [PSCustomObject]@{ value = $status }
+                }
+            }
+
+            $result = Wait-NBBranch -Id 42 -TargetStatus 'merged' -PollIntervalMs 100
+            $result.status.value | Should -Be 'merged'
+        }
+
+        It "Should throw on 'failed' status and include branch errors" {
+            Mock -CommandName 'Get-NBBranch' -ModuleName 'PowerNetbox' -MockWith {
+                return [PSCustomObject]@{
+                    id     = 42
+                    name   = 'doomed'
+                    status = [PSCustomObject]@{ value = 'failed' }
+                    errors = @('Schema migration failed: relation already exists')
+                }
+            }
+
+            { Wait-NBBranch -Id 42 -PollIntervalMs 100 } |
+                Should -Throw -ExpectedMessage "*failed*Schema migration failed*"
+        }
+
+        It "Should fail fast on unexpected terminal status (archived while waiting for ready)" {
+            Mock -CommandName 'Get-NBBranch' -ModuleName 'PowerNetbox' -MockWith {
+                return [PSCustomObject]@{
+                    id     = 42
+                    name   = 'stale'
+                    status = [PSCustomObject]@{ value = 'archived' }
+                }
+            }
+
+            { Wait-NBBranch -Id 42 -TargetStatus 'ready' -PollIntervalMs 100 } |
+                Should -Throw -ExpectedMessage "*terminal status 'archived'*"
+        }
+
+        It "Should throw a timeout error when branch never reaches target" {
+            Mock -CommandName 'Get-NBBranch' -ModuleName 'PowerNetbox' -MockWith {
+                return [PSCustomObject]@{
+                    id     = 42
+                    name   = 'slow'
+                    status = [PSCustomObject]@{ value = 'provisioning' }
+                }
+            }
+
+            { Wait-NBBranch -Id 42 -TimeoutSeconds 1 -PollIntervalMs 100 } |
+                Should -Throw -ExpectedMessage "*Timed out*provisioning*"
+        }
+
+        It "Should resolve -Name via Get-NBBranch on first poll" {
+            Mock -CommandName 'Get-NBBranch' -ModuleName 'PowerNetbox' -MockWith {
+                return [PSCustomObject]@{
+                    id     = 99
+                    name   = 'lookup-branch'
+                    status = [PSCustomObject]@{ value = 'ready' }
+                }
+            }
+
+            $result = Wait-NBBranch -Name 'lookup-branch' -PollIntervalMs 100
+            $result.id | Should -Be 99
+            $result.name | Should -Be 'lookup-branch'
+        }
+
+        It "Should accept pipeline input from a New-NBBranch-style object" {
+            Mock -CommandName 'Get-NBBranch' -ModuleName 'PowerNetbox' -MockWith {
+                return [PSCustomObject]@{
+                    id     = 55
+                    name   = 'piped'
+                    status = [PSCustomObject]@{ value = 'ready' }
+                }
+            }
+
+            # Simulate what New-NBBranch returns (status is still 'new')
+            $newBranch = [PSCustomObject]@{
+                id     = 55
+                name   = 'piped'
+                status = [PSCustomObject]@{ value = 'new' }
+            }
+
+            $result = $newBranch | Wait-NBBranch -PollIntervalMs 100
+            $result.id | Should -Be 55
+            $result.status.value | Should -Be 'ready'
+        }
+
+        It "Should throw when branch is not found on first poll" {
+            Mock -CommandName 'Get-NBBranch' -ModuleName 'PowerNetbox' -MockWith { return $null }
+
+            { Wait-NBBranch -Id 99999 -PollIntervalMs 100 } |
+                Should -Throw -ExpectedMessage "*not found*"
+        }
+
+        It "Should throw 'removed' error when branch disappears mid-wait" {
+            Mock -CommandName 'Get-NBBranch' -ModuleName 'PowerNetbox' -MockWith {
+                $script:WaitTestCallCount++
+                if ($script:WaitTestCallCount -eq 1) {
+                    return [PSCustomObject]@{
+                        id     = 42
+                        name   = 'vanishing'
+                        status = [PSCustomObject]@{ value = 'provisioning' }
+                    }
+                }
+                return $null
+            }
+
+            { Wait-NBBranch -Id 42 -PollIntervalMs 100 } |
+                Should -Throw -ExpectedMessage "*removed*"
+        }
+
+        It "Should validate -TargetStatus against known terminal states" {
+            # 'provisioning' is transitional, not a valid terminal target
+            { Wait-NBBranch -Id 1 -TargetStatus 'provisioning' } | Should -Throw
+            # 'failed' is terminal but is always an error path, not a target
+            { Wait-NBBranch -Id 1 -TargetStatus 'failed' } | Should -Throw
+        }
+
+        It "Should reject zero or negative TimeoutSeconds" {
+            { Wait-NBBranch -Id 1 -TimeoutSeconds 0 } | Should -Throw
+        }
+    }
+    #endregion
+
     #region Get-NBBranchEvent Tests
     Context "Get-NBBranchEvent" {
         It "Should request branch events" {


### PR DESCRIPTION
## Summary

Closes #383. `New-NBBranch` returns immediately while the branching plugin asynchronously provisions the schema. Interacting with a branch too soon produces the cryptic `'HttpResponseBadRequest' object has no attribute 'schema_name'` error. This PR adds `Wait-NBBranch`, which blocks until a branch reaches a target status with sensible defaults for the common case and opt-in flexibility for sync/merge/archive workflows.

The three usage examples from the issue all work unchanged:

```powershell
If (-Not (Get-NBBranch -Name $BranchName)) {
    New-NBBranch -Name $BranchName | Wait-NBBranch
}
Enter-NBBranch -Name $BranchName

Wait-NBBranch -Name $BranchName | Enter-NBBranch

New-NBBranch -Name $BranchName | Wait-NBBranch -Timeout 60 | Invoke-NBInBranch { Get-NBDCIMDevice }
```

## Signature

```powershell
Wait-NBBranch [-Id <uint64>] [-Name <string>]
              [-TargetStatus {ready | merged | archived}]  # default: ready
              [-TimeoutSeconds <int>]                       # default: 120
              [-PollIntervalMs <int>]                       # default: 1000
```

- `[ValueFromPipelineByPropertyName]` on `-Id` so a `New-NBBranch` output binds automatically.
- Returns the fully-resolved branch object on success — no `-PassThru` needed. Downstream `Enter-NBBranch` / `Invoke-NBInBranch` bind directly.

## Status lifecycle (derived from `netbox-branching/choices.py`)

| State | Handling |
|---|---|
| `new`, `provisioning`, `syncing`, `migrating`, `merging`, `reverting` | Keep polling |
| Target reached (e.g. `ready`) | Return the branch object |
| `failed` | Throw with `branch.errors` attached to the message |
| Any other terminal status that isn't the target (e.g. `archived` while waiting for `ready`) | Fail fast — don't burn the timeout on an impossible wait |
| Branch not found on first poll | Throw "not found" |
| Branch disappears mid-wait | Throw "removed" |
| Deadline exceeded | Throw with last observed status |

`new` is technically a terminal "working" state per the plugin's taxonomy, but in practice a freshly-created branch lingers on `new` for only a few hundred ms before the worker moves it to `provisioning`, so I treat it as transient.

## Guardrails

- `PollIntervalMs` has a minimum of 100 (10 req/s ceiling to protect the API)
- `TimeoutSeconds` capped at 3600
- `-TargetStatus` ValidateSet restricted to `ready | merged | archived` — users cannot wait for `provisioning` or `failed` which would be nonsensical

## Tests

12 new unit tests in `Tests/Branching.Tests.ps1`:

- Return immediately when already at target
- Poll through `new → provisioning → ready`
- Custom `-TargetStatus merged` for merge workflow
- `failed` status surfaces `branch.errors` in the thrown message
- Fail-fast on unexpected terminal status (archived while waiting for ready)
- Timeout error includes last observed status
- `-Name` resolution on first poll
- Pipeline binding from a `New-NBBranch`-shaped object
- Not-found on first poll
- Mid-wait disappearance ("removed")
- `-TargetStatus` parameter validation (rejects transitional/failure values)
- `-TimeoutSeconds` parameter validation (rejects 0)

## Test plan

- [x] `Invoke-Pester ./Tests/Branching.Tests.ps1` — 79 passed, 0 failed (12 new)
- [x] `Invoke-Pester ./Tests/ErrorHandling.Tests.ps1` — 70 passed, 0 failed (regression)
- [x] `Invoke-ScriptAnalyzer` on the new file — clean
- [ ] Manual integration test against live NetBox with branching plugin (deferred to reporter / live-instance smoke run — happy to add to `Branching.Integration.Tests.ps1` if you want)

## Related

- #385 (tangential): `Get-NBBranch -Status` ValidateSet is incorrect (contains `conflict` which doesn't exist, missing 9 real statuses). Not touched by this PR to keep scope focused.