### PR TITLE
fix: Correct Get-NBBranch -Status ValidateSet to match plugin (#385)

### DIFF
--- a/Functions/Plugins/Branching/Branch/Get-NBBranch.ps1
+++ b/Functions/Plugins/Branching/Branch/Get-NBBranch.ps1
@@ -13,7 +13,20 @@
     Filter branches by name.
 
 .PARAMETER Status
-    Filter branches by status. Valid values: ready, merged, conflict.
+    Filter branches by status. Valid values (from netbox-branching
+    BranchStatusChoices):
+
+    Transitional:
+      provisioning, syncing, migrating, merging, reverting
+
+    Terminal "working":
+      new, ready, pending-migrations
+
+    Terminal "done":
+      merged, archived
+
+    Terminal "failure":
+      failed
 
 .PARAMETER Owner
     Filter branches by owner username.
@@ -94,7 +107,11 @@ function Get-NBBranch {
         [string]$Name,
 
         [Parameter(ParameterSetName = 'Query')]
-        [ValidateSet('ready', 'merged', 'conflict')]
+        [ValidateSet(
+            'new', 'provisioning', 'ready', 'syncing', 'migrating',
+            'merging', 'reverting', 'merged', 'archived',
+            'pending-migrations', 'failed'
+        )]
         [string]$Status,
 
         [Parameter(ParameterSetName = 'Query')]

--- a/Functions/Plugins/Branching/Branch/Get-NBBranch.ps1
+++ b/Functions/Plugins/Branching/Branch/Get-NBBranch.ps1
@@ -13,20 +13,11 @@
     Filter branches by name.
 
 .PARAMETER Status
-    Filter branches by status. Valid values (from netbox-branching
-    BranchStatusChoices):
-
-    Transitional:
-      provisioning, syncing, migrating, merging, reverting
-
-    Terminal "working":
-      new, ready, pending-migrations
-
-    Terminal "done":
-      merged, archived
-
-    Terminal "failure":
-      failed
+    Filter branches by status. Valid values (from netbox-branching BranchStatusChoices):
+    Transitional: provisioning, syncing, migrating, merging, reverting
+    Terminal "working": new, ready, pending-migrations
+    Terminal "done": merged, archived
+    Terminal "failure": failed
 
 .PARAMETER Owner
     Filter branches by owner username.

--- a/Tests/Branching.Tests.ps1
+++ b/Tests/Branching.Tests.ps1
@@ -260,6 +260,25 @@ Describe "Branching Module Tests" -Tag 'Branching' {
             $Result.Uri | Should -Match 'status=ready'
         }
 
+        It "Should accept all 11 real BranchStatusChoices values (#385)" {
+            # Source of truth: netbox-branching/choices.py → BranchStatusChoices
+            $allStatuses = @(
+                'new', 'provisioning', 'ready', 'syncing', 'migrating',
+                'merging', 'reverting', 'merged', 'archived',
+                'pending-migrations', 'failed'
+            )
+            foreach ($status in $allStatuses) {
+                $Result = Get-NBBranch -Status $status
+                $Result.Uri | Should -Match "status=$([regex]::Escape($status))" -Because "$status is a real plugin status"
+            }
+        }
+
+        It "Should reject the non-existent 'conflict' status (#385)" {
+            # 'conflict' was in the original ValidateSet but does not exist in
+            # BranchStatusChoices. Reject it at parameter binding time.
+            { Get-NBBranch -Status 'conflict' } | Should -Throw
+        }
+
         It "Should request branches by owner" {
             $Result = Get-NBBranch -Owner 'admin'
             $Result.Uri | Should -Match 'owner=admin'


### PR DESCRIPTION
## Summary

Closes #385. The `-Status` parameter on `Get-NBBranch` accepted `conflict` — a value that does not exist in the netbox-branching plugin — and rejected 9 of the 11 real statuses. Passing `-Status conflict` passed PowerShell-side validation and silently returned zero results because the API never emits that value.

### Before
```powershell
[ValidateSet('ready', 'merged', 'conflict')]
[string]$Status,
```
- `conflict` passes validation but returns nothing.
- `Get-NBBranch -Status failed`, `-Status provisioning`, `-Status archived` etc. all fail at parameter binding even though they are valid plugin statuses.

### After
```powershell
[ValidateSet(
    'new', 'provisioning', 'ready', 'syncing', 'migrating',
    'merging', 'reverting', 'merged', 'archived',
    'pending-migrations', 'failed'
)]
[string]$Status,
```

All 11 real `BranchStatusChoices` values from [`netbox-branching/netbox_branching/choices.py`](https://github.com/netboxlabs/netbox-branching/blob/main/netbox_branching/choices.py), grouped by lifecycle in the parameter doc:

- **Transitional:** `provisioning`, `syncing`, `migrating`, `merging`, `reverting`
- **Terminal "working":** `new`, `ready`, `pending-migrations`
- **Terminal "done":** `merged`, `archived`
- **Terminal "failure":** `failed`

## Tests

Two new tests in `Tests/Branching.Tests.ps1` under the existing `Context "Get-NBBranch"`:

- `Should accept all 11 real BranchStatusChoices values (#385)` — iterates every status and asserts the URI contains the expected `status=` filter.
- `Should reject the non-existent 'conflict' status (#385)` — asserts that the invalid value is now rejected at parameter binding time.

## Test plan

- [x] `Invoke-Pester ./Tests/Branching.Tests.ps1` — 69 passed, 0 failed (2 new)
- [x] Manual inspection: `.PARAMETER Status` doc block rewritten to group statuses by lifecycle phase

## Notes

This was discovered while designing `Wait-NBBranch` in #386. Kept deliberately separate from that PR to keep scope tight. The two PRs are independent and can merge in either order.