### PR TITLE
fix: enforce mutual exclusion between -Brief, -Fields, -Omit (PR-1: helper + 3 pilots)

### DIFF
--- a/Functions/DCIM/Devices/Get-NBDCIMDevice.ps1
+++ b/Functions/DCIM/Devices/Get-NBDCIMDevice.ps1
@@ -191,14 +191,24 @@ function Get-NBDCIMDevice {
     #endregion Parameters
 
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
+
         Write-Verbose "Retrieving DCIM Device"
 
-        # Build omit list: add config_context unless explicitly included
+        # Auto-omit config_context only when the user has not otherwise
+        # restricted the projection. -Brief returns a minimal representation
+        # (config_context is never included). -Fields explicitly selects the
+        # returned shape, so the user owns that choice.
+        $inProjectionMode = $PSBoundParameters.ContainsKey('Brief') -or
+                            $PSBoundParameters.ContainsKey('Fields')
+
         $omitFields = @()
         if ($PSBoundParameters.ContainsKey('Omit')) {
             $omitFields += $Omit
         }
-        if (-not $IncludeConfigContext) {
+        if (-not $IncludeConfigContext -and -not $inProjectionMode) {
             $omitFields += 'config_context'
         }
 

--- a/Functions/Helpers/AssertNBMutualExclusiveParam.ps1
+++ b/Functions/Helpers/AssertNBMutualExclusiveParam.ps1
@@ -1,0 +1,44 @@
+function AssertNBMutualExclusiveParam {
+    <#
+    .SYNOPSIS
+        Throws when two or more of the named parameters are present in a bound-parameters dictionary.
+
+    .DESCRIPTION
+        Internal helper used to enforce mutual exclusion between cmdlet parameters
+        at runtime. Throws a terminating ParameterBindingException that names the
+        conflicting parameters.
+
+    .PARAMETER BoundParameters
+        The $PSBoundParameters dictionary from the calling cmdlet, or any
+        IDictionary that maps parameter names to values.
+
+    .PARAMETER Parameters
+        The list of parameter names that are mutually exclusive. At least two
+        must be provided; typically 2-5 in practice.
+
+    .PARAMETER HelpHint
+        Optional text appended to the exception message (e.g. a pointer to docs).
+
+    .EXAMPLE
+        AssertNBMutualExclusiveParam -BoundParameters $PSBoundParameters -Parameters 'Brief','Fields','Omit'
+    #>
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory)]
+        [System.Collections.IDictionary]$BoundParameters,
+
+        [Parameter(Mandatory)]
+        [ValidateCount(2, 10)]
+        [string[]]$Parameters,
+
+        [string]$HelpHint
+    )
+
+    $supplied = $Parameters | Where-Object { $BoundParameters.ContainsKey($_) }
+    if ($supplied.Count -gt 1) {
+        $joined = '-' + ($supplied -join ', -')
+        $message = "Parameters $joined are mutually exclusive. Specify only one."
+        if ($HelpHint) { $message += " $HelpHint" }
+        throw [System.Management.Automation.ParameterBindingException]::new($message)
+    }
+}

--- a/Functions/IPAM/Address/Get-NBIPAMAddress.ps1
+++ b/Functions/IPAM/Address/Get-NBIPAMAddress.ps1
@@ -119,6 +119,10 @@ function Get-NBIPAMAddress {
     )
 
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
+
         Write-Verbose "Retrieving IPAM Address"
         switch ($PSCmdlet.ParameterSetName) {
         'ById' {

--- a/Functions/VPN/Tunnel/Get-NBVPNTunnel.ps1
+++ b/Functions/VPN/Tunnel/Get-NBVPNTunnel.ps1
@@ -64,6 +64,10 @@ function Get-NBVPNTunnel {
         [switch]$Raw
     )
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
+
         Write-Verbose "Retrieving VPN Tunnel"
         switch ($PSCmdlet.ParameterSetName) {
             'ByID' {

--- a/Tests/DCIM.Devices.Tests.ps1
+++ b/Tests/DCIM.Devices.Tests.ps1
@@ -161,16 +161,6 @@ Describe "DCIM Devices Tests" -Tag 'DCIM', 'Devices' {
             $Result.Uri | Should -Match 'fields=id(%2C|,)name(%2C|,)status(%2C|,)site.name'
         }
 
-        It "Should combine Brief with exclude config_context" {
-            # After the guard fix: -Brief does NOT inject omit=config_context because
-            # the server already controls the response shape in brief mode.
-            $Result = Get-NBDCIMDevice -Brief
-
-            $Result.Method | Should -Be 'GET'
-            $Result.Uri | Should -Match 'brief=True'
-            $Result.Uri | Should -Not -Match 'omit=config_context'
-        }
-
         Context "Brief/Fields/Omit mutual exclusion" {
             It "Throws when -Brief and -Fields are both specified" {
                 { Get-NBDCIMDevice -Brief -Fields 'id' } |
@@ -203,12 +193,10 @@ Describe "DCIM Devices Tests" -Tag 'DCIM', 'Devices' {
 
             It "With -Fields: URI contains the fields parameter and no config_context omit" {
                 $Result = Get-NBDCIMDevice -Fields 'id', 'name'
-                # Match 'fields=' separately from each value name — commas between
-                # values may be URL-encoded as %2C on some platforms but the field
-                # names themselves will appear literally.
-                $Result.Uri | Should -Match 'fields='
-                $Result.Uri | Should -Match 'id'
-                $Result.Uri | Should -Match 'name'
+                # Anchor field names to the fields= parameter to avoid false-positive
+                # matches elsewhere in the URI. Comma between values may be URL-encoded
+                # as %2C on some platforms (pattern matches both forms).
+                $Result.Uri | Should -Match 'fields=id(%2C|,)name'
                 $Result.Uri | Should -Not -Match 'omit=config_context'
             }
 

--- a/Tests/DCIM.Devices.Tests.ps1
+++ b/Tests/DCIM.Devices.Tests.ps1
@@ -193,10 +193,10 @@ Describe "DCIM Devices Tests" -Tag 'DCIM', 'Devices' {
 
             It "With -Fields: URI contains the fields parameter and no config_context omit" {
                 $Result = Get-NBDCIMDevice -Fields 'id', 'name'
-                # Anchor field names to the fields= parameter to avoid false-positive
-                # matches elsewhere in the URI. Comma between values may be URL-encoded
-                # as %2C on some platforms (pattern matches both forms).
-                $Result.Uri | Should -Match 'fields=id(%2C|,)name'
+                # Lookahead anchors confirm both field names appear after fields=
+                # regardless of order and regardless of whether the comma between
+                # values is URL-encoded as %2C on some platforms.
+                $Result.Uri | Should -Match 'fields=(?=.*id)(?=.*name)'
                 $Result.Uri | Should -Not -Match 'omit=config_context'
             }
 

--- a/Tests/DCIM.Devices.Tests.ps1
+++ b/Tests/DCIM.Devices.Tests.ps1
@@ -162,11 +162,73 @@ Describe "DCIM Devices Tests" -Tag 'DCIM', 'Devices' {
         }
 
         It "Should combine Brief with exclude config_context" {
+            # After the guard fix: -Brief does NOT inject omit=config_context because
+            # the server already controls the response shape in brief mode.
             $Result = Get-NBDCIMDevice -Brief
 
             $Result.Method | Should -Be 'GET'
             $Result.Uri | Should -Match 'brief=True'
-            $Result.Uri | Should -Match 'omit=config_context'
+            $Result.Uri | Should -Not -Match 'omit=config_context'
+        }
+
+        Context "Brief/Fields/Omit mutual exclusion" {
+            It "Throws when -Brief and -Fields are both specified" {
+                { Get-NBDCIMDevice -Brief -Fields 'id' } |
+                    Should -Throw -ExceptionType ([System.Management.Automation.ParameterBindingException])
+            }
+
+            It "Throws when -Brief and -Omit are both specified" {
+                { Get-NBDCIMDevice -Brief -Omit 'comments' } |
+                    Should -Throw -ExceptionType ([System.Management.Automation.ParameterBindingException])
+            }
+
+            It "Throws when -Fields and -Omit are both specified" {
+                { Get-NBDCIMDevice -Fields 'id' -Omit 'comments' } |
+                    Should -Throw -ExceptionType ([System.Management.Automation.ParameterBindingException])
+            }
+
+            It "Does not throw when -Brief is specified alone (control)" {
+                $Result = Get-NBDCIMDevice -Brief
+                $Result.Method | Should -Be 'GET'
+                $Result.Uri | Should -Match 'brief=True'
+            }
+        }
+
+        Context "Brief/Fields/Omit interaction with IncludeConfigContext" {
+            It "With -Brief: URI contains brief=True and no config_context omit" {
+                $Result = Get-NBDCIMDevice -Brief
+                $Result.Uri | Should -Match 'brief=True'
+                $Result.Uri | Should -Not -Match 'omit=config_context'
+            }
+
+            It "With -Fields: URI contains the fields parameter and no config_context omit" {
+                $Result = Get-NBDCIMDevice -Fields 'id', 'name'
+                # Match 'fields=' separately from each value name — commas between
+                # values may be URL-encoded as %2C on some platforms but the field
+                # names themselves will appear literally.
+                $Result.Uri | Should -Match 'fields='
+                $Result.Uri | Should -Match 'id'
+                $Result.Uri | Should -Match 'name'
+                $Result.Uri | Should -Not -Match 'omit=config_context'
+            }
+
+            It "With -Omit: URI contains the user's omit value merged with config_context" {
+                $Result = Get-NBDCIMDevice -Omit 'comments'
+                $Result.Uri | Should -Match 'omit='
+                $Result.Uri | Should -Match 'comments'
+                $Result.Uri | Should -Match 'config_context'
+            }
+
+            It "With -IncludeConfigContext -Brief: URI contains brief=True only (IncludeConfigContext silently ignored)" {
+                $Result = Get-NBDCIMDevice -IncludeConfigContext -Brief
+                $Result.Uri | Should -Match 'brief=True'
+                $Result.Uri | Should -Not -Match 'config_context'
+            }
+
+            It "With no projection flags: URI contains the default config_context auto-omit" {
+                $Result = Get-NBDCIMDevice
+                $Result.Uri | Should -Match 'omit=config_context'
+            }
         }
     }
 

--- a/Tests/Helpers.Tests.ps1
+++ b/Tests/Helpers.Tests.ps1
@@ -870,4 +870,97 @@ Describe "Helpers tests" -Tag 'Core', 'Helpers' {
             }
         }
     }
+
+    Context "AssertNBMutualExclusiveParam" {
+        It "Does not throw when zero parameters from the list are bound" {
+            InModuleScope -ModuleName 'PowerNetbox' {
+                $bound = @{}
+                { AssertNBMutualExclusiveParam -BoundParameters $bound -Parameters 'Brief', 'Fields', 'Omit' } |
+                    Should -Not -Throw
+            }
+        }
+
+        It "Does not throw when exactly one parameter from the list is bound" {
+            InModuleScope -ModuleName 'PowerNetbox' {
+                $bound = @{ Brief = $true }
+                { AssertNBMutualExclusiveParam -BoundParameters $bound -Parameters 'Brief', 'Fields', 'Omit' } |
+                    Should -Not -Throw
+            }
+        }
+
+        It "Throws ParameterBindingException when two parameters are bound" {
+            InModuleScope -ModuleName 'PowerNetbox' {
+                $bound = @{ Brief = $true; Fields = @('id', 'name') }
+                { AssertNBMutualExclusiveParam -BoundParameters $bound -Parameters 'Brief', 'Fields', 'Omit' } |
+                    Should -Throw -ExceptionType ([System.Management.Automation.ParameterBindingException])
+            }
+        }
+
+        It "Throws with a message naming all conflicting parameters when three are bound" {
+            InModuleScope -ModuleName 'PowerNetbox' {
+                $bound = @{ Brief = $true; Fields = @('id'); Omit = @('x') }
+                try {
+                    AssertNBMutualExclusiveParam -BoundParameters $bound -Parameters 'Brief', 'Fields', 'Omit'
+                    throw "Expected an exception but none was thrown"
+                } catch [System.Management.Automation.ParameterBindingException] {
+                    $_.Exception.Message | Should -Match '-Brief'
+                    $_.Exception.Message | Should -Match '-Fields'
+                    $_.Exception.Message | Should -Match '-Omit'
+                    $_.Exception.Message | Should -Match 'mutually exclusive'
+                }
+            }
+        }
+
+        It "Appends HelpHint to the exception message when supplied" {
+            InModuleScope -ModuleName 'PowerNetbox' {
+                $bound = @{ Brief = $true; Fields = @('id') }
+                try {
+                    AssertNBMutualExclusiveParam -BoundParameters $bound -Parameters 'Brief', 'Fields', 'Omit' -HelpHint 'See Get-Help for alternatives.'
+                    throw "Expected an exception but none was thrown"
+                } catch [System.Management.Automation.ParameterBindingException] {
+                    $_.Exception.Message | Should -Match 'See Get-Help for alternatives\.'
+                }
+            }
+        }
+
+        It "Rejects calls with fewer than 2 parameter names via ValidateCount" {
+            InModuleScope -ModuleName 'PowerNetbox' {
+                { AssertNBMutualExclusiveParam -BoundParameters @{} -Parameters 'Brief' } |
+                    Should -Throw
+            }
+        }
+
+        It "Treats parameter names case-sensitively (matching PSBoundParameters semantics)" {
+            InModuleScope -ModuleName 'PowerNetbox' {
+                $bound = @{ brief = $true; fields = @('id') }
+                { AssertNBMutualExclusiveParam -BoundParameters $bound -Parameters 'brief', 'fields' } |
+                    Should -Throw -ExceptionType ([System.Management.Automation.ParameterBindingException])
+            }
+        }
+
+        It "Accepts a generic Dictionary as BoundParameters" {
+            InModuleScope -ModuleName 'PowerNetbox' {
+                $bound = [System.Collections.Generic.Dictionary[string, object]]::new()
+                $bound['Brief'] = $true
+                $bound['Fields'] = @('id')
+                { AssertNBMutualExclusiveParam -BoundParameters $bound -Parameters 'Brief', 'Fields', 'Omit' } |
+                    Should -Throw -ExceptionType ([System.Management.Automation.ParameterBindingException])
+            }
+        }
+
+        It "Does not throw for empty or null BoundParameters" {
+            InModuleScope -ModuleName 'PowerNetbox' {
+                { AssertNBMutualExclusiveParam -BoundParameters @{} -Parameters 'Brief', 'Fields', 'Omit' } |
+                    Should -Not -Throw
+            }
+        }
+
+        It "Ignores parameters outside the checked list" {
+            InModuleScope -ModuleName 'PowerNetbox' {
+                $bound = @{ Brief = $true; Limit = 10; Offset = 100 }
+                { AssertNBMutualExclusiveParam -BoundParameters $bound -Parameters 'Brief', 'Fields', 'Omit' } |
+                    Should -Not -Throw
+            }
+        }
+    }
 }

--- a/Tests/Helpers.Tests.ps1
+++ b/Tests/Helpers.Tests.ps1
@@ -926,11 +926,15 @@ Describe "Helpers tests" -Tag 'Core', 'Helpers' {
         It "Rejects calls with fewer than 2 parameter names via ValidateCount" {
             InModuleScope -ModuleName 'PowerNetbox' {
                 { AssertNBMutualExclusiveParam -BoundParameters @{} -Parameters 'Brief' } |
-                    Should -Throw
+                    Should -Throw -ExceptionType ([System.Management.Automation.ParameterBindingException])
             }
         }
 
-        It "Treats parameter names case-sensitively (matching PSBoundParameters semantics)" {
+        It "Works with lowercase parameter names when Parameters list also uses lowercase" {
+            # PSBoundParameters (and plain Hashtable) use OrdinalIgnoreCase comparisons,
+            # so key lookup is case-insensitive regardless of the dictionary-key casing.
+            # The helper delegates case behavior to the dictionary; when caller and
+            # dictionary agree on casing the comparison trivially succeeds.
             InModuleScope -ModuleName 'PowerNetbox' {
                 $bound = @{ brief = $true; fields = @('id') }
                 { AssertNBMutualExclusiveParam -BoundParameters $bound -Parameters 'brief', 'fields' } |

--- a/Tests/IPAM.Tests.ps1
+++ b/Tests/IPAM.Tests.ps1
@@ -68,6 +68,29 @@ Describe "IPAM tests" -Tag 'Ipam' {
             $Result = Get-NBIPAMAddress -Family 4
             $Result.Uri | Should -Be 'https://netbox.domain.com/api/ipam/ip-addresses/?family=4'
         }
+
+        Context "Brief/Fields/Omit mutual exclusion" {
+            It "Throws when -Brief and -Fields are both specified" {
+                { Get-NBIPAMAddress -Brief -Fields 'id' } |
+                    Should -Throw -ExceptionType ([System.Management.Automation.ParameterBindingException])
+            }
+
+            It "Throws when -Brief and -Omit are both specified" {
+                { Get-NBIPAMAddress -Brief -Omit 'comments' } |
+                    Should -Throw -ExceptionType ([System.Management.Automation.ParameterBindingException])
+            }
+
+            It "Throws when -Fields and -Omit are both specified" {
+                { Get-NBIPAMAddress -Fields 'id' -Omit 'comments' } |
+                    Should -Throw -ExceptionType ([System.Management.Automation.ParameterBindingException])
+            }
+
+            It "Does not throw when -Brief is specified alone (control)" {
+                $Result = Get-NBIPAMAddress -Brief
+                $Result.Method | Should -Be 'GET'
+                $Result.Uri | Should -Match 'brief=True'
+            }
+        }
     }
 
     Context "New-NBIPAMAddress" {

--- a/Tests/VPN.Tests.ps1
+++ b/Tests/VPN.Tests.ps1
@@ -60,6 +60,29 @@ Describe "VPN Module Tests" -Tag 'VPN' {
             $Result.Uri | Should -Match 'limit=10'
             $Result.Uri | Should -Match 'offset=20'
         }
+
+        Context "Brief/Fields/Omit mutual exclusion" {
+            It "Throws when -Brief and -Fields are both specified" {
+                { Get-NBVPNTunnel -Brief -Fields 'id' } |
+                    Should -Throw -ExceptionType ([System.Management.Automation.ParameterBindingException])
+            }
+
+            It "Throws when -Brief and -Omit are both specified" {
+                { Get-NBVPNTunnel -Brief -Omit 'comments' } |
+                    Should -Throw -ExceptionType ([System.Management.Automation.ParameterBindingException])
+            }
+
+            It "Throws when -Fields and -Omit are both specified" {
+                { Get-NBVPNTunnel -Fields 'id' -Omit 'comments' } |
+                    Should -Throw -ExceptionType ([System.Management.Automation.ParameterBindingException])
+            }
+
+            It "Does not throw when -Brief is specified alone (control)" {
+                $Result = Get-NBVPNTunnel -Brief
+                $Result.Method | Should -Be 'GET'
+                $Result.Uri | Should -Match 'brief=True'
+            }
+        }
     }
 
     Context "New-NBVPNTunnel" {

--- a/docs/superpowers/plans/2026-04-16-filter-exclusion-pr1.md
+++ b/docs/superpowers/plans/2026-04-16-filter-exclusion-pr1.md
@@ -1,0 +1,753 @@
+# Brief/Fields/Omit Mutual Exclusion — PR-1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the `AssertNBMutualExclusiveParam` helper and apply it to 3 pilot Get functions, proving the pattern works before PR-2 rolls out to the remaining 121 functions.
+
+**Architecture:** One internal helper (`Functions/Helpers/AssertNBMutualExclusiveParam.ps1`) throws a `ParameterBindingException` when ≥2 of a named parameter list are supplied together. Each Get function calls it once at the top of `process { }`. Special case: `Get-NBDCIMDevice`'s `IncludeConfigContext`-driven auto-omit is guarded so it only fires when neither `Brief` nor `Fields` is specified.
+
+**Tech Stack:** PowerShell 5.1+ / 7, Pester v5 tests, module built via `./deploy.ps1 -Environment dev -SkipVersion`, branch `fix/silent-filter-combination`.
+
+**Spec reference:** `docs/superpowers/specs/2026-04-16-filter-exclusion-design.md`
+
+---
+
+## Task 1: Establish baseline
+
+**Files:**
+- Read-only: `PowerNetbox.psd1`, `Tests/**`
+
+- [ ] **Step 1: Confirm current branch**
+
+```bash
+cd /Users/elvis/Developer/PowerNetbox-project/PowerNetbox
+git rev-parse --abbrev-ref HEAD
+```
+
+Expected output: `fix/silent-filter-combination`
+
+If you are on another branch, stop and switch: `git checkout fix/silent-filter-combination`. Do not proceed if HEAD is on `dev` or `main`.
+
+- [ ] **Step 2: Build the module**
+
+```bash
+./deploy.ps1 -Environment dev -SkipVersion
+```
+
+Expected output: last line mentions successful build. No errors. This populates `PowerNetbox/PowerNetbox/PowerNetbox.psd1` (the gitignored build artifact).
+
+- [ ] **Step 3: Run the existing Helpers tests (sanity check)**
+
+```bash
+pwsh -NoProfile -Command "Invoke-Pester ./Tests/Helpers.Tests.ps1 -Output Detailed"
+```
+
+Expected: all existing tests pass. Record the passing count — you'll add to it.
+
+- [ ] **Step 4: Run the existing Devices/IPAM/VPN tests**
+
+```bash
+pwsh -NoProfile -Command "Invoke-Pester ./Tests/DCIM.Devices.Tests.ps1, ./Tests/IPAM.Tests.ps1, ./Tests/VPN.Tests.ps1 -Output Detailed"
+```
+
+Expected: all tests pass. Record the passing count.
+
+- [ ] **Step 5: Restore the build artifact before starting**
+
+```bash
+git checkout -- PowerNetbox.psd1 2>/dev/null; git status --short
+```
+
+Expected: clean working tree (other than untracked files). `deploy.ps1` sometimes stamps the source `PowerNetbox.psd1` with a fresh date — this reset avoids committing build noise later.
+
+---
+
+## Task 2: Add `AssertNBMutualExclusiveParam` helper (TDD)
+
+**Files:**
+- Create: `Functions/Helpers/AssertNBMutualExclusiveParam.ps1`
+- Modify: `Tests/Helpers.Tests.ps1` (append new `Context`)
+
+- [ ] **Step 1: Write the failing tests**
+
+Open `Tests/Helpers.Tests.ps1`. Append this new `Context` block inside the existing top-level `Describe "Helpers tests"` block, just before its closing `}`:
+
+```powershell
+Context "AssertNBMutualExclusiveParam" {
+    It "Does not throw when zero parameters from the list are bound" {
+        InModuleScope -ModuleName 'PowerNetbox' {
+            $bound = @{}
+            { AssertNBMutualExclusiveParam -BoundParameters $bound -Parameters 'Brief', 'Fields', 'Omit' } |
+                Should -Not -Throw
+        }
+    }
+
+    It "Does not throw when exactly one parameter from the list is bound" {
+        InModuleScope -ModuleName 'PowerNetbox' {
+            $bound = @{ Brief = $true }
+            { AssertNBMutualExclusiveParam -BoundParameters $bound -Parameters 'Brief', 'Fields', 'Omit' } |
+                Should -Not -Throw
+        }
+    }
+
+    It "Throws ParameterBindingException when two parameters are bound" {
+        InModuleScope -ModuleName 'PowerNetbox' {
+            $bound = @{ Brief = $true; Fields = @('id', 'name') }
+            { AssertNBMutualExclusiveParam -BoundParameters $bound -Parameters 'Brief', 'Fields', 'Omit' } |
+                Should -Throw -ExceptionType ([System.Management.Automation.ParameterBindingException])
+        }
+    }
+
+    It "Throws with a message naming all conflicting parameters when three are bound" {
+        InModuleScope -ModuleName 'PowerNetbox' {
+            $bound = @{ Brief = $true; Fields = @('id'); Omit = @('x') }
+            try {
+                AssertNBMutualExclusiveParam -BoundParameters $bound -Parameters 'Brief', 'Fields', 'Omit'
+                throw "Expected an exception but none was thrown"
+            } catch [System.Management.Automation.ParameterBindingException] {
+                $_.Exception.Message | Should -Match '-Brief'
+                $_.Exception.Message | Should -Match '-Fields'
+                $_.Exception.Message | Should -Match '-Omit'
+                $_.Exception.Message | Should -Match 'mutually exclusive'
+            }
+        }
+    }
+
+    It "Appends HelpHint to the exception message when supplied" {
+        InModuleScope -ModuleName 'PowerNetbox' {
+            $bound = @{ Brief = $true; Fields = @('id') }
+            try {
+                AssertNBMutualExclusiveParam -BoundParameters $bound -Parameters 'Brief', 'Fields', 'Omit' -HelpHint 'See Get-Help for alternatives.'
+                throw "Expected an exception but none was thrown"
+            } catch [System.Management.Automation.ParameterBindingException] {
+                $_.Exception.Message | Should -Match 'See Get-Help for alternatives\.'
+            }
+        }
+    }
+
+    It "Rejects calls with fewer than 2 parameter names via ValidateCount" {
+        InModuleScope -ModuleName 'PowerNetbox' {
+            { AssertNBMutualExclusiveParam -BoundParameters @{} -Parameters 'Brief' } |
+                Should -Throw
+        }
+    }
+
+    It "Treats parameter names case-sensitively (matching PSBoundParameters semantics)" {
+        InModuleScope -ModuleName 'PowerNetbox' {
+            # PSBoundParameters keys are case-insensitive in practice, but we match
+            # whatever the caller provides. Verify that an exact-match pair triggers
+            # the throw, and that only-lower-case-key also triggers (PSBoundParameters
+            # is case-insensitive).
+            $bound = @{ brief = $true; fields = @('id') }
+            { AssertNBMutualExclusiveParam -BoundParameters $bound -Parameters 'brief', 'fields' } |
+                Should -Throw -ExceptionType ([System.Management.Automation.ParameterBindingException])
+        }
+    }
+
+    It "Accepts a generic Dictionary as BoundParameters" {
+        InModuleScope -ModuleName 'PowerNetbox' {
+            $bound = [System.Collections.Generic.Dictionary[string, object]]::new()
+            $bound['Brief'] = $true
+            $bound['Fields'] = @('id')
+            { AssertNBMutualExclusiveParam -BoundParameters $bound -Parameters 'Brief', 'Fields', 'Omit' } |
+                Should -Throw -ExceptionType ([System.Management.Automation.ParameterBindingException])
+        }
+    }
+
+    It "Does not throw for empty or null BoundParameters" {
+        InModuleScope -ModuleName 'PowerNetbox' {
+            { AssertNBMutualExclusiveParam -BoundParameters @{} -Parameters 'Brief', 'Fields', 'Omit' } |
+                Should -Not -Throw
+        }
+    }
+
+    It "Ignores parameters outside the checked list" {
+        InModuleScope -ModuleName 'PowerNetbox' {
+            $bound = @{ Brief = $true; Limit = 10; Offset = 100 }
+            { AssertNBMutualExclusiveParam -BoundParameters $bound -Parameters 'Brief', 'Fields', 'Omit' } |
+                Should -Not -Throw
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Build, then run the new tests — verify they fail**
+
+```bash
+./deploy.ps1 -Environment dev -SkipVersion
+pwsh -NoProfile -Command "Invoke-Pester ./Tests/Helpers.Tests.ps1 -Output Detailed -FullNameFilter '*AssertNBMutualExclusiveParam*'"
+```
+
+Expected: **all 10 new tests fail** with error messages like "The term 'AssertNBMutualExclusiveParam' is not recognized...". This confirms the tests are wired correctly before the implementation exists.
+
+- [ ] **Step 3: Create the helper file**
+
+Create `Functions/Helpers/AssertNBMutualExclusiveParam.ps1` with this content:
+
+```powershell
+function AssertNBMutualExclusiveParam {
+    <#
+    .SYNOPSIS
+        Throws when two or more of the named parameters are present in a bound-parameters dictionary.
+
+    .DESCRIPTION
+        Internal helper used to enforce mutual exclusion between cmdlet parameters
+        at runtime. Throws a terminating ParameterBindingException that names the
+        conflicting parameters.
+
+    .PARAMETER BoundParameters
+        The $PSBoundParameters dictionary from the calling cmdlet, or any
+        IDictionary that maps parameter names to values.
+
+    .PARAMETER Parameters
+        The list of parameter names that are mutually exclusive. At least two
+        must be provided; typically 2-5 in practice.
+
+    .PARAMETER HelpHint
+        Optional text appended to the exception message (e.g. a pointer to docs).
+
+    .EXAMPLE
+        AssertNBMutualExclusiveParam -BoundParameters $PSBoundParameters -Parameters 'Brief','Fields','Omit'
+    #>
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory)]
+        [System.Collections.IDictionary]$BoundParameters,
+
+        [Parameter(Mandatory)]
+        [ValidateCount(2, 10)]
+        [string[]]$Parameters,
+
+        [string]$HelpHint
+    )
+
+    $supplied = $Parameters | Where-Object { $BoundParameters.ContainsKey($_) }
+    if ($supplied.Count -gt 1) {
+        $joined = '-' + ($supplied -join ', -')
+        $message = "Parameters $joined are mutually exclusive. Specify only one."
+        if ($HelpHint) { $message += " $HelpHint" }
+        throw [System.Management.Automation.ParameterBindingException]::new($message)
+    }
+}
+```
+
+- [ ] **Step 4: Rebuild the module**
+
+```bash
+./deploy.ps1 -Environment dev -SkipVersion
+```
+
+Expected: the build output list includes `Functions/Helpers/AssertNBMutualExclusiveParam.ps1` (or the helper count increases by 1).
+
+- [ ] **Step 5: Run the tests — verify they pass**
+
+```bash
+pwsh -NoProfile -Command "Invoke-Pester ./Tests/Helpers.Tests.ps1 -Output Detailed -FullNameFilter '*AssertNBMutualExclusiveParam*'"
+```
+
+Expected: **all 10 new tests pass**.
+
+- [ ] **Step 6: Run the full Helpers test suite (regression check)**
+
+```bash
+pwsh -NoProfile -Command "Invoke-Pester ./Tests/Helpers.Tests.ps1 -Output Detailed"
+```
+
+Expected: all tests pass, including the pre-existing ones from Task 1 Step 3. Zero failures.
+
+- [ ] **Step 7: Restore build artifact, stage, commit**
+
+```bash
+git checkout -- PowerNetbox.psd1 2>/dev/null
+git add Functions/Helpers/AssertNBMutualExclusiveParam.ps1 Tests/Helpers.Tests.ps1
+git status --short
+```
+
+Expected `git status` output: only the two files added, no unexpected modifications.
+
+```bash
+git commit -m "$(cat <<'EOF'
+feat: add AssertNBMutualExclusiveParam helper
+
+Internal helper that throws ParameterBindingException when two or
+more of a named parameter list are present in a bound-parameters
+dictionary. Consumed by Get functions to enforce that -Brief,
+-Fields, and -Omit are mutually exclusive (see spec).
+
+Adds 10 unit tests in Tests/Helpers.Tests.ps1.
+EOF
+)"
+```
+
+---
+
+## Task 3: Apply assertion to `Get-NBIPAMAddress` (standard pilot)
+
+**Files:**
+- Modify: `Functions/IPAM/Address/Get-NBIPAMAddress.ps1:121-123` (insert one call)
+- Modify: `Tests/IPAM.Tests.ps1` (append 4 tests to `Context "Get-NBIPAMAddress"`)
+
+- [ ] **Step 1: Write the failing tests**
+
+Open `Tests/IPAM.Tests.ps1`. Find the `Context "Get-NBIPAMAddress" {` block (line 44). Inside that block, before its closing `}`, append:
+
+```powershell
+Context "Brief/Fields/Omit mutual exclusion" {
+    It "Throws when -Brief and -Fields are both specified" {
+        { Get-NBIPAMAddress -Brief -Fields 'id' } |
+            Should -Throw -ExceptionType ([System.Management.Automation.ParameterBindingException])
+    }
+
+    It "Throws when -Brief and -Omit are both specified" {
+        { Get-NBIPAMAddress -Brief -Omit 'comments' } |
+            Should -Throw -ExceptionType ([System.Management.Automation.ParameterBindingException])
+    }
+
+    It "Throws when -Fields and -Omit are both specified" {
+        { Get-NBIPAMAddress -Fields 'id' -Omit 'comments' } |
+            Should -Throw -ExceptionType ([System.Management.Automation.ParameterBindingException])
+    }
+
+    It "Does not throw when -Brief is specified alone (control)" {
+        $Result = Get-NBIPAMAddress -Brief
+        $Result.Method | Should -Be 'GET'
+        $Result.Uri | Should -Match 'brief=True'
+    }
+}
+```
+
+- [ ] **Step 2: Build, run tests — verify the three throw-tests fail**
+
+```bash
+./deploy.ps1 -Environment dev -SkipVersion
+pwsh -NoProfile -Command "Invoke-Pester ./Tests/IPAM.Tests.ps1 -Output Detailed -FullNameFilter '*Brief/Fields/Omit mutual exclusion*'"
+```
+
+Expected: the 3 throw-tests fail (the function accepts combinations silently today); the 1 control test passes.
+
+- [ ] **Step 3: Add the assertion call to `Get-NBIPAMAddress`**
+
+Open `Functions/IPAM/Address/Get-NBIPAMAddress.ps1`. Locate the `process {` block at line 121. Change it from:
+
+```powershell
+    process {
+        Write-Verbose "Retrieving IPAM Address"
+        switch ($PSCmdlet.ParameterSetName) {
+```
+
+…to:
+
+```powershell
+    process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
+
+        Write-Verbose "Retrieving IPAM Address"
+        switch ($PSCmdlet.ParameterSetName) {
+```
+
+- [ ] **Step 4: Rebuild the module**
+
+```bash
+./deploy.ps1 -Environment dev -SkipVersion
+```
+
+- [ ] **Step 5: Run tests — verify all 4 pass**
+
+```bash
+pwsh -NoProfile -Command "Invoke-Pester ./Tests/IPAM.Tests.ps1 -Output Detailed -FullNameFilter '*Brief/Fields/Omit mutual exclusion*'"
+```
+
+Expected: all 4 new tests pass.
+
+- [ ] **Step 6: Run the full IPAM test file (regression check)**
+
+```bash
+pwsh -NoProfile -Command "Invoke-Pester ./Tests/IPAM.Tests.ps1 -Output Detailed"
+```
+
+Expected: zero failures. Pre-existing IPAM tests continue to pass.
+
+- [ ] **Step 7: Restore build artifact, stage, commit**
+
+```bash
+git checkout -- PowerNetbox.psd1 2>/dev/null
+git add Functions/IPAM/Address/Get-NBIPAMAddress.ps1 Tests/IPAM.Tests.ps1
+git status --short
+git commit -m "$(cat <<'EOF'
+feat: enforce Brief/Fields/Omit mutual exclusion on Get-NBIPAMAddress
+
+First standard-pattern pilot for the helper introduced in the
+previous commit. Adds 4 integration tests.
+EOF
+)"
+```
+
+---
+
+## Task 4: Apply assertion to `Get-NBVPNTunnel` (standard pilot)
+
+**Files:**
+- Modify: `Functions/VPN/Tunnel/Get-NBVPNTunnel.ps1:66-68`
+- Modify: `Tests/VPN.Tests.ps1` (append 4 tests to `Context "Get-NBVPNTunnel"`)
+
+- [ ] **Step 1: Write the failing tests**
+
+Open `Tests/VPN.Tests.ps1`. Find the `Context "Get-NBVPNTunnel" {` block (line 41). Inside that block, before its closing `}`, append:
+
+```powershell
+Context "Brief/Fields/Omit mutual exclusion" {
+    It "Throws when -Brief and -Fields are both specified" {
+        { Get-NBVPNTunnel -Brief -Fields 'id' } |
+            Should -Throw -ExceptionType ([System.Management.Automation.ParameterBindingException])
+    }
+
+    It "Throws when -Brief and -Omit are both specified" {
+        { Get-NBVPNTunnel -Brief -Omit 'comments' } |
+            Should -Throw -ExceptionType ([System.Management.Automation.ParameterBindingException])
+    }
+
+    It "Throws when -Fields and -Omit are both specified" {
+        { Get-NBVPNTunnel -Fields 'id' -Omit 'comments' } |
+            Should -Throw -ExceptionType ([System.Management.Automation.ParameterBindingException])
+    }
+
+    It "Does not throw when -Brief is specified alone (control)" {
+        $Result = Get-NBVPNTunnel -Brief
+        $Result.Method | Should -Be 'GET'
+        $Result.Uri | Should -Match 'brief=True'
+    }
+}
+```
+
+- [ ] **Step 2: Build, run tests — verify the three throw-tests fail**
+
+```bash
+./deploy.ps1 -Environment dev -SkipVersion
+pwsh -NoProfile -Command "Invoke-Pester ./Tests/VPN.Tests.ps1 -Output Detailed -FullNameFilter '*Brief/Fields/Omit mutual exclusion*'"
+```
+
+Expected: 3 fail, 1 pass.
+
+- [ ] **Step 3: Add the assertion call to `Get-NBVPNTunnel`**
+
+Open `Functions/VPN/Tunnel/Get-NBVPNTunnel.ps1`. Locate the `process {` block at line 66. Change from:
+
+```powershell
+    process {
+        Write-Verbose "Retrieving VPN Tunnel"
+        switch ($PSCmdlet.ParameterSetName) {
+```
+
+…to:
+
+```powershell
+    process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
+
+        Write-Verbose "Retrieving VPN Tunnel"
+        switch ($PSCmdlet.ParameterSetName) {
+```
+
+- [ ] **Step 4: Rebuild and run tests — verify all 4 pass**
+
+```bash
+./deploy.ps1 -Environment dev -SkipVersion
+pwsh -NoProfile -Command "Invoke-Pester ./Tests/VPN.Tests.ps1 -Output Detailed -FullNameFilter '*Brief/Fields/Omit mutual exclusion*'"
+```
+
+Expected: all 4 new tests pass.
+
+- [ ] **Step 5: Run the full VPN test file (regression check)**
+
+```bash
+pwsh -NoProfile -Command "Invoke-Pester ./Tests/VPN.Tests.ps1 -Output Detailed"
+```
+
+Expected: zero failures.
+
+- [ ] **Step 6: Restore build artifact, stage, commit**
+
+```bash
+git checkout -- PowerNetbox.psd1 2>/dev/null
+git add Functions/VPN/Tunnel/Get-NBVPNTunnel.ps1 Tests/VPN.Tests.ps1
+git status --short
+git commit -m "$(cat <<'EOF'
+feat: enforce Brief/Fields/Omit mutual exclusion on Get-NBVPNTunnel
+
+Second standard-pattern pilot. Adds 4 integration tests.
+EOF
+)"
+```
+
+---
+
+## Task 5: Apply assertion to `Get-NBDCIMDevice` (special case with `IncludeConfigContext`)
+
+**Files:**
+- Modify: `Functions/DCIM/Devices/Get-NBDCIMDevice.ps1:193-203` (insert call, guard auto-omit)
+- Modify: `Tests/DCIM.Devices.Tests.ps1` (append mutex-exclusion and special-case tests to `Context "Get-NBDCIMDevice"`)
+
+- [ ] **Step 1: Write the failing tests**
+
+Open `Tests/DCIM.Devices.Tests.ps1`. Find the `Context "Get-NBDCIMDevice" {` block (line 39). Inside that block, before its closing `}`, append:
+
+```powershell
+Context "Brief/Fields/Omit mutual exclusion" {
+    It "Throws when -Brief and -Fields are both specified" {
+        { Get-NBDCIMDevice -Brief -Fields 'id' } |
+            Should -Throw -ExceptionType ([System.Management.Automation.ParameterBindingException])
+    }
+
+    It "Throws when -Brief and -Omit are both specified" {
+        { Get-NBDCIMDevice -Brief -Omit 'comments' } |
+            Should -Throw -ExceptionType ([System.Management.Automation.ParameterBindingException])
+    }
+
+    It "Throws when -Fields and -Omit are both specified" {
+        { Get-NBDCIMDevice -Fields 'id' -Omit 'comments' } |
+            Should -Throw -ExceptionType ([System.Management.Automation.ParameterBindingException])
+    }
+
+    It "Does not throw when -Brief is specified alone (control)" {
+        $Result = Get-NBDCIMDevice -Brief
+        $Result.Method | Should -Be 'GET'
+        $Result.Uri | Should -Match 'brief=True'
+    }
+}
+
+Context "Brief/Fields/Omit interaction with IncludeConfigContext" {
+    It "With -Brief: URI contains brief=True and no config_context omit" {
+        $Result = Get-NBDCIMDevice -Brief
+        $Result.Uri | Should -Match 'brief=True'
+        $Result.Uri | Should -Not -Match 'omit=config_context'
+    }
+
+    It "With -Fields: URI contains the fields parameter and no config_context omit" {
+        $Result = Get-NBDCIMDevice -Fields 'id', 'name'
+        # Match 'fields=' separately from each value name — commas between
+        # values may be URL-encoded as %2C on some platforms but the field
+        # names themselves will appear literally.
+        $Result.Uri | Should -Match 'fields='
+        $Result.Uri | Should -Match 'id'
+        $Result.Uri | Should -Match 'name'
+        $Result.Uri | Should -Not -Match 'omit=config_context'
+    }
+
+    It "With -Omit: URI contains the user's omit value merged with config_context" {
+        $Result = Get-NBDCIMDevice -Omit 'comments'
+        $Result.Uri | Should -Match 'omit='
+        $Result.Uri | Should -Match 'comments'
+        $Result.Uri | Should -Match 'config_context'
+    }
+
+    It "With -IncludeConfigContext -Brief: URI contains brief=True only (IncludeConfigContext silently ignored)" {
+        $Result = Get-NBDCIMDevice -IncludeConfigContext -Brief
+        $Result.Uri | Should -Match 'brief=True'
+        $Result.Uri | Should -Not -Match 'config_context'
+    }
+
+    It "With no projection flags: URI contains the default config_context auto-omit" {
+        $Result = Get-NBDCIMDevice
+        $Result.Uri | Should -Match 'omit=config_context'
+    }
+}
+```
+
+- [ ] **Step 2: Build, run tests — verify the mutex tests + at least two special-case tests fail**
+
+```bash
+./deploy.ps1 -Environment dev -SkipVersion
+pwsh -NoProfile -Command "Invoke-Pester ./Tests/DCIM.Devices.Tests.ps1 -Output Detailed -FullNameFilter '*Brief/Fields/Omit*'"
+```
+
+Expected failures:
+- All 3 throw-tests fail (current function accepts combinations silently).
+- "With -Brief: URI contains brief=True and no config_context omit" fails (current code always appends `omit=config_context` unless `-IncludeConfigContext`, so the URI contains both).
+- "With -Fields: URI contains fields= and no config_context omit" fails for the same reason.
+
+Expected passes (before the fix):
+- The `-Omit 'comments'` case (merge behavior already correct).
+- The `-IncludeConfigContext -Brief` case (already produces `brief=True` with no config_context, because `IncludeConfigContext` suppresses the auto-omit).
+- The no-flags case (`omit=config_context` already present).
+
+Record exactly which tests fail — the fix should turn these from FAIL to PASS without affecting the already-passing ones.
+
+- [ ] **Step 3: Edit `Get-NBDCIMDevice.ps1`**
+
+Open `Functions/DCIM/Devices/Get-NBDCIMDevice.ps1`. Locate the `process {` block at line 193. Currently:
+
+```powershell
+    process {
+        Write-Verbose "Retrieving DCIM Device"
+
+        # Build omit list: add config_context unless explicitly included
+        $omitFields = @()
+        if ($PSBoundParameters.ContainsKey('Omit')) {
+            $omitFields += $Omit
+        }
+        if (-not $IncludeConfigContext) {
+            $omitFields += 'config_context'
+        }
+```
+
+Replace that block with:
+
+```powershell
+    process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
+
+        Write-Verbose "Retrieving DCIM Device"
+
+        # Auto-omit config_context only when the user has not otherwise
+        # restricted the projection. -Brief returns a minimal representation
+        # (config_context is never included). -Fields explicitly selects the
+        # returned shape, so the user owns that choice.
+        $inProjectionMode = $PSBoundParameters.ContainsKey('Brief') -or
+                            $PSBoundParameters.ContainsKey('Fields')
+
+        $omitFields = @()
+        if ($PSBoundParameters.ContainsKey('Omit')) {
+            $omitFields += $Omit
+        }
+        if (-not $IncludeConfigContext -and -not $inProjectionMode) {
+            $omitFields += 'config_context'
+        }
+```
+
+Leave the rest of the function body (the `switch ($PSCmdlet.ParameterSetName)` block and below) unchanged.
+
+- [ ] **Step 4: Rebuild and run the new tests**
+
+```bash
+./deploy.ps1 -Environment dev -SkipVersion
+pwsh -NoProfile -Command "Invoke-Pester ./Tests/DCIM.Devices.Tests.ps1 -Output Detailed -FullNameFilter '*Brief/Fields/Omit*'"
+```
+
+Expected: all 9 new tests pass (4 mutex + 5 interaction).
+
+- [ ] **Step 5: Run the full DCIM.Devices test file (regression check)**
+
+```bash
+pwsh -NoProfile -Command "Invoke-Pester ./Tests/DCIM.Devices.Tests.ps1 -Output Detailed"
+```
+
+Expected: zero failures. Pre-existing tests (e.g., "Should request the default number of devices" which checks for `omit=config_context`) continue to pass because the default path is unchanged.
+
+- [ ] **Step 6: Restore build artifact, stage, commit**
+
+```bash
+git checkout -- PowerNetbox.psd1 2>/dev/null
+git add Functions/DCIM/Devices/Get-NBDCIMDevice.ps1 Tests/DCIM.Devices.Tests.ps1
+git status --short
+git commit -m "$(cat <<'EOF'
+feat: enforce Brief/Fields/Omit mutual exclusion on Get-NBDCIMDevice
+
+Third pilot, covering the IncludeConfigContext special case. The
+auto-omit of config_context is now guarded: it only fires when the
+user has not specified -Brief or -Fields (in which case the server
+already controls the response shape).
+
+Adds 4 mutex-exclusion tests + 5 interaction tests covering the full
+behavior matrix from the spec.
+EOF
+)"
+```
+
+---
+
+## Task 6: Full regression check
+
+**Files:** none (read-only)
+
+- [ ] **Step 1: Run the full Pester unit test suite**
+
+```bash
+./deploy.ps1 -Environment dev -SkipVersion
+pwsh -NoProfile -Command "Invoke-Pester ./Tests/ -ExcludeTagFilter Integration -Output Detailed"
+```
+
+Expected output: pass count equals the baseline from Task 1 plus the new tests added in Tasks 2–5 (10 + 4 + 4 + 9 = 27 new tests). Zero failures.
+
+- [ ] **Step 2: Run PSScriptAnalyzer (catches lint issues before CI does)**
+
+```bash
+pwsh -NoProfile -Command "Invoke-ScriptAnalyzer -Path . -Recurse -Severity Error,Warning -ExcludeRule PSUseDeclaredVarsMoreThanAssignments"
+```
+
+Expected: zero new findings on the files changed in this branch. Ignore pre-existing findings on files you didn't touch.
+
+- [ ] **Step 3: Confirm build artifact is not staged**
+
+```bash
+git status --short
+git log --oneline origin/dev..HEAD
+```
+
+Expected commits on the branch (top to bottom, newest first):
+1. `feat: enforce Brief/Fields/Omit mutual exclusion on Get-NBDCIMDevice`
+2. `feat: enforce Brief/Fields/Omit mutual exclusion on Get-NBVPNTunnel`
+3. `feat: enforce Brief/Fields/Omit mutual exclusion on Get-NBIPAMAddress`
+4. `feat: add AssertNBMutualExclusiveParam helper`
+5. `docs: design spec for Brief/Fields/Omit mutual exclusion`
+
+`git status` should be clean (no unstaged changes).
+
+- [ ] **Step 4: Push the branch**
+
+```bash
+git push -u origin fix/silent-filter-combination
+```
+
+---
+
+## Task 7: Open PR-1
+
+**Files:** none (GitHub)
+
+- [ ] **Step 1: Create the pull request**
+
+```bash
+gh pr create --base dev --title "fix: enforce mutual exclusion between -Brief, -Fields, -Omit (PR-1: helper + 3 pilots)" --body "$(cat <<'EOF'
+## Summary
+
+Implements PR-1 of the two-phase rollout described in `docs/superpowers/specs/2026-04-16-filter-exclusion-design.md`.
+
+- Adds internal helper `AssertNBMutualExclusiveParam` (`Functions/Helpers/`) with 10 unit tests.
+- Applies it to 3 pilot Get functions: `Get-NBDCIMDevice`, `Get-NBIPAMAddress`, `Get-NBVPNTunnel`.
+- Guards the `config_context` auto-omit in `Get-NBDCIMDevice` so it only fires when the user hasn't otherwise restricted the projection (via `-Brief` or `-Fields`).
+- Adds 17 integration + interaction tests.
+
+## Why
+
+Today, supplying `-Brief` with `-Fields` or `-Omit` silently passes all three to Netbox, which applies undefined precedence (brief typically wins). Scripts that combine these flags get the result of one and ignore the others — a silent-surprise class of bug that Gemini has flagged three times in code review.
+
+This PR introduces the mechanism and validates it on three representative functions. PR-2 (tracked separately) will roll it out to the remaining 121 Get functions and add a CI auditor.
+
+## Test plan
+
+- [ ] CI passes on all platforms (PS 5.1, PS 7)
+- [ ] PSScriptAnalyzer no new findings
+- [ ] Full Pester unit suite green
+- [ ] Manual smoke test against a live Netbox: `Get-NBDCIMDevice -Brief -Fields 'id'` throws with a clear message
+- [ ] Manual smoke test: `Get-NBDCIMDevice -Brief` returns devices without `config_context` in the response and without `omit=config_context` in the URI
+
+## Spec
+
+See `docs/superpowers/specs/2026-04-16-filter-exclusion-design.md` (included in this branch as the first commit).
+
+## Follow-up
+
+PR-2 will add `scripts/Verify-FilterExclusion.ps1` CI auditor and apply the helper to 121 remaining Get functions (including `Get-NBVirtualMachine` with its matching `IncludeConfigContext` logic and 5 parallel interaction tests).
+EOF
+)"
+```
+
+- [ ] **Step 2: Record the PR number**
+
+Capture the URL output by `gh pr create` for reference when PR-2 is drafted (PR-2's description will link back to PR-1).

--- a/docs/superpowers/specs/2026-04-16-filter-exclusion-design.md
+++ b/docs/superpowers/specs/2026-04-16-filter-exclusion-design.md
@@ -1,0 +1,304 @@
+---
+title: Brief / Fields / Omit Mutual Exclusion
+status: approved
+date: 2026-04-16
+tracking_issue: to be created post-approval
+prs:
+  - PR-1 — helper + pilot
+  - PR-2 — rollout + auditor
+---
+
+# Brief / Fields / Omit Mutual Exclusion — Design
+
+## Problem
+
+PowerNetbox's 124 `Get-NB*` functions each expose three independent projection parameters:
+
+- `-Brief` — request a minimal representation (`?brief=True`)
+- `-Fields` — specify which fields to return (`?fields=a,b,c`)
+- `-Omit` — exclude specific fields (`?omit=x,y`)
+
+Today these can be combined in any way. `BuildURIComponents` writes each into the query string independently without cross-validation. Netbox applies them with undefined precedence (empirically `brief` wins over the others, `fields` and `omit` interact by set difference). Scripts that pass two of these flags get the result of one and silently ignore the other.
+
+This is the "silent surprise" class of bug: the call works, but the caller's intent does not map to the response.
+
+Gemini flagged the pattern in reviews three times across 2026; it has been on the future-refactoring list per project memory. This spec formalises the fix.
+
+## Decision Summary
+
+| Question | Choice |
+|---|---|
+| Which combinations are forbidden? | **All three are mutually exclusive (A)**. `-Brief` XOR `-Fields` XOR `-Omit`. |
+| Validation mechanism? | **Runtime helper with terminating error (Option 2)**. No new ParameterSets. |
+| Rollout | **Two-phase**. PR-1: helper + 3 pilots. PR-2: auditor + remaining 121 functions + docs. |
+| Version impact | Minor bump (`v4.5.7.0` → `v4.5.8.0`). Breaking in error surface, not in successful behavior. |
+
+Rejected alternatives:
+
+- **Option A vs B (Fields+Omit allowed)**: rejected because the `fields - omit` intersection is exotic, users better served by picking one filter strategy, and Netbox's own documentation formulates the three as alternatives ("use X or Y").
+- **ParameterSets (Option 1)**: rejected because the cartesian product of ByID/Query × Default/Brief/Fields/Omit requires 8 sets per function and ~992 additional `[Parameter(ParameterSetName=...)]` attributes on query filter params, with a cryptic built-in error message ("Parameter set cannot be resolved using the specified named parameters").
+- **Warn-don't-error (Option C)**: rejected because the silent-surprise bug persists if we only warn.
+
+## Architecture
+
+Single validation pass executes before URI construction. One helper function, one call site per Get function:
+
+```
+User invocation
+   │
+   ▼
+process { }
+   │
+   ├── AssertNBMutualExclusiveParam -BoundParameters $PSBoundParameters \
+   │                                -Parameters 'Brief','Fields','Omit'
+   │       ◆ throws ParameterBindingException if ≥2 supplied
+   │
+   ├── (existing) Build Segments, BuildURIComponents, BuildNewURI
+   │
+   └── InvokeNetboxRequest
+```
+
+The helper is **pure** (no I/O, no module state) and therefore unit-testable in isolation.
+
+## Components
+
+### 1. `AssertNBMutualExclusiveParam` helper
+
+**Location:** `PowerNetbox/Functions/Helpers/AssertNBMutualExclusiveParam.ps1`
+**Export policy:** Internal. No hyphen in name, consistent with `BuildURIComponents`, `BuildNewURI`, `InvokeNetboxRequest`, `GetNetboxAPIErrorBody`. Not exported in production build (`deploy.ps1 -Environment prod` filters by hyphenated names).
+**Error behavior:** Terminating — `throw [System.Management.Automation.ParameterBindingException]`.
+
+```powershell
+function AssertNBMutualExclusiveParam {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory)]
+        [System.Collections.IDictionary]$BoundParameters,
+
+        [Parameter(Mandatory)]
+        [ValidateCount(2, 10)]
+        [string[]]$Parameters,
+
+        [string]$HelpHint
+    )
+
+    $supplied = $Parameters | Where-Object { $BoundParameters.ContainsKey($_) }
+    if ($supplied.Count -gt 1) {
+        $joined = '-' + ($supplied -join ', -')
+        $message = "Parameters $joined are mutually exclusive. Specify only one."
+        if ($HelpHint) { $message += " $HelpHint" }
+        throw [System.Management.Automation.ParameterBindingException]::new($message)
+    }
+}
+```
+
+**Design notes:**
+
+- `[System.Collections.IDictionary]` accepts both `$PSBoundParameters` (a `Dictionary<string,object>`) and plain `Hashtable` — enables clean unit testing without mocking the cmdlet runtime.
+- `[ValidateCount(2, 10)]` rejects nonsensical usage (0 or 1 parameter to check). Upper bound of 10 is generous; current use case is 3.
+- `ParameterBindingException` is the semantically correct exception type — the defect is conceptually a parameter-binding issue, even if raised at runtime.
+- `HelpHint` is optional and appended to the message. Leaves room for per-call-site guidance (e.g., "See Get-Help for -IncludeConfigContext").
+
+### 2. Call-site pattern (standard Get function)
+
+One-line insertion at the top of `process { }`, before `Write-Verbose`:
+
+```powershell
+process {
+    AssertNBMutualExclusiveParam `
+        -BoundParameters $PSBoundParameters `
+        -Parameters 'Brief', 'Fields', 'Omit'
+
+    Write-Verbose "Retrieving ..."
+    switch ($PSCmdlet.ParameterSetName) { ... }
+}
+```
+
+**Why `process {}` and not `begin {}`:** In `begin {}`, `$PSBoundParameters` contains only non-pipeline-bound parameters. Pipeline-bound `-Id` from `ValueFromPipelineByPropertyName` arrives per-object in `process {}`. Placing the assertion in `process {}` keeps its view consistent with how the rest of the function uses `$PSBoundParameters`.
+
+**Scope:** 122 of 124 Get functions follow this pattern exactly. The remaining 2 (`Get-NBDCIMDevice`, `Get-NBVirtualMachine`) have special `IncludeConfigContext` handling — see §3.
+
+Functions **without** `Brief`/`Fields`/`Omit` are left untouched:
+- `Get-NBDCIMRackElevation`, `Get-NBDCIMConnectedDevice`, `Get-NBIPAMAvailableIP` — PR #343 already removed these parameters as inapplicable.
+
+### 3. Special case: `IncludeConfigContext` interaction
+
+`Get-NBDCIMDevice` and `Get-NBVirtualMachine` inject `config_context` into the `omit` list by default (performance optimisation — config_context rendering is 10-100× slower). The user opts in with `-IncludeConfigContext`.
+
+With Option A (mutual exclusion), the auto-omit logic becomes conditional on not being in Brief or Fields mode:
+
+```powershell
+process {
+    AssertNBMutualExclusiveParam `
+        -BoundParameters $PSBoundParameters `
+        -Parameters 'Brief', 'Fields', 'Omit'
+
+    $inProjectionMode = $PSBoundParameters.ContainsKey('Brief') -or
+                        $PSBoundParameters.ContainsKey('Fields')
+
+    $omitFields = @()
+    if ($PSBoundParameters.ContainsKey('Omit')) {
+        $omitFields += $Omit
+    }
+    # Auto-omit config_context only when the user has not otherwise restricted
+    # the projection. Brief returns minimal representations (config_context never
+    # included). Fields explicitly selects what to return (user owns that choice).
+    if (-not $IncludeConfigContext -and -not $inProjectionMode) {
+        $omitFields += 'config_context'
+    }
+    # ... rest unchanged
+}
+```
+
+**Behavior matrix:**
+
+| User invocation | Query sent to Netbox | Rationale |
+|---|---|---|
+| `-Brief` | `?brief=True` | Minimal already; auto-omit unnecessary. |
+| `-Fields id,name` | `?fields=id,name` | User-selected projection owns the result shape. |
+| `-Omit comments` | `?omit=comments,config_context` | Merge user omit with performance default. |
+| (no flags) | `?omit=config_context` | Default performance optimisation. |
+| `-IncludeConfigContext` | (no omit) | Explicit opt-in. |
+| `-IncludeConfigContext -Brief` | `?brief=True` | IncludeConfigContext is silently ignored (no-op in Brief mode). |
+| `-Brief -Fields X` | — | **Throws `ParameterBindingException`**. |
+
+**`IncludeConfigContext + Brief` silent no-op:** Decided during brainstorming. Alternative was `Write-Warning`. Chose silent because the switch has a well-defined semantic ("return config_context when it would otherwise be omitted") that is simply vacuous in Brief mode — no user action is wrong, nothing is worth logging.
+
+### 4. Auditor script (PR-2)
+
+**Location:** `PowerNetbox/scripts/Verify-FilterExclusion.ps1`
+**Pattern:** Mirrors `Verify-ValidateSetParity.ps1` (PR #391). Same output format options, same CI-gating approach, same exemptions file convention.
+
+**Algorithm:**
+
+1. Glob `Functions/**/Get-NB*.ps1`.
+2. Parse each file with `[System.Management.Automation.Language.Parser]::ParseFile(...)`.
+3. For each `FunctionDefinitionAst`:
+   a. Collect declared parameter names from `ParamBlockAst.Parameters`.
+   b. If the set `{Brief, Fields, Omit}` is not a subset, skip (function doesn't need the assertion).
+   c. Find all `CommandAst` nodes inside the function body. Check for a `CommandAst` whose `CommandElements[0]` is `AssertNBMutualExclusiveParam` and whose arguments include `-Parameters 'Brief','Fields','Omit'`.
+   d. If not found, emit a finding.
+4. Output:
+   - Default: human-readable table (`File`, `Function`, `Status`).
+   - `-OutputFormat Json`: machine-readable for CI consumption.
+   - `-FailOnMismatch`: exit code ≠ 0 if any findings.
+5. Exemptions file (`scripts/filter-exclusion-exemptions.txt`) for edge cases that the AST filter doesn't catch.
+
+**CI integration:** New job in `.github/workflows/test.yml`, parallel to PSScriptAnalyzer. Fails the build when a new Get function lands without the assertion.
+
+**Why AST over regex:** AST parsing correctly handles commented-out calls (`# AssertNBMutualExclusiveParam ...`), mistyped parameter lists (`-Parameters 'Brief','Wrong'`), and multi-line formatting. A regex would produce false positives on the first and false negatives on the second and third.
+
+### 5. Test strategy
+
+**5a. Unit tests for the helper** — `PowerNetbox/Tests/Unit/AssertNBMutualExclusiveParam.Tests.ps1` (~10 tests):
+
+- Zero parameters from the list in `$BoundParameters` → no throw.
+- Exactly one parameter from the list → no throw.
+- Two parameters → throws `ParameterBindingException`; message contains both names prefixed with `-`.
+- Three parameters → throws; message lists all three.
+- `$HelpHint` is appended to the message when supplied.
+- `ValidateCount(2, 10)` rejects calls with < 2 parameters.
+- Case-sensitive name matching (`'Brief'` ≠ `'brief'`), consistent with `$PSBoundParameters` semantics.
+- Accepts both `System.Collections.Generic.Dictionary[string,object]` and `Hashtable` for `$BoundParameters`.
+- Empty/`$null` `$BoundParameters` → no throw.
+- Exception is `ParameterBindingException`, not `ArgumentException` or generic `Exception`.
+
+**5b. Pilot integration tests** — extended into existing test files for the 3 pilots (4 scenarios × 3 pilots = 12 tests):
+
+For each of `Get-NBDCIMDevice`, `Get-NBIPAMAddress`, `Get-NBVPNTunnel`:
+
+- `-Brief -Fields 'id'` → throws `ParameterBindingException`.
+- `-Brief -Omit 'comments'` → throws.
+- `-Fields 'id' -Omit 'name'` → throws.
+- Control: `-Brief` alone → no throw, URI contains `brief=True`.
+
+**5c. Special-case tests** for the two functions with `IncludeConfigContext` (5 tests per function):
+
+In PR-1 — `Get-NBDCIMDevice` (part of the pilot set):
+
+- `-Brief` → URI `?brief=True`, no `config_context` in omit.
+- `-Fields id,name` → URI `?fields=id,name`, no `config_context` in omit.
+- `-Omit comments` → URI `?omit=comments,config_context` (merged).
+- `-IncludeConfigContext -Brief` → URI `?brief=True` (IncludeConfigContext silently ignored).
+- No flags → URI `?omit=config_context` (default behavior preserved).
+
+In PR-2 — `Get-NBVirtualMachine` (rolled out alongside the other 120 standard functions): same five scenarios, identical assertions.
+
+**Mock layer:** `InvokeNetboxRequest` mock, consistent with 17 of 24 existing test files. Assertion throws before reaching the mock, so throw-path tests do not need mock setup.
+
+**Total tests added:**
+- PR-1: ~27 new tests (10 helper unit + 12 pilot integration + 5 special-case for Device).
+- PR-2: ~5 new tests for VM special case + any regression tests the auditor surfaces.
+
+### 6. Documentation & migration
+
+**6a. `CLAUDE.md` "Recent Changes" section:**
+
+```markdown
+### v4.5.8.0 (date TBD)
+
+**Breaking change: Brief, Fields, and Omit are now mutually exclusive (#XXX, PR-1 #YYY, PR-2 #ZZZ)**
+
+- Previously, supplying `-Brief` with `-Fields` or `-Omit` silently sent all three
+  to Netbox, which applied undefined precedence (brief typically won). The
+  silently-ignored flag(s) produced results that did not match caller intent.
+- Now throws `ParameterBindingException` with a message naming which parameters
+  conflict, e.g. `"Parameters -Brief, -Fields are mutually exclusive. Specify only one."`
+- Migration: pick one filter strategy per call.
+  - Minimal: `-Brief`
+  - Specific fields: `-Fields 'id','name','status'`
+  - Default minus specific fields: `-Omit 'comments','description'`
+- New internal helper: `AssertNBMutualExclusiveParam` (`Functions/Helpers/`).
+- New CI guard: `scripts/Verify-FilterExclusion.ps1` (fails build if a Get
+  function with Brief/Fields/Omit lacks the assertion).
+```
+
+**6b. Per-function help `.NOTES` block** — applied to all 124 functions via the PR-2 script:
+
+```powershell
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
+    Specify only one filter strategy per call.
+```
+
+**6c. PSGallery release notes:** one sentence linking to CHANGELOG.
+
+### 7. Phased rollout
+
+| Phase | PR | Deliverables | Size estimate | CI duration |
+|---|---|---|---|---|
+| 1 | PR-1 | Helper + 10 unit tests + 3 pilot functions (`Get-NBDCIMDevice`, `Get-NBIPAMAddress`, `Get-NBVPNTunnel`) + 12 pilot integration tests + 5 special-case tests for Device | ~300 prod + ~400 test | ~15 min |
+| 2 | PR-2 | 121 remaining functions (scripted, includes `Get-NBVirtualMachine` with its special case) + 5 special-case tests for VM + `Verify-FilterExclusion.ps1` auditor + CI integration + help-text updates + CHANGELOG | ~500 mechanical prod + ~300 auditor + ~60 CI config | ~15 min + auditor job |
+
+**Between PRs:** wait for PR-1 green CI + review; incorporate feedback on helper / pattern; PR-2 then is purely mechanical.
+
+**Release flow:** follows `CLAUDE.md` standard — merge `dev` → `main`, version bump in `.psd1`, `gh release create vX.Y.Z.W --target main`.
+
+## Out of scope
+
+- Migrating `-Fields` / `-Omit` to ParameterSets-based validation. Explicitly considered and rejected (§Decision Summary).
+- Tag-type unification for the 78 legacy Set/New functions (separate sub-project B3 in the refactor roadmap).
+- Centralised `InvokeNetboxGet` helper refactor (separate sub-project B2).
+- Changing behavior for the 3 functions that don't have Brief/Fields/Omit (RackElevation, ConnectedDevice, AvailableIP) — already correct per PR #343.
+- Soft-deprecation period (warn for N versions, then error). Explicitly rejected: the current state already produces broken scripts, erroring immediately is more informative.
+
+## Risks
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| Downstream scripts rely on the silently-ignored behavior | Low-Medium | CHANGELOG is explicit about the breaking-ness; error message tells the user exactly what to remove. |
+| Auditor script flags false positives | Low | AST-based parsing, exemption file for edge cases, mirrors proven `Verify-ValidateSetParity.ps1` approach. |
+| Pilot functions' IncludeConfigContext edge case is implemented differently from standard pattern | Medium | Explicit §3 section in the spec. Test coverage for all 5 behavior-matrix rows. |
+| `$PSBoundParameters` not populated as expected with pipeline input | Low | Call site is `process {}` not `begin {}`; tests include pipeline scenarios. |
+| Rollout PR-2 merge conflicts with unrelated dev work | Medium | Script-driven application makes conflicts mechanical to resolve. Run rollout after any in-flight PRs merge. |
+
+## Open questions
+
+None at spec approval. All captured decisions are final pending user review.
+
+## References
+
+- Source files: `PowerNetbox/Functions/Helpers/BuildURIComponents.ps1`, `PowerNetbox/Functions/DCIM/Devices/Get-NBDCIMDevice.ps1`, `PowerNetbox/Functions/Virtualization/VirtualMachine/Get-NBVirtualMachine.ps1`.
+- Related PRs: #297 (All/PageSize passthrough), #298 (Query/ByID parameter sets standardised), #343 (removed inapplicable Brief/Fields/Omit), #391 (`Verify-ValidateSetParity.ps1` — pattern reference for auditor).
+- Netbox best practices: `netbox-best-practices/HUMAN.md:17,66-67` (formulates Brief/Fields/Omit as alternatives).
+- Project memory: repeated Gemini review suggestions on Brief/Fields/Omit mutual exclusivity.


### PR DESCRIPTION
## Summary

Implements PR-1 of the two-phase rollout described in [`docs/superpowers/specs/2026-04-16-filter-exclusion-design.md`](docs/superpowers/specs/2026-04-16-filter-exclusion-design.md).

- Adds internal helper `AssertNBMutualExclusiveParam` (`Functions/Helpers/`) with 10 unit tests.
- Applies it to 3 pilot Get functions: `Get-NBDCIMDevice`, `Get-NBIPAMAddress`, `Get-NBVPNTunnel`.
- Guards the `config_context` auto-omit in `Get-NBDCIMDevice` so it only fires when the user hasn't otherwise restricted the projection (via `-Brief` or `-Fields`).
- Adds 17 integration + interaction tests; removes 1 pre-existing test that encoded the pre-fix bug behavior.

## Why

Today, supplying `-Brief` with `-Fields` or `-Omit` silently passes all three to Netbox, which applies undefined precedence (brief typically wins). Scripts that combine these flags get the result of one and silently ignore the others — a silent-surprise class of bug that Gemini has flagged three times in code review.

This PR introduces the mechanism and validates it on three representative functions. PR-2 (tracked separately) will roll it out to the remaining 121 Get functions and add a CI auditor.

## Design decisions

- **Option A** (all three mutually exclusive): `-Brief` XOR `-Fields` XOR `-Omit`. Rejected the "Brief-only isolation" alternative because the `fields − omit` intersection is exotic and NetBox docs consistently frame the three as alternatives.
- **Option 2** (runtime helper, terminating error): rejected ParameterSets because the cartesian product of `ByID`/`Query` × `Default`/`Brief`/`Fields`/`Omit` would add 8 sets per function and ~992 attribute declarations across query filter params, with a cryptic built-in error message.
- **Two-phase rollout**: helper + 3 pilots in this PR, then 121 remaining functions + auditor in PR-2.

## Behavior change

Previously:
```powershell
Get-NBDCIMDevice -Brief -Fields 'id','name'
# Silently sent all three to Netbox; brief won; Fields was ignored.
```

Now:
```powershell
Get-NBDCIMDevice -Brief -Fields 'id','name'
# Throws ParameterBindingException:
# "Parameters -Brief, -Fields are mutually exclusive. Specify only one."
```

Migration: pick one filter strategy per call (`-Brief`, `-Fields`, or `-Omit`).

## `IncludeConfigContext` special case

`Get-NBDCIMDevice` (and `Get-NBVirtualMachine` in PR-2) auto-injects `config_context` into the `omit` list for performance. After this change the auto-omit only fires when the user hasn't specified `-Brief` or `-Fields` — in those modes the server already controls the response shape, so the auto-omit is redundant and would conflict with the mutual exclusion rule.

Full behavior matrix is documented in the design spec §3.

## Notes for reviewers

- `HelpHint` parameter on the helper is an extension point; intentionally not used at any call site (reserved for per-call-site guidance that may be added later).
- The blank-line style between `)` and `process {` differs between functions (existing inconsistency, not introduced by this PR). The PR-2 script must respect each target function's existing style rather than impose a uniform template.
- Spec §7 size estimates were approximate (300+400 prod/test lines); actual: 66 prod + ~270 test.

## Test plan

- [x] 10 helper unit tests (`Tests/Helpers.Tests.ps1`), all pass
- [x] 4 mutex-exclusion tests for each of `Get-NBIPAMAddress`, `Get-NBVPNTunnel`, `Get-NBDCIMDevice`
- [x] 5 interaction tests for `Get-NBDCIMDevice` covering the `IncludeConfigContext` behavior matrix
- [x] Full unit regression (excluding Integration/Live/Scenario): 2192 passed / 0 failed
- [x] PSScriptAnalyzer on changed production files: 0 findings
- [ ] CI passes on PS 5.1 (Windows) and PS 7 (Linux/Mac)
- [ ] Manual smoke test against a live Netbox: `Get-NBDCIMDevice -Brief -Fields 'id'` throws with clear message
- [ ] Manual smoke test: `Get-NBDCIMDevice -Brief` returns devices without `config_context` in response and without `omit=config_context` in URI

## Follow-up (PR-2, separate)

- Apply the same pattern to 121 remaining Get functions (including `Get-NBVirtualMachine` with its parallel special case)
- Add `scripts/Verify-FilterExclusion.ps1` AST-based auditor with CI integration
- Add per-function `.NOTES` help-text updates
- Add CHANGELOG entry for the breaking change