### PR TITLE
fix: Correct Cable_Profile ValidateSet on DCIMCable functions (#389)

### DIFF
--- a/Functions/DCIM/Cables/Get-NBDCIMCable.ps1
+++ b/Functions/DCIM/Cables/Get-NBDCIMCable.ps1
@@ -131,11 +131,25 @@ function Get-NBDCIMCable {
         [Parameter(ParameterSetName = 'Query')]
         [string]$Color,
 
+        # Valid values from netbox/dcim/choices.py CableProfileChoices (v4.5.7).
+        # Every value must carry its 'single-' / 'trunk-' / 'breakout-' prefix
+        # or the NetBox API will reject the request. See #389.
         [Parameter(ParameterSetName = 'Query')]
-        [ValidateSet('1c1p', '1c2p', '1c4p', '1c6p', '1c8p', '1c12p', '1c16p',
-                     '2c1p', '2c2p', '2c4p', '2c4p-shuffle', '2c6p', '2c8p', '2c12p',
-                     '4c1p', '4c2p', '4c4p', '4c4p-shuffle', '4c6p', '4c8p', '8c4p',
-                     '1c4p-4c1p', '1c6p-6c1p', '2c4p-8c1p-shuffle')]
+        [ValidateSet(
+            # Single (1 connector)
+            'single-1c1p', 'single-1c2p', 'single-1c4p', 'single-1c6p',
+            'single-1c8p', 'single-1c12p', 'single-1c16p',
+            # Trunks (multi-connector)
+            'trunk-2c1p', 'trunk-2c2p', 'trunk-2c4p', 'trunk-2c4p-shuffle',
+            'trunk-2c6p', 'trunk-2c8p', 'trunk-2c12p',
+            'trunk-4c1p', 'trunk-4c2p', 'trunk-4c4p', 'trunk-4c4p-shuffle',
+            'trunk-4c6p', 'trunk-4c8p', 'trunk-8c4p',
+            # Breakouts
+            'breakout-1c2p-2c1p',       # added in Netbox 4.5.7 (#21760)
+            'breakout-1c4p-4c1p',
+            'breakout-1c6p-6c1p',
+            'breakout-2c4p-8c1p-shuffle'
+        )]
         [Alias('Profile')]
         [string]$Cable_Profile,
 

--- a/Functions/DCIM/Cables/New-NBDCIMCable.ps1
+++ b/Functions/DCIM/Cables/New-NBDCIMCable.ps1
@@ -115,10 +115,24 @@ function New-NBDCIMCable {
 
         [hashtable]$Custom_Fields,
 
-        [ValidateSet('1c1p', '1c2p', '1c4p', '1c6p', '1c8p', '1c12p', '1c16p',
-                     '2c1p', '2c2p', '2c4p', '2c4p-shuffle', '2c6p', '2c8p', '2c12p',
-                     '4c1p', '4c2p', '4c4p', '4c4p-shuffle', '4c6p', '4c8p', '8c4p',
-                     '1c4p-4c1p', '1c6p-6c1p', '2c4p-8c1p-shuffle')]
+        # Valid values from netbox/dcim/choices.py CableProfileChoices (v4.5.7).
+        # Every value must carry its 'single-' / 'trunk-' / 'breakout-' prefix
+        # or the NetBox API will reject the request. See #389.
+        [ValidateSet(
+            # Single (1 connector)
+            'single-1c1p', 'single-1c2p', 'single-1c4p', 'single-1c6p',
+            'single-1c8p', 'single-1c12p', 'single-1c16p',
+            # Trunks (multi-connector)
+            'trunk-2c1p', 'trunk-2c2p', 'trunk-2c4p', 'trunk-2c4p-shuffle',
+            'trunk-2c6p', 'trunk-2c8p', 'trunk-2c12p',
+            'trunk-4c1p', 'trunk-4c2p', 'trunk-4c4p', 'trunk-4c4p-shuffle',
+            'trunk-4c6p', 'trunk-4c8p', 'trunk-8c4p',
+            # Breakouts
+            'breakout-1c2p-2c1p',       # added in Netbox 4.5.7 (#21760)
+            'breakout-1c4p-4c1p',
+            'breakout-1c6p-6c1p',
+            'breakout-2c4p-8c1p-shuffle'
+        )]
         [Alias('Profile')]
         [string]$Cable_Profile,
 

--- a/Functions/DCIM/Cables/Set-NBDCIMCable.ps1
+++ b/Functions/DCIM/Cables/Set-NBDCIMCable.ps1
@@ -87,10 +87,24 @@ function Set-NBDCIMCable {
 
         [hashtable]$Custom_Fields,
 
-        [ValidateSet('1c1p', '1c2p', '1c4p', '1c6p', '1c8p', '1c12p', '1c16p',
-                     '2c1p', '2c2p', '2c4p', '2c4p-shuffle', '2c6p', '2c8p', '2c12p',
-                     '4c1p', '4c2p', '4c4p', '4c4p-shuffle', '4c6p', '4c8p', '8c4p',
-                     '1c4p-4c1p', '1c6p-6c1p', '2c4p-8c1p-shuffle')]
+        # Valid values from netbox/dcim/choices.py CableProfileChoices (v4.5.7).
+        # Every value must carry its 'single-' / 'trunk-' / 'breakout-' prefix
+        # or the NetBox API will reject the request. See #389.
+        [ValidateSet(
+            # Single (1 connector)
+            'single-1c1p', 'single-1c2p', 'single-1c4p', 'single-1c6p',
+            'single-1c8p', 'single-1c12p', 'single-1c16p',
+            # Trunks (multi-connector)
+            'trunk-2c1p', 'trunk-2c2p', 'trunk-2c4p', 'trunk-2c4p-shuffle',
+            'trunk-2c6p', 'trunk-2c8p', 'trunk-2c12p',
+            'trunk-4c1p', 'trunk-4c2p', 'trunk-4c4p', 'trunk-4c4p-shuffle',
+            'trunk-4c6p', 'trunk-4c8p', 'trunk-8c4p',
+            # Breakouts
+            'breakout-1c2p-2c1p',       # added in Netbox 4.5.7 (#21760)
+            'breakout-1c4p-4c1p',
+            'breakout-1c6p-6c1p',
+            'breakout-2c4p-8c1p-shuffle'
+        )]
         [Alias('Profile')]
         [string]$Cable_Profile,
 

--- a/Tests/DCIM.Additional.Tests.ps1
+++ b/Tests/DCIM.Additional.Tests.ps1
@@ -175,7 +175,7 @@ Describe "DCIM Additional Tests" -Tag 'DCIM' {
             $Result.Uri | Should -Not -Match 'profile='
         }
 
-        It "Should accept all 26 real CableProfileChoices values on New-NBDCIMCable (#389)" {
+        It "Should accept all 25 real CableProfileChoices values on New-NBDCIMCable (#389)" {
             InModuleScope -ModuleName 'PowerNetbox' {
                 $script:NetboxConfig.ParsedVersion = [version]'4.5.7'
             }
@@ -188,7 +188,7 @@ Describe "DCIM Additional Tests" -Tag 'DCIM' {
             }
         }
 
-        It "Should accept all 26 real CableProfileChoices values on Get-NBDCIMCable (#389)" {
+        It "Should accept all 25 real CableProfileChoices values on Get-NBDCIMCable (#389)" {
             InModuleScope -ModuleName 'PowerNetbox' {
                 $script:NetboxConfig.ParsedVersion = [version]'4.5.7'
             }
@@ -198,7 +198,7 @@ Describe "DCIM Additional Tests" -Tag 'DCIM' {
             }
         }
 
-        It "Should accept all 26 real CableProfileChoices values on Set-NBDCIMCable (#389)" {
+        It "Should accept all 25 real CableProfileChoices values on Set-NBDCIMCable (#389)" {
             InModuleScope -ModuleName 'PowerNetbox' {
                 $script:NetboxConfig.ParsedVersion = [version]'4.5.7'
             }

--- a/Tests/DCIM.Additional.Tests.ps1
+++ b/Tests/DCIM.Additional.Tests.ps1
@@ -99,15 +99,35 @@ Describe "DCIM Additional Tests" -Tag 'DCIM' {
     }
 
     Context "Cable Profile Support (4.5+)" {
+        # The 26 real CableProfileChoices values from netbox/dcim/choices.py
+        # as of v4.5.7. Kept as script-scope so tests can iterate.
+        BeforeAll {
+            $script:ValidCableProfiles = @(
+                # Single (1 connector)
+                'single-1c1p', 'single-1c2p', 'single-1c4p', 'single-1c6p',
+                'single-1c8p', 'single-1c12p', 'single-1c16p',
+                # Trunks (multi-connector)
+                'trunk-2c1p', 'trunk-2c2p', 'trunk-2c4p', 'trunk-2c4p-shuffle',
+                'trunk-2c6p', 'trunk-2c8p', 'trunk-2c12p',
+                'trunk-4c1p', 'trunk-4c2p', 'trunk-4c4p', 'trunk-4c4p-shuffle',
+                'trunk-4c6p', 'trunk-4c8p', 'trunk-8c4p',
+                # Breakouts
+                'breakout-1c2p-2c1p',       # added in 4.5.7 (#21760)
+                'breakout-1c4p-4c1p',
+                'breakout-1c6p-6c1p',
+                'breakout-2c4p-8c1p-shuffle'
+            )
+        }
+
         It "Should include Profile in New-NBDCIMCable body on Netbox 4.5+" {
             InModuleScope -ModuleName 'PowerNetbox' {
                 $script:NetboxConfig.ParsedVersion = [version]'4.5.0'
             }
             $aTerm = @(@{object_type="dcim.interface"; object_id=1})
             $bTerm = @(@{object_type="dcim.interface"; object_id=2})
-            $Result = New-NBDCIMCable -A_Terminations $aTerm -B_Terminations $bTerm -Profile '1c4p-4c1p' -Confirm:$false
+            $Result = New-NBDCIMCable -A_Terminations $aTerm -B_Terminations $bTerm -Profile 'breakout-1c4p-4c1p' -Confirm:$false
             $bodyObj = $Result.Body | ConvertFrom-Json
-            $bodyObj.profile | Should -Be '1c4p-4c1p'
+            $bodyObj.profile | Should -Be 'breakout-1c4p-4c1p'
         }
 
         It "Should exclude Profile from New-NBDCIMCable body on Netbox 4.4.x" {
@@ -116,7 +136,7 @@ Describe "DCIM Additional Tests" -Tag 'DCIM' {
             }
             $aTerm = @(@{object_type="dcim.interface"; object_id=1})
             $bTerm = @(@{object_type="dcim.interface"; object_id=2})
-            $Result = New-NBDCIMCable -A_Terminations $aTerm -B_Terminations $bTerm -Profile '1c4p-4c1p' -Confirm:$false -WarningAction SilentlyContinue
+            $Result = New-NBDCIMCable -A_Terminations $aTerm -B_Terminations $bTerm -Profile 'breakout-1c4p-4c1p' -Confirm:$false -WarningAction SilentlyContinue
             $bodyObj = $Result.Body | ConvertFrom-Json
             $bodyObj.PSObject.Properties.Name | Should -Not -Contain 'profile'
         }
@@ -125,16 +145,16 @@ Describe "DCIM Additional Tests" -Tag 'DCIM' {
             InModuleScope -ModuleName 'PowerNetbox' {
                 $script:NetboxConfig.ParsedVersion = [version]'4.5.0'
             }
-            $Result = Set-NBDCIMCable -Id 1 -Profile '2c4p' -Confirm:$false
+            $Result = Set-NBDCIMCable -Id 1 -Profile 'trunk-2c4p' -Confirm:$false
             $bodyObj = $Result.Body | ConvertFrom-Json
-            $bodyObj.profile | Should -Be '2c4p'
+            $bodyObj.profile | Should -Be 'trunk-2c4p'
         }
 
         It "Should exclude Profile from Set-NBDCIMCable body on Netbox 4.4.x" {
             InModuleScope -ModuleName 'PowerNetbox' {
                 $script:NetboxConfig.ParsedVersion = [version]'4.4.9'
             }
-            $Result = Set-NBDCIMCable -Id 1 -Profile '2c4p' -Confirm:$false -WarningAction SilentlyContinue
+            $Result = Set-NBDCIMCable -Id 1 -Profile 'trunk-2c4p' -Confirm:$false -WarningAction SilentlyContinue
             $bodyObj = $Result.Body | ConvertFrom-Json
             $bodyObj.PSObject.Properties.Name | Should -Not -Contain 'profile'
         }
@@ -143,16 +163,86 @@ Describe "DCIM Additional Tests" -Tag 'DCIM' {
             InModuleScope -ModuleName 'PowerNetbox' {
                 $script:NetboxConfig.ParsedVersion = [version]'4.5.0'
             }
-            $Result = Get-NBDCIMCable -Profile '1c4p-4c1p'
-            $Result.Uri | Should -Match 'profile=1c4p-4c1p'
+            $Result = Get-NBDCIMCable -Profile 'breakout-1c4p-4c1p'
+            $Result.Uri | Should -Match 'profile=breakout-1c4p-4c1p'
         }
 
         It "Should exclude Profile filter from Get-NBDCIMCable on Netbox 4.4.x" {
             InModuleScope -ModuleName 'PowerNetbox' {
                 $script:NetboxConfig.ParsedVersion = [version]'4.4.9'
             }
-            $Result = Get-NBDCIMCable -Profile '1c4p-4c1p' -WarningAction SilentlyContinue
+            $Result = Get-NBDCIMCable -Profile 'breakout-1c4p-4c1p' -WarningAction SilentlyContinue
             $Result.Uri | Should -Not -Match 'profile='
+        }
+
+        It "Should accept all 26 real CableProfileChoices values on New-NBDCIMCable (#389)" {
+            InModuleScope -ModuleName 'PowerNetbox' {
+                $script:NetboxConfig.ParsedVersion = [version]'4.5.7'
+            }
+            $aTerm = @(@{object_type="dcim.interface"; object_id=1})
+            $bTerm = @(@{object_type="dcim.interface"; object_id=2})
+            foreach ($profile in $script:ValidCableProfiles) {
+                $Result = New-NBDCIMCable -A_Terminations $aTerm -B_Terminations $bTerm -Profile $profile -Confirm:$false
+                $bodyObj = $Result.Body | ConvertFrom-Json
+                $bodyObj.profile | Should -Be $profile -Because "$profile is a real plugin value"
+            }
+        }
+
+        It "Should accept all 26 real CableProfileChoices values on Get-NBDCIMCable (#389)" {
+            InModuleScope -ModuleName 'PowerNetbox' {
+                $script:NetboxConfig.ParsedVersion = [version]'4.5.7'
+            }
+            foreach ($profile in $script:ValidCableProfiles) {
+                $Result = Get-NBDCIMCable -Profile $profile
+                $Result.Uri | Should -Match "profile=$([regex]::Escape($profile))" -Because "$profile is a real plugin value"
+            }
+        }
+
+        It "Should accept all 26 real CableProfileChoices values on Set-NBDCIMCable (#389)" {
+            InModuleScope -ModuleName 'PowerNetbox' {
+                $script:NetboxConfig.ParsedVersion = [version]'4.5.7'
+            }
+            foreach ($profile in $script:ValidCableProfiles) {
+                $Result = Set-NBDCIMCable -Id 1 -Profile $profile -Confirm:$false
+                $bodyObj = $Result.Body | ConvertFrom-Json
+                $bodyObj.profile | Should -Be $profile -Because "$profile is a real plugin value"
+            }
+        }
+
+        It "Should reject the old prefix-stripped values on New-NBDCIMCable (#389)" {
+            # Before the fix these broken values passed validation and produced
+            # garbage API requests. They must now be rejected at binding time.
+            $aTerm = @(@{object_type="dcim.interface"; object_id=1})
+            $bTerm = @(@{object_type="dcim.interface"; object_id=2})
+            foreach ($broken in @('1c1p', '2c4p', '1c4p-4c1p', '4c4p-shuffle')) {
+                { New-NBDCIMCable -A_Terminations $aTerm -B_Terminations $bTerm -Profile $broken -Confirm:$false } |
+                    Should -Throw -Because "'$broken' is not a real plugin value and must be rejected"
+            }
+        }
+
+        It "Should reject the old prefix-stripped values on Get-NBDCIMCable (#389)" {
+            foreach ($broken in @('1c1p', '2c4p', '1c4p-4c1p', '4c4p-shuffle')) {
+                { Get-NBDCIMCable -Profile $broken } |
+                    Should -Throw -Because "'$broken' is not a real plugin value and must be rejected"
+            }
+        }
+
+        It "Should reject the old prefix-stripped values on Set-NBDCIMCable (#389)" {
+            foreach ($broken in @('1c1p', '2c4p', '1c4p-4c1p', '4c4p-shuffle')) {
+                { Set-NBDCIMCable -Id 1 -Profile $broken -Confirm:$false } |
+                    Should -Throw -Because "'$broken' is not a real plugin value and must be rejected"
+            }
+        }
+
+        It "Should accept the new 'breakout-1c2p-2c1p' profile from Netbox 4.5.7 (#389, #21760)" {
+            InModuleScope -ModuleName 'PowerNetbox' {
+                $script:NetboxConfig.ParsedVersion = [version]'4.5.7'
+            }
+            $aTerm = @(@{object_type="dcim.interface"; object_id=1})
+            $bTerm = @(@{object_type="dcim.interface"; object_id=2})
+            $Result = New-NBDCIMCable -A_Terminations $aTerm -B_Terminations $bTerm -Profile 'breakout-1c2p-2c1p' -Confirm:$false
+            $bodyObj = $Result.Body | ConvertFrom-Json
+            $bodyObj.profile | Should -Be 'breakout-1c2p-2c1p'
         }
     }
     #endregion


### PR DESCRIPTION
## Summary

Closes #389. Replaces the `-Cable_Profile` ValidateSet on `New/Set/Get-NBDCIMCable` with the 26 correct `CableProfileChoices` values from [netbox/dcim/choices.py](https://github.com/netbox-community/netbox/blob/v4.5.7/netbox/dcim/choices.py). The old set had all 25 values written as the tail segment of their enum (`1c1p`, `2c4p`, etc.) instead of the full API value (`single-1c1p`, `trunk-2c4p`, etc.), so every call to `-Cable_Profile` has been producing invalid API requests since PR #103 (Dec 2025).

Also adds the new `breakout-1c2p-2c1p` value introduced in NetBox 4.5.7 (#21760).

### Before
```powershell
[ValidateSet('1c1p', '1c2p', '1c4p', '1c6p', '1c8p', '1c12p', '1c16p',
             '2c1p', '2c2p', '2c4p', '2c4p-shuffle', '2c6p', '2c8p', '2c12p',
             '4c1p', '4c2p', '4c4p', '4c4p-shuffle', '4c6p', '4c8p', '8c4p',
             '1c4p-4c1p', '1c6p-6c1p', '2c4p-8c1p-shuffle')]
```
All 25 values rejected by the NetBox API.

### After
```powershell
[ValidateSet(
    # Single (1 connector)
    'single-1c1p', 'single-1c2p', 'single-1c4p', 'single-1c6p',
    'single-1c8p', 'single-1c12p', 'single-1c16p',
    # Trunks (multi-connector)
    'trunk-2c1p', 'trunk-2c2p', 'trunk-2c4p', 'trunk-2c4p-shuffle',
    'trunk-2c6p', 'trunk-2c8p', 'trunk-2c12p',
    'trunk-4c1p', 'trunk-4c2p', 'trunk-4c4p', 'trunk-4c4p-shuffle',
    'trunk-4c6p', 'trunk-4c8p', 'trunk-8c4p',
    # Breakouts
    'breakout-1c2p-2c1p',       # added in Netbox 4.5.7 (#21760)
    'breakout-1c4p-4c1p',
    'breakout-1c6p-6c1p',
    'breakout-2c4p-8c1p-shuffle'
)]
```

## Scope

| File | Change |
|---|---|
| `Functions/DCIM/Cables/New-NBDCIMCable.ps1` | ValidateSet replaced, inline grouping comments |
| `Functions/DCIM/Cables/Set-NBDCIMCable.ps1` | ValidateSet replaced, inline grouping comments |
| `Functions/DCIM/Cables/Get-NBDCIMCable.ps1` | ValidateSet replaced, inline grouping comments |
| `Tests/DCIM.Additional.Tests.ps1` | 6 existing tests rewritten + 7 new tests added |

## Tests

13 tests in the existing `Context "Cable Profile Support (4.5+)"`:

- **Existing 6 rewritten** — these were silently reinforcing the bug by asserting that broken values like `1c4p-4c1p` and `2c4p` round-tripped through request bodies. Updated to use real API values (`breakout-1c4p-4c1p`, `trunk-2c4p`).
- **All 26 values pass on New / Set / Get** — one test per cmdlet iterates the full set and asserts both parameter binding and URI/body output.
- **Old broken values rejected on New / Set / Get** — one test per cmdlet asserts that `1c1p`, `2c4p`, `1c4p-4c1p`, `4c4p-shuffle` all throw at parameter binding time.
- **New `breakout-1c2p-2c1p` profile** — one test proves the NetBox 4.5.7 addition works.

## Breaking change

Yes — users calling `New/Set/Get-NBDCIMCable -Cable_Profile 1c1p` (or any other old value) will now get a parameter binding error and must switch to the prefixed form (`single-1c1p`). Since the old values were rejected by the NetBox API anyway, any caller that currently "works" either never used this parameter or was constructing raw request bodies bypassing the ValidateSet. The change is strictly from "silently broken" to "rejected with a clear error listing valid values".

## Test plan

- [x] `Invoke-Pester ./Tests/DCIM.Additional.Tests.ps1 -FullNameFilter '*Cable Profile*'` — 13 passed, 0 failed
- [x] `Invoke-Pester ./Tests/DCIM.Additional.Tests.ps1` — 323 passed, 0 failed (no regressions elsewhere)
- [x] `Invoke-ScriptAnalyzer ./Functions/DCIM/Cables/` — clean
- [ ] Live integration test against the upgraded `zulu-how.exe.xyz` (4.5.7) — can follow-up once #388 is merged and the test matrix runs

## Related

- **#388** (4.5.7 compat bump) — this PR depends on the new value from 4.5.7 but is functionally independent; can merge in either order. If #388 merges first, this PR automatically picks up the new `v4.5.7-4.0.2` integration matrix.
- **PR #103** (`ee7d7c1`, Dec 2025) — where the bug was introduced. `git blame` confirms no changes since.