### PR TITLE
feat: enforce Brief/Fields/Omit mutex on all Get functions (#397 PR-2)

### DIFF
--- a/.github/workflows/filter-exclusion.yml
+++ b/.github/workflows/filter-exclusion.yml
@@ -1,0 +1,32 @@
+name: Filter-Exclusion Audit
+
+on:
+  push:
+    branches: [dev, main, master]
+    paths:
+      - 'Functions/**/Get-NB*.ps1'
+      - 'scripts/Verify-FilterExclusion.ps1'
+      - 'scripts/filter-exclusion-exemptions.txt'
+      - '.github/workflows/filter-exclusion.yml'
+  pull_request:
+    branches: [dev, main, master]
+    paths:
+      - 'Functions/**/Get-NB*.ps1'
+      - 'scripts/Verify-FilterExclusion.ps1'
+      - 'scripts/filter-exclusion-exemptions.txt'
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    name: Filter-exclusion audit
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run auditor
+        shell: pwsh
+        run: ./scripts/Verify-FilterExclusion.ps1 -FailOnMismatch

--- a/Functions/Circuits/CircuitGroupAssignments/Get-NBCircuitGroupAssignment.ps1
+++ b/Functions/Circuits/CircuitGroupAssignments/Get-NBCircuitGroupAssignment.ps1
@@ -89,6 +89,9 @@ function Get-NBCircuitGroupAssignment {
     )
 
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving Circuit Group Assignment"
         switch ($PSCmdlet.ParameterSetName) {
             'ById' {

--- a/Functions/Circuits/CircuitGroupAssignments/Get-NBCircuitGroupAssignment.ps1
+++ b/Functions/Circuits/CircuitGroupAssignments/Get-NBCircuitGroupAssignment.ps1
@@ -49,6 +49,8 @@
 .EXAMPLE
     Get-NBCircuitGroupAssignment
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/Circuits/CircuitGroups/Get-NBCircuitGroup.ps1
+++ b/Functions/Circuits/CircuitGroups/Get-NBCircuitGroup.ps1
@@ -52,6 +52,8 @@
 .EXAMPLE
     Get-NBCircuitGroup -Id 1
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/Circuits/CircuitGroups/Get-NBCircuitGroup.ps1
+++ b/Functions/Circuits/CircuitGroups/Get-NBCircuitGroup.ps1
@@ -92,6 +92,9 @@ function Get-NBCircuitGroup {
     )
 
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving Circuit Group"
         switch ($PSCmdlet.ParameterSetName) {
             'ById' {

--- a/Functions/Circuits/Circuits/Get-NBCircuit.ps1
+++ b/Functions/Circuits/Circuits/Get-NBCircuit.ps1
@@ -137,6 +137,9 @@ function Get-NBCircuit {
     )
 
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving Circuit"
         switch ($PSCmdlet.ParameterSetName) {
             'ById' {

--- a/Functions/Circuits/ProviderAccounts/Get-NBCircuitProviderAccount.ps1
+++ b/Functions/Circuits/ProviderAccounts/Get-NBCircuitProviderAccount.ps1
@@ -52,6 +52,8 @@
 .EXAMPLE
     Get-NBCircuitProviderAccount
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/Circuits/ProviderAccounts/Get-NBCircuitProviderAccount.ps1
+++ b/Functions/Circuits/ProviderAccounts/Get-NBCircuitProviderAccount.ps1
@@ -95,6 +95,9 @@ function Get-NBCircuitProviderAccount {
     )
 
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving Circuit Provider Account"
         switch ($PSCmdlet.ParameterSetName) {
             'ById' {

--- a/Functions/Circuits/ProviderNetworks/Get-NBCircuitProviderNetwork.ps1
+++ b/Functions/Circuits/ProviderNetworks/Get-NBCircuitProviderNetwork.ps1
@@ -89,6 +89,9 @@ function Get-NBCircuitProviderNetwork {
     )
 
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving Circuit Provider Network"
         switch ($PSCmdlet.ParameterSetName) {
             'ById' {

--- a/Functions/Circuits/ProviderNetworks/Get-NBCircuitProviderNetwork.ps1
+++ b/Functions/Circuits/ProviderNetworks/Get-NBCircuitProviderNetwork.ps1
@@ -49,6 +49,8 @@
 .EXAMPLE
     Get-NBCircuitProviderNetwork
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/Circuits/Providers/Get-NBCircuitProvider.ps1
+++ b/Functions/Circuits/Providers/Get-NBCircuitProvider.ps1
@@ -31,6 +31,8 @@
 .EXAMPLE
     Get-NBCircuitProvider
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/Circuits/Providers/Get-NBCircuitProvider.ps1
+++ b/Functions/Circuits/Providers/Get-NBCircuitProvider.ps1
@@ -81,6 +81,9 @@ function Get-NBCircuitProvider {
     )
 
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving Circuit Provider"
         switch ($PSCmdlet.ParameterSetName) {
         'ById' {

--- a/Functions/Circuits/Terminations/Get-NBCircuitTermination.ps1
+++ b/Functions/Circuits/Terminations/Get-NBCircuitTermination.ps1
@@ -31,6 +31,8 @@
 .EXAMPLE
     Get-NBCircuitTermination
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/Circuits/Terminations/Get-NBCircuitTermination.ps1
+++ b/Functions/Circuits/Terminations/Get-NBCircuitTermination.ps1
@@ -85,6 +85,9 @@ function Get-NBCircuitTermination {
     )
 
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving Circuit Termination"
         switch ($PSCmdlet.ParameterSetName) {
             'ById' {

--- a/Functions/Circuits/Types/Get-NBCircuitType.ps1
+++ b/Functions/Circuits/Types/Get-NBCircuitType.ps1
@@ -72,6 +72,9 @@ function Get-NBCircuitType {
     )
 
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving Circuit Type"
         switch ($PSCmdlet.ParameterSetName) {
         'ById' {

--- a/Functions/Circuits/Types/Get-NBCircuitType.ps1
+++ b/Functions/Circuits/Types/Get-NBCircuitType.ps1
@@ -31,6 +31,8 @@
 .EXAMPLE
     Get-NBCircuitType
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/Circuits/VirtualCircuitTerminations/Get-NBVirtualCircuitTermination.ps1
+++ b/Functions/Circuits/VirtualCircuitTerminations/Get-NBVirtualCircuitTermination.ps1
@@ -96,6 +96,9 @@ function Get-NBVirtualCircuitTermination {
     )
 
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving Virtual Circuit Termination"
         switch ($PSCmdlet.ParameterSetName) {
             'ById' {

--- a/Functions/Circuits/VirtualCircuitTerminations/Get-NBVirtualCircuitTermination.ps1
+++ b/Functions/Circuits/VirtualCircuitTerminations/Get-NBVirtualCircuitTermination.ps1
@@ -52,6 +52,8 @@
 .EXAMPLE
     Get-NBVirtualCircuitTermination
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/Circuits/VirtualCircuitTypes/Get-NBVirtualCircuitType.ps1
+++ b/Functions/Circuits/VirtualCircuitTypes/Get-NBVirtualCircuitType.ps1
@@ -89,6 +89,9 @@ function Get-NBVirtualCircuitType {
     )
 
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving Virtual Circuit Type"
         switch ($PSCmdlet.ParameterSetName) {
             'ById' {

--- a/Functions/Circuits/VirtualCircuitTypes/Get-NBVirtualCircuitType.ps1
+++ b/Functions/Circuits/VirtualCircuitTypes/Get-NBVirtualCircuitType.ps1
@@ -49,6 +49,8 @@
 .EXAMPLE
     Get-NBVirtualCircuitType
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/Circuits/VirtualCircuits/Get-NBVirtualCircuit.ps1
+++ b/Functions/Circuits/VirtualCircuits/Get-NBVirtualCircuit.ps1
@@ -119,6 +119,9 @@ function Get-NBVirtualCircuit {
     )
 
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving Virtual Circuit"
         switch ($PSCmdlet.ParameterSetName) {
             'ById' {

--- a/Functions/Circuits/VirtualCircuits/Get-NBVirtualCircuit.ps1
+++ b/Functions/Circuits/VirtualCircuits/Get-NBVirtualCircuit.ps1
@@ -64,6 +64,8 @@
 .EXAMPLE
     Get-NBVirtualCircuit
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/Core/DataFiles/Get-NBDataFile.ps1
+++ b/Functions/Core/DataFiles/Get-NBDataFile.ps1
@@ -49,6 +49,8 @@
 .EXAMPLE
     Get-NBDataFile
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/Core/DataFiles/Get-NBDataFile.ps1
+++ b/Functions/Core/DataFiles/Get-NBDataFile.ps1
@@ -89,6 +89,9 @@ function Get-NBDataFile {
     )
 
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving Data File"
         switch ($PSCmdlet.ParameterSetName) {
             'ById' {

--- a/Functions/Core/DataSources/Get-NBDataSource.ps1
+++ b/Functions/Core/DataSources/Get-NBDataSource.ps1
@@ -52,6 +52,8 @@
 .EXAMPLE
     Get-NBDataSource
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/Core/DataSources/Get-NBDataSource.ps1
+++ b/Functions/Core/DataSources/Get-NBDataSource.ps1
@@ -96,6 +96,9 @@ function Get-NBDataSource {
     )
 
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving Data Source"
         switch ($PSCmdlet.ParameterSetName) {
             'ById' {

--- a/Functions/Core/Jobs/Get-NBJob.ps1
+++ b/Functions/Core/Jobs/Get-NBJob.ps1
@@ -61,6 +61,8 @@
 .EXAMPLE
     Get-NBJob -Status "running"
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/Core/Jobs/Get-NBJob.ps1
+++ b/Functions/Core/Jobs/Get-NBJob.ps1
@@ -111,6 +111,9 @@ function Get-NBJob {
     )
 
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving Job"
         switch ($PSCmdlet.ParameterSetName) {
             'ById' {

--- a/Functions/Core/ObjectChanges/Get-NBObjectChange.ps1
+++ b/Functions/Core/ObjectChanges/Get-NBObjectChange.ps1
@@ -111,6 +111,9 @@ function Get-NBObjectChange {
     )
 
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving Object Change"
         switch ($PSCmdlet.ParameterSetName) {
             'ById' {

--- a/Functions/Core/ObjectChanges/Get-NBObjectChange.ps1
+++ b/Functions/Core/ObjectChanges/Get-NBObjectChange.ps1
@@ -61,6 +61,8 @@
 .EXAMPLE
     Get-NBObjectChange -Action "create" -Limit 50
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/Core/ObjectTypes/Get-NBObjectType.ps1
+++ b/Functions/Core/ObjectTypes/Get-NBObjectType.ps1
@@ -95,6 +95,9 @@ function Get-NBObjectType {
     )
 
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving Object Type"
 
         # Version-aware endpoint selection

--- a/Functions/Core/ObjectTypes/Get-NBObjectType.ps1
+++ b/Functions/Core/ObjectTypes/Get-NBObjectType.ps1
@@ -55,6 +55,8 @@
 .EXAMPLE
     Get-NBObjectType -App_Label "dcim"
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/DCIM/Cable Terminations/Get-NBDCIMCableTermination.ps1
+++ b/Functions/DCIM/Cable Terminations/Get-NBDCIMCableTermination.ps1
@@ -78,6 +78,9 @@ function Get-NBDCIMCableTermination {
     #endregion Parameters
 
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving DCIM Cable Termination"
         $Segments = [System.Collections.ArrayList]::new(@('dcim', 'cable-terminations'))
 

--- a/Functions/DCIM/Cable Terminations/Get-NBDCIMCableTermination.ps1
+++ b/Functions/DCIM/Cable Terminations/Get-NBDCIMCableTermination.ps1
@@ -31,6 +31,8 @@
 .EXAMPLE
     Get-NBDCIMCableTermination
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/DCIM/Cables/Get-NBDCIMCable.ps1
+++ b/Functions/DCIM/Cables/Get-NBDCIMCable.ps1
@@ -177,6 +177,9 @@ function Get-NBDCIMCable {
     #endregion Parameters
 
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving DCIM Cable"
         switch ($PSCmdlet.ParameterSetName) {
             'ByID' { foreach ($i in $Id) { InvokeNetboxRequest -URI (BuildNewURI -Segments @('dcim', 'cables', $i)) -Raw:$Raw } }

--- a/Functions/DCIM/Cables/Get-NBDCIMCable.ps1
+++ b/Functions/DCIM/Cables/Get-NBDCIMCable.ps1
@@ -78,6 +78,8 @@
 .EXAMPLE
     Get-NBDCIMCable -Status 'connected' -Device_ID 5
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/DCIM/ConsolePortTemplates/Get-NBDCIMConsolePortTemplate.ps1
+++ b/Functions/DCIM/ConsolePortTemplates/Get-NBDCIMConsolePortTemplate.ps1
@@ -31,6 +31,8 @@
 .EXAMPLE
     Get-NBDCIMConsolePortTemplate
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/DCIM/ConsolePortTemplates/Get-NBDCIMConsolePortTemplate.ps1
+++ b/Functions/DCIM/ConsolePortTemplates/Get-NBDCIMConsolePortTemplate.ps1
@@ -62,6 +62,9 @@ function Get-NBDCIMConsolePortTemplate {
         [switch]$Raw
     )
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving DCIM Console Port Template"
         switch ($PSCmdlet.ParameterSetName) {
             'ByID' { foreach ($i in $Id) { InvokeNetboxRequest -URI (BuildNewURI -Segments @('dcim','console-port-templates',$i)) -Raw:$Raw } }

--- a/Functions/DCIM/ConsolePorts/Get-NBDCIMConsolePort.ps1
+++ b/Functions/DCIM/ConsolePorts/Get-NBDCIMConsolePort.ps1
@@ -31,6 +31,8 @@
 .EXAMPLE
     Get-NBDCIMConsolePort
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/DCIM/ConsolePorts/Get-NBDCIMConsolePort.ps1
+++ b/Functions/DCIM/ConsolePorts/Get-NBDCIMConsolePort.ps1
@@ -62,6 +62,9 @@ function Get-NBDCIMConsolePort {
         [switch]$Raw
     )
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving DCIM Console Port"
         switch ($PSCmdlet.ParameterSetName) {
             'ByID' { foreach ($i in $Id) { InvokeNetboxRequest -URI (BuildNewURI -Segments @('dcim','console-ports',$i)) -Raw:$Raw } }

--- a/Functions/DCIM/ConsoleServerPortTemplates/Get-NBDCIMConsoleServerPortTemplate.ps1
+++ b/Functions/DCIM/ConsoleServerPortTemplates/Get-NBDCIMConsoleServerPortTemplate.ps1
@@ -31,6 +31,8 @@
 .EXAMPLE
     Get-NBDCIMConsoleServerPortTemplate
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/DCIM/ConsoleServerPortTemplates/Get-NBDCIMConsoleServerPortTemplate.ps1
+++ b/Functions/DCIM/ConsoleServerPortTemplates/Get-NBDCIMConsoleServerPortTemplate.ps1
@@ -62,6 +62,9 @@ function Get-NBDCIMConsoleServerPortTemplate {
         [switch]$Raw
     )
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving DCIM Console Server Port Template"
         switch ($PSCmdlet.ParameterSetName) {
             'ByID' { foreach ($i in $Id) { InvokeNetboxRequest -URI (BuildNewURI -Segments @('dcim','console-server-port-templates',$i)) -Raw:$Raw } }

--- a/Functions/DCIM/ConsoleServerPorts/Get-NBDCIMConsoleServerPort.ps1
+++ b/Functions/DCIM/ConsoleServerPorts/Get-NBDCIMConsoleServerPort.ps1
@@ -31,6 +31,8 @@
 .EXAMPLE
     Get-NBDCIMConsoleServerPort
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/DCIM/ConsoleServerPorts/Get-NBDCIMConsoleServerPort.ps1
+++ b/Functions/DCIM/ConsoleServerPorts/Get-NBDCIMConsoleServerPort.ps1
@@ -62,6 +62,9 @@ function Get-NBDCIMConsoleServerPort {
         [switch]$Raw
     )
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving DCIM Console Server Port"
         switch ($PSCmdlet.ParameterSetName) {
             'ByID' { foreach ($i in $Id) { InvokeNetboxRequest -URI (BuildNewURI -Segments @('dcim','console-server-ports',$i)) -Raw:$Raw } }

--- a/Functions/DCIM/DeviceBayTemplates/Get-NBDCIMDeviceBayTemplate.ps1
+++ b/Functions/DCIM/DeviceBayTemplates/Get-NBDCIMDeviceBayTemplate.ps1
@@ -60,6 +60,9 @@ function Get-NBDCIMDeviceBayTemplate {
         [switch]$Raw
     )
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving DCIM Device Bay Template"
         switch ($PSCmdlet.ParameterSetName) {
             'ByID' { foreach ($i in $Id) { InvokeNetboxRequest -URI (BuildNewURI -Segments @('dcim','device-bay-templates',$i)) -Raw:$Raw } }

--- a/Functions/DCIM/DeviceBayTemplates/Get-NBDCIMDeviceBayTemplate.ps1
+++ b/Functions/DCIM/DeviceBayTemplates/Get-NBDCIMDeviceBayTemplate.ps1
@@ -31,6 +31,8 @@
 .EXAMPLE
     Get-NBDCIMDeviceBayTemplate
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/DCIM/DeviceBays/Get-NBDCIMDeviceBay.ps1
+++ b/Functions/DCIM/DeviceBays/Get-NBDCIMDeviceBay.ps1
@@ -31,6 +31,8 @@
 .EXAMPLE
     Get-NBDCIMDeviceBay
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/DCIM/DeviceBays/Get-NBDCIMDeviceBay.ps1
+++ b/Functions/DCIM/DeviceBays/Get-NBDCIMDeviceBay.ps1
@@ -60,6 +60,9 @@ function Get-NBDCIMDeviceBay {
         [switch]$Raw
     )
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving DCIM Device Bay"
         switch ($PSCmdlet.ParameterSetName) {
             'ByID' { foreach ($i in $Id) { InvokeNetboxRequest -URI (BuildNewURI -Segments @('dcim','device-bays',$i)) -Raw:$Raw } }

--- a/Functions/DCIM/Devices/Get-NBDCIMDevice.ps1
+++ b/Functions/DCIM/Devices/Get-NBDCIMDevice.ps1
@@ -69,6 +69,8 @@
     Get-NBDCIMDevice -All -PageSize 200 -Verbose
     Returns all devices with 200 items per request, showing progress.
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/DCIM/Devices/Get-NBDCIMDeviceRole.ps1
+++ b/Functions/DCIM/Devices/Get-NBDCIMDeviceRole.ps1
@@ -75,6 +75,9 @@ function Get-NBDCIMDeviceRole {
     )
 
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving DCIM Device Role"
         switch ($PSCmdlet.ParameterSetName) {
         'ById' {

--- a/Functions/DCIM/Devices/Get-NBDCIMDeviceRole.ps1
+++ b/Functions/DCIM/Devices/Get-NBDCIMDeviceRole.ps1
@@ -31,6 +31,8 @@
 .EXAMPLE
     Get-NBDCIMDeviceRole
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/DCIM/Devices/Get-NBDCIMDeviceType.ps1
+++ b/Functions/DCIM/Devices/Get-NBDCIMDeviceType.ps1
@@ -31,6 +31,8 @@
 .EXAMPLE
     Get-NBDCIMDeviceType
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/DCIM/Devices/Get-NBDCIMDeviceType.ps1
+++ b/Functions/DCIM/Devices/Get-NBDCIMDeviceType.ps1
@@ -102,6 +102,9 @@ function Get-NBDCIMDeviceType {
     #endregion Parameters
 
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving DCIM Device Type"
         switch ($PSCmdlet.ParameterSetName) {
             'ByID' { foreach ($i in $Id) { InvokeNetboxRequest -URI (BuildNewURI -Segments @('dcim', 'device-types', $i)) -Raw:$Raw } }

--- a/Functions/DCIM/FrontPortTemplates/Get-NBDCIMFrontPortTemplate.ps1
+++ b/Functions/DCIM/FrontPortTemplates/Get-NBDCIMFrontPortTemplate.ps1
@@ -62,6 +62,9 @@ function Get-NBDCIMFrontPortTemplate {
         [switch]$Raw
     )
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving DCIM Front Port Template"
         switch ($PSCmdlet.ParameterSetName) {
             'ByID' { foreach ($i in $Id) { InvokeNetboxRequest -URI (BuildNewURI -Segments @('dcim','front-port-templates',$i)) -Raw:$Raw } }

--- a/Functions/DCIM/FrontPortTemplates/Get-NBDCIMFrontPortTemplate.ps1
+++ b/Functions/DCIM/FrontPortTemplates/Get-NBDCIMFrontPortTemplate.ps1
@@ -31,6 +31,8 @@
 .EXAMPLE
     Get-NBDCIMFrontPortTemplate
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/DCIM/FrontPorts/Get-NBDCIMFrontPort.ps1
+++ b/Functions/DCIM/FrontPorts/Get-NBDCIMFrontPort.ps1
@@ -31,6 +31,8 @@
 .EXAMPLE
     Get-NBDCIMFrontPort
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/DCIM/FrontPorts/Get-NBDCIMFrontPort.ps1
+++ b/Functions/DCIM/FrontPorts/Get-NBDCIMFrontPort.ps1
@@ -75,6 +75,9 @@ function Get-NBDCIMFrontPort {
     )
 
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving DCIM Front Port"
         switch ($PSCmdlet.ParameterSetName) {
             'ByID' { foreach ($i in $Id) { InvokeNetboxRequest -URI (BuildNewURI -Segments @('dcim', 'front-ports', $i)) -Raw:$Raw } }

--- a/Functions/DCIM/InterfaceTemplates/Get-NBDCIMInterfaceTemplate.ps1
+++ b/Functions/DCIM/InterfaceTemplates/Get-NBDCIMInterfaceTemplate.ps1
@@ -31,6 +31,8 @@
 .EXAMPLE
     Get-NBDCIMInterfaceTemplate
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/DCIM/InterfaceTemplates/Get-NBDCIMInterfaceTemplate.ps1
+++ b/Functions/DCIM/InterfaceTemplates/Get-NBDCIMInterfaceTemplate.ps1
@@ -62,6 +62,9 @@ function Get-NBDCIMInterfaceTemplate {
         [switch]$Raw
     )
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving DCIM Interface Template"
         switch ($PSCmdlet.ParameterSetName) {
             'ByID' { foreach ($i in $Id) { InvokeNetboxRequest -URI (BuildNewURI -Segments @('dcim','interface-templates',$i)) -Raw:$Raw } }

--- a/Functions/DCIM/Interfaces/Get-NBDCIMInterface.ps1
+++ b/Functions/DCIM/Interfaces/Get-NBDCIMInterface.ps1
@@ -98,6 +98,9 @@ function Get-NBDCIMInterface {
     )
 
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving DCIM Interface"
         switch ($PSCmdlet.ParameterSetName) {
             'ByID' { foreach ($i in $Id) { InvokeNetboxRequest -URI (BuildNewURI -Segments @('dcim', 'interfaces', $i)) -Raw:$Raw } }

--- a/Functions/DCIM/Interfaces/Get-NBDCIMInterface.ps1
+++ b/Functions/DCIM/Interfaces/Get-NBDCIMInterface.ps1
@@ -35,6 +35,8 @@
     Get-NBDCIMInterface -Omit 'description'
     Returns interfaces without the description field (Netbox 4.5+).
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/DCIM/Interfaces/Get-NBDCIMInterfaceConnection.ps1
+++ b/Functions/DCIM/Interfaces/Get-NBDCIMInterfaceConnection.ps1
@@ -31,6 +31,8 @@
 .EXAMPLE
     Get-NBDCIMInterfaceConnection
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/DCIM/Interfaces/Get-NBDCIMInterfaceConnection.ps1
+++ b/Functions/DCIM/Interfaces/Get-NBDCIMInterfaceConnection.ps1
@@ -73,6 +73,9 @@ function Get-NBDCIMInterfaceConnection {
     )
 
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving DCIM Interface Connection"
         switch ($PSCmdlet.ParameterSetName) {
             'ByID' { foreach ($i in $Id) { InvokeNetboxRequest -URI (BuildNewURI -Segments @('dcim', 'interface-connections', $i)) -Raw:$Raw } }

--- a/Functions/DCIM/InventoryItemRoles/Get-NBDCIMInventoryItemRole.ps1
+++ b/Functions/DCIM/InventoryItemRoles/Get-NBDCIMInventoryItemRole.ps1
@@ -31,6 +31,8 @@
 .EXAMPLE
     Get-NBDCIMInventoryItemRole
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/DCIM/InventoryItemRoles/Get-NBDCIMInventoryItemRole.ps1
+++ b/Functions/DCIM/InventoryItemRoles/Get-NBDCIMInventoryItemRole.ps1
@@ -60,6 +60,9 @@ function Get-NBDCIMInventoryItemRole {
         [switch]$Raw
     )
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving DCIM Inventory Item Role"
         switch ($PSCmdlet.ParameterSetName) {
             'ByID' { foreach ($i in $Id) { InvokeNetboxRequest -URI (BuildNewURI -Segments @('dcim','inventory-item-roles',$i)) -Raw:$Raw } }

--- a/Functions/DCIM/InventoryItemTemplates/Get-NBDCIMInventoryItemTemplate.ps1
+++ b/Functions/DCIM/InventoryItemTemplates/Get-NBDCIMInventoryItemTemplate.ps1
@@ -31,6 +31,8 @@
 .EXAMPLE
     Get-NBDCIMInventoryItemTemplate
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/DCIM/InventoryItemTemplates/Get-NBDCIMInventoryItemTemplate.ps1
+++ b/Functions/DCIM/InventoryItemTemplates/Get-NBDCIMInventoryItemTemplate.ps1
@@ -61,6 +61,9 @@ function Get-NBDCIMInventoryItemTemplate {
         [switch]$Raw
     )
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving DCIM Inventory Item Template"
         switch ($PSCmdlet.ParameterSetName) {
             'ByID' { foreach ($i in $Id) { InvokeNetboxRequest -URI (BuildNewURI -Segments @('dcim','inventory-item-templates',$i)) -Raw:$Raw } }

--- a/Functions/DCIM/InventoryItems/Get-NBDCIMInventoryItem.ps1
+++ b/Functions/DCIM/InventoryItems/Get-NBDCIMInventoryItem.ps1
@@ -31,6 +31,8 @@
 .EXAMPLE
     Get-NBDCIMInventoryItem
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/DCIM/InventoryItems/Get-NBDCIMInventoryItem.ps1
+++ b/Functions/DCIM/InventoryItems/Get-NBDCIMInventoryItem.ps1
@@ -64,6 +64,9 @@ function Get-NBDCIMInventoryItem {
         [switch]$Raw
     )
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving DCIM Inventory Item"
         switch ($PSCmdlet.ParameterSetName) {
             'ByID' { foreach ($i in $Id) { InvokeNetboxRequest -URI (BuildNewURI -Segments @('dcim','inventory-items',$i)) -Raw:$Raw } }

--- a/Functions/DCIM/Locations/Get-NBDCIMLocation.ps1
+++ b/Functions/DCIM/Locations/Get-NBDCIMLocation.ps1
@@ -133,6 +133,9 @@ function Get-NBDCIMLocation {
     )
 
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving DCIM Location"
         switch ($PSCmdlet.ParameterSetName) {
             'ByID' {

--- a/Functions/DCIM/Locations/Get-NBDCIMLocation.ps1
+++ b/Functions/DCIM/Locations/Get-NBDCIMLocation.ps1
@@ -77,6 +77,8 @@ function Get-NBDCIMLocation {
         Get-NBDCIMLocation -Name "Server Room"
 
         Returns locations matching the name "Server Room"
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 #>
 
     [CmdletBinding(DefaultParameterSetName = 'Query')]

--- a/Functions/DCIM/MACAddresses/Get-NBDCIMMACAddress.ps1
+++ b/Functions/DCIM/MACAddresses/Get-NBDCIMMACAddress.ps1
@@ -63,6 +63,9 @@ function Get-NBDCIMMACAddress {
         [switch]$Raw
     )
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving DCIM MAC Address"
         switch ($PSCmdlet.ParameterSetName) {
             'ByID' { foreach ($i in $Id) { InvokeNetboxRequest -URI (BuildNewURI -Segments @('dcim','mac-addresses',$i)) -Raw:$Raw } }

--- a/Functions/DCIM/MACAddresses/Get-NBDCIMMACAddress.ps1
+++ b/Functions/DCIM/MACAddresses/Get-NBDCIMMACAddress.ps1
@@ -31,6 +31,8 @@
 .EXAMPLE
     Get-NBDCIMMACAddress
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/DCIM/Manufacturers/Get-NBDCIMManufacturer.ps1
+++ b/Functions/DCIM/Manufacturers/Get-NBDCIMManufacturer.ps1
@@ -96,6 +96,9 @@ function Get-NBDCIMManufacturer {
     )
 
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving DCIM Manufacturer"
         switch ($PSCmdlet.ParameterSetName) {
             'ByID' {

--- a/Functions/DCIM/Manufacturers/Get-NBDCIMManufacturer.ps1
+++ b/Functions/DCIM/Manufacturers/Get-NBDCIMManufacturer.ps1
@@ -56,6 +56,8 @@ function Get-NBDCIMManufacturer {
         Get-NBDCIMManufacturer -Name "Cisco"
 
         Returns manufacturers matching the name "Cisco"
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 #>
 
     [CmdletBinding(DefaultParameterSetName = 'Query')]

--- a/Functions/DCIM/ModuleBayTemplates/Get-NBDCIMModuleBayTemplate.ps1
+++ b/Functions/DCIM/ModuleBayTemplates/Get-NBDCIMModuleBayTemplate.ps1
@@ -31,6 +31,8 @@
 .EXAMPLE
     Get-NBDCIMModuleBayTemplate
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/DCIM/ModuleBayTemplates/Get-NBDCIMModuleBayTemplate.ps1
+++ b/Functions/DCIM/ModuleBayTemplates/Get-NBDCIMModuleBayTemplate.ps1
@@ -60,6 +60,9 @@ function Get-NBDCIMModuleBayTemplate {
         [switch]$Raw
     )
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving DCIM Module Bay Template"
         switch ($PSCmdlet.ParameterSetName) {
             'ByID' { foreach ($i in $Id) { InvokeNetboxRequest -URI (BuildNewURI -Segments @('dcim','module-bay-templates',$i)) -Raw:$Raw } }

--- a/Functions/DCIM/ModuleBays/Get-NBDCIMModuleBay.ps1
+++ b/Functions/DCIM/ModuleBays/Get-NBDCIMModuleBay.ps1
@@ -31,6 +31,8 @@
 .EXAMPLE
     Get-NBDCIMModuleBay
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/DCIM/ModuleBays/Get-NBDCIMModuleBay.ps1
+++ b/Functions/DCIM/ModuleBays/Get-NBDCIMModuleBay.ps1
@@ -60,6 +60,9 @@ function Get-NBDCIMModuleBay {
         [switch]$Raw
     )
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving DCIM Module Bay"
         switch ($PSCmdlet.ParameterSetName) {
             'ByID' { foreach ($i in $Id) { InvokeNetboxRequest -URI (BuildNewURI -Segments @('dcim','module-bays',$i)) -Raw:$Raw } }

--- a/Functions/DCIM/ModuleTypeProfiles/Get-NBDCIMModuleTypeProfile.ps1
+++ b/Functions/DCIM/ModuleTypeProfiles/Get-NBDCIMModuleTypeProfile.ps1
@@ -59,6 +59,9 @@ function Get-NBDCIMModuleTypeProfile {
         [switch]$Raw
     )
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving DCIM Module Type Profile"
         switch ($PSCmdlet.ParameterSetName) {
             'ByID' { foreach ($i in $Id) { InvokeNetboxRequest -URI (BuildNewURI -Segments @('dcim','module-type-profiles',$i)) -Raw:$Raw } }

--- a/Functions/DCIM/ModuleTypeProfiles/Get-NBDCIMModuleTypeProfile.ps1
+++ b/Functions/DCIM/ModuleTypeProfiles/Get-NBDCIMModuleTypeProfile.ps1
@@ -31,6 +31,8 @@
 .EXAMPLE
     Get-NBDCIMModuleTypeProfile
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/DCIM/ModuleTypes/Get-NBDCIMModuleType.ps1
+++ b/Functions/DCIM/ModuleTypes/Get-NBDCIMModuleType.ps1
@@ -61,6 +61,9 @@ function Get-NBDCIMModuleType {
         [switch]$Raw
     )
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving DCIM Module Type"
         switch ($PSCmdlet.ParameterSetName) {
             'ByID' { foreach ($i in $Id) { InvokeNetboxRequest -URI (BuildNewURI -Segments @('dcim','module-types',$i)) -Raw:$Raw } }

--- a/Functions/DCIM/ModuleTypes/Get-NBDCIMModuleType.ps1
+++ b/Functions/DCIM/ModuleTypes/Get-NBDCIMModuleType.ps1
@@ -31,6 +31,8 @@
 .EXAMPLE
     Get-NBDCIMModuleType
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/DCIM/Modules/Get-NBDCIMModule.ps1
+++ b/Functions/DCIM/Modules/Get-NBDCIMModule.ps1
@@ -64,6 +64,9 @@ function Get-NBDCIMModule {
         [switch]$Raw
     )
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving DCIM Module"
         switch ($PSCmdlet.ParameterSetName) {
             'ByID' { foreach ($i in $Id) { InvokeNetboxRequest -URI (BuildNewURI -Segments @('dcim','modules',$i)) -Raw:$Raw } }

--- a/Functions/DCIM/Modules/Get-NBDCIMModule.ps1
+++ b/Functions/DCIM/Modules/Get-NBDCIMModule.ps1
@@ -31,6 +31,8 @@
 .EXAMPLE
     Get-NBDCIMModule
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/DCIM/Platforms/Get-NBDCIMPlatform.ps1
+++ b/Functions/DCIM/Platforms/Get-NBDCIMPlatform.ps1
@@ -75,6 +75,9 @@ function Get-NBDCIMPlatform {
     )
 
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving DCIM Platform"
         switch ($PSCmdlet.ParameterSetName) {
         'ById' {

--- a/Functions/DCIM/Platforms/Get-NBDCIMPlatform.ps1
+++ b/Functions/DCIM/Platforms/Get-NBDCIMPlatform.ps1
@@ -31,6 +31,8 @@
 .EXAMPLE
     Get-NBDCIMPlatform
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/DCIM/PowerFeeds/Get-NBDCIMPowerFeed.ps1
+++ b/Functions/DCIM/PowerFeeds/Get-NBDCIMPowerFeed.ps1
@@ -63,6 +63,9 @@ function Get-NBDCIMPowerFeed {
         [switch]$Raw
     )
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving DCIM Power Feed"
         switch ($PSCmdlet.ParameterSetName) {
             'ByID' { foreach ($i in $Id) { InvokeNetboxRequest -URI (BuildNewURI -Segments @('dcim','power-feeds',$i)) -Raw:$Raw } }

--- a/Functions/DCIM/PowerFeeds/Get-NBDCIMPowerFeed.ps1
+++ b/Functions/DCIM/PowerFeeds/Get-NBDCIMPowerFeed.ps1
@@ -31,6 +31,8 @@
 .EXAMPLE
     Get-NBDCIMPowerFeed
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/DCIM/PowerOutletTemplates/Get-NBDCIMPowerOutletTemplate.ps1
+++ b/Functions/DCIM/PowerOutletTemplates/Get-NBDCIMPowerOutletTemplate.ps1
@@ -62,6 +62,9 @@ function Get-NBDCIMPowerOutletTemplate {
         [switch]$Raw
     )
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving DCIM Power Outlet Template"
         switch ($PSCmdlet.ParameterSetName) {
             'ByID' { foreach ($i in $Id) { InvokeNetboxRequest -URI (BuildNewURI -Segments @('dcim','power-outlet-templates',$i)) -Raw:$Raw } }

--- a/Functions/DCIM/PowerOutletTemplates/Get-NBDCIMPowerOutletTemplate.ps1
+++ b/Functions/DCIM/PowerOutletTemplates/Get-NBDCIMPowerOutletTemplate.ps1
@@ -31,6 +31,8 @@
 .EXAMPLE
     Get-NBDCIMPowerOutletTemplate
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/DCIM/PowerOutlets/Get-NBDCIMPowerOutlet.ps1
+++ b/Functions/DCIM/PowerOutlets/Get-NBDCIMPowerOutlet.ps1
@@ -62,6 +62,9 @@ function Get-NBDCIMPowerOutlet {
         [switch]$Raw
     )
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving DCIM Power Outlet"
         switch ($PSCmdlet.ParameterSetName) {
             'ByID' { foreach ($i in $Id) { InvokeNetboxRequest -URI (BuildNewURI -Segments @('dcim','power-outlets',$i)) -Raw:$Raw } }

--- a/Functions/DCIM/PowerOutlets/Get-NBDCIMPowerOutlet.ps1
+++ b/Functions/DCIM/PowerOutlets/Get-NBDCIMPowerOutlet.ps1
@@ -31,6 +31,8 @@
 .EXAMPLE
     Get-NBDCIMPowerOutlet
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/DCIM/PowerPanels/Get-NBDCIMPowerPanel.ps1
+++ b/Functions/DCIM/PowerPanels/Get-NBDCIMPowerPanel.ps1
@@ -61,6 +61,9 @@ function Get-NBDCIMPowerPanel {
         [switch]$Raw
     )
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving DCIM Power Panel"
         switch ($PSCmdlet.ParameterSetName) {
             'ByID' { foreach ($i in $Id) { InvokeNetboxRequest -URI (BuildNewURI -Segments @('dcim','power-panels',$i)) -Raw:$Raw } }

--- a/Functions/DCIM/PowerPanels/Get-NBDCIMPowerPanel.ps1
+++ b/Functions/DCIM/PowerPanels/Get-NBDCIMPowerPanel.ps1
@@ -31,6 +31,8 @@
 .EXAMPLE
     Get-NBDCIMPowerPanel
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/DCIM/PowerPortTemplates/Get-NBDCIMPowerPortTemplate.ps1
+++ b/Functions/DCIM/PowerPortTemplates/Get-NBDCIMPowerPortTemplate.ps1
@@ -31,6 +31,8 @@
 .EXAMPLE
     Get-NBDCIMPowerPortTemplate
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/DCIM/PowerPortTemplates/Get-NBDCIMPowerPortTemplate.ps1
+++ b/Functions/DCIM/PowerPortTemplates/Get-NBDCIMPowerPortTemplate.ps1
@@ -62,6 +62,9 @@ function Get-NBDCIMPowerPortTemplate {
         [switch]$Raw
     )
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving DCIM Power Port Template"
         switch ($PSCmdlet.ParameterSetName) {
             'ByID' { foreach ($i in $Id) { InvokeNetboxRequest -URI (BuildNewURI -Segments @('dcim','power-port-templates',$i)) -Raw:$Raw } }

--- a/Functions/DCIM/PowerPorts/Get-NBDCIMPowerPort.ps1
+++ b/Functions/DCIM/PowerPorts/Get-NBDCIMPowerPort.ps1
@@ -62,6 +62,9 @@ function Get-NBDCIMPowerPort {
         [switch]$Raw
     )
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving DCIM Power Port"
         switch ($PSCmdlet.ParameterSetName) {
             'ByID' { foreach ($i in $Id) { InvokeNetboxRequest -URI (BuildNewURI -Segments @('dcim','power-ports',$i)) -Raw:$Raw } }

--- a/Functions/DCIM/PowerPorts/Get-NBDCIMPowerPort.ps1
+++ b/Functions/DCIM/PowerPorts/Get-NBDCIMPowerPort.ps1
@@ -31,6 +31,8 @@
 .EXAMPLE
     Get-NBDCIMPowerPort
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/DCIM/RackReservations/Get-NBDCIMRackReservation.ps1
+++ b/Functions/DCIM/RackReservations/Get-NBDCIMRackReservation.ps1
@@ -31,6 +31,8 @@
 .EXAMPLE
     Get-NBDCIMRackReservation
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/DCIM/RackReservations/Get-NBDCIMRackReservation.ps1
+++ b/Functions/DCIM/RackReservations/Get-NBDCIMRackReservation.ps1
@@ -62,6 +62,9 @@ function Get-NBDCIMRackReservation {
         [switch]$Raw
     )
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving DCIM Rack Reservation"
         switch ($PSCmdlet.ParameterSetName) {
             'ByID' { foreach ($i in $Id) { InvokeNetboxRequest -URI (BuildNewURI -Segments @('dcim','rack-reservations',$i)) -Raw:$Raw } }

--- a/Functions/DCIM/RackRoles/Get-NBDCIMRackRole.ps1
+++ b/Functions/DCIM/RackRoles/Get-NBDCIMRackRole.ps1
@@ -60,6 +60,9 @@ function Get-NBDCIMRackRole {
         [switch]$Raw
     )
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving DCIM Rack Role"
         switch ($PSCmdlet.ParameterSetName) {
             'ByID' { foreach ($i in $Id) { InvokeNetboxRequest -URI (BuildNewURI -Segments @('dcim','rack-roles',$i)) -Raw:$Raw } }

--- a/Functions/DCIM/RackRoles/Get-NBDCIMRackRole.ps1
+++ b/Functions/DCIM/RackRoles/Get-NBDCIMRackRole.ps1
@@ -31,6 +31,8 @@
 .EXAMPLE
     Get-NBDCIMRackRole
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/DCIM/RackTypes/Get-NBDCIMRackType.ps1
+++ b/Functions/DCIM/RackTypes/Get-NBDCIMRackType.ps1
@@ -61,6 +61,9 @@ function Get-NBDCIMRackType {
         [switch]$Raw
     )
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving DCIM Rack Type"
         switch ($PSCmdlet.ParameterSetName) {
             'ByID' { foreach ($i in $Id) { InvokeNetboxRequest -URI (BuildNewURI -Segments @('dcim','rack-types',$i)) -Raw:$Raw } }

--- a/Functions/DCIM/RackTypes/Get-NBDCIMRackType.ps1
+++ b/Functions/DCIM/RackTypes/Get-NBDCIMRackType.ps1
@@ -31,6 +31,8 @@
 .EXAMPLE
     Get-NBDCIMRackType
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/DCIM/Racks/Get-NBDCIMRack.ps1
+++ b/Functions/DCIM/Racks/Get-NBDCIMRack.ps1
@@ -85,6 +85,8 @@ function Get-NBDCIMRack {
         Get-NBDCIMRack -Name "Rack-01"
 
         Returns racks matching the name "Rack-01"
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 #>
 
     [CmdletBinding(DefaultParameterSetName = 'Query')]

--- a/Functions/DCIM/Racks/Get-NBDCIMRack.ps1
+++ b/Functions/DCIM/Racks/Get-NBDCIMRack.ps1
@@ -150,6 +150,9 @@ function Get-NBDCIMRack {
     )
 
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving DCIM Rack"
         switch ($PSCmdlet.ParameterSetName) {
             'ByID' {

--- a/Functions/DCIM/RearPortTemplates/Get-NBDCIMRearPortTemplate.ps1
+++ b/Functions/DCIM/RearPortTemplates/Get-NBDCIMRearPortTemplate.ps1
@@ -31,6 +31,8 @@
 .EXAMPLE
     Get-NBDCIMRearPortTemplate
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/DCIM/RearPortTemplates/Get-NBDCIMRearPortTemplate.ps1
+++ b/Functions/DCIM/RearPortTemplates/Get-NBDCIMRearPortTemplate.ps1
@@ -62,6 +62,9 @@ function Get-NBDCIMRearPortTemplate {
         [switch]$Raw
     )
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving DCIM Rear Port Template"
         switch ($PSCmdlet.ParameterSetName) {
             'ByID' { foreach ($i in $Id) { InvokeNetboxRequest -URI (BuildNewURI -Segments @('dcim','rear-port-templates',$i)) -Raw:$Raw } }

--- a/Functions/DCIM/RearPorts/Get-NBDCIMRearPort.ps1
+++ b/Functions/DCIM/RearPorts/Get-NBDCIMRearPort.ps1
@@ -31,6 +31,8 @@
 .EXAMPLE
     Get-NBDCIMRearPort
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/DCIM/RearPorts/Get-NBDCIMRearPort.ps1
+++ b/Functions/DCIM/RearPorts/Get-NBDCIMRearPort.ps1
@@ -75,6 +75,9 @@ function Get-NBDCIMRearPort {
     )
 
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving DCIM Rear Port"
         switch ($PSCmdlet.ParameterSetName) {
             'ByID' { foreach ($i in $Id) { InvokeNetboxRequest -URI (BuildNewURI -Segments @('dcim', 'rear-ports', $i)) -Raw:$Raw } }

--- a/Functions/DCIM/Regions/Get-NBDCIMRegion.ps1
+++ b/Functions/DCIM/Regions/Get-NBDCIMRegion.ps1
@@ -108,6 +108,9 @@ function Get-NBDCIMRegion {
     )
 
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving DCIM Region"
         switch ($PSCmdlet.ParameterSetName) {
             'ByID' {

--- a/Functions/DCIM/Regions/Get-NBDCIMRegion.ps1
+++ b/Functions/DCIM/Regions/Get-NBDCIMRegion.ps1
@@ -65,6 +65,8 @@ function Get-NBDCIMRegion {
         Get-NBDCIMRegion -Parent_Id 1
 
         Returns all child regions of region 1
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 #>
 
     [CmdletBinding(DefaultParameterSetName = 'Query')]

--- a/Functions/DCIM/SiteGroups/Get-NBDCIMSiteGroup.ps1
+++ b/Functions/DCIM/SiteGroups/Get-NBDCIMSiteGroup.ps1
@@ -65,6 +65,8 @@ function Get-NBDCIMSiteGroup {
         Get-NBDCIMSiteGroup -Parent_Id 1
 
         Returns all child site groups of site group 1
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 #>
 
     [CmdletBinding(DefaultParameterSetName = 'Query')]

--- a/Functions/DCIM/SiteGroups/Get-NBDCIMSiteGroup.ps1
+++ b/Functions/DCIM/SiteGroups/Get-NBDCIMSiteGroup.ps1
@@ -108,6 +108,9 @@ function Get-NBDCIMSiteGroup {
     )
 
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving DCIM Site Group"
         switch ($PSCmdlet.ParameterSetName) {
             'ByID' {

--- a/Functions/DCIM/Sites/Get-NBDCIMSite.ps1
+++ b/Functions/DCIM/Sites/Get-NBDCIMSite.ps1
@@ -31,6 +31,8 @@
 .EXAMPLE
     Get-NBDCIMSite
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/DCIM/Sites/Get-NBDCIMSite.ps1
+++ b/Functions/DCIM/Sites/Get-NBDCIMSite.ps1
@@ -114,6 +114,9 @@ function Get-NBDCIMSite {
     )
 
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving DCIM Site"
         switch ($PSCmdlet.ParameterSetName) {
             'ById' {

--- a/Functions/DCIM/VirtualChassis/Get-NBDCIMVirtualChassis.ps1
+++ b/Functions/DCIM/VirtualChassis/Get-NBDCIMVirtualChassis.ps1
@@ -64,6 +64,9 @@ function Get-NBDCIMVirtualChassis {
         [switch]$Raw
     )
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving DCIM Virtual Chassis"
         switch ($PSCmdlet.ParameterSetName) {
             'ByID' { foreach ($i in $Id) { InvokeNetboxRequest -URI (BuildNewURI -Segments @('dcim','virtual-chassis',$i)) -Raw:$Raw } }

--- a/Functions/DCIM/VirtualChassis/Get-NBDCIMVirtualChassis.ps1
+++ b/Functions/DCIM/VirtualChassis/Get-NBDCIMVirtualChassis.ps1
@@ -31,6 +31,8 @@
 .EXAMPLE
     Get-NBDCIMVirtualChassis
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/DCIM/VirtualDeviceContexts/Get-NBDCIMVirtualDeviceContext.ps1
+++ b/Functions/DCIM/VirtualDeviceContexts/Get-NBDCIMVirtualDeviceContext.ps1
@@ -31,6 +31,8 @@
 .EXAMPLE
     Get-NBDCIMVirtualDeviceContext
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/DCIM/VirtualDeviceContexts/Get-NBDCIMVirtualDeviceContext.ps1
+++ b/Functions/DCIM/VirtualDeviceContexts/Get-NBDCIMVirtualDeviceContext.ps1
@@ -64,6 +64,9 @@ function Get-NBDCIMVirtualDeviceContext {
         [switch]$Raw
     )
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving DCIM Virtual Device Context"
         switch ($PSCmdlet.ParameterSetName) {
             'ByID' { foreach ($i in $Id) { InvokeNetboxRequest -URI (BuildNewURI -Segments @('dcim','virtual-device-contexts',$i)) -Raw:$Raw } }

--- a/Functions/Extras/Bookmarks/Get-NBBookmark.ps1
+++ b/Functions/Extras/Bookmarks/Get-NBBookmark.ps1
@@ -49,6 +49,8 @@
 .EXAMPLE
     Get-NBBookmark
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/Extras/Bookmarks/Get-NBBookmark.ps1
+++ b/Functions/Extras/Bookmarks/Get-NBBookmark.ps1
@@ -89,6 +89,9 @@ function Get-NBBookmark {
     )
 
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving Bookmark"
         switch ($PSCmdlet.ParameterSetName) {
             'ById' {

--- a/Functions/Extras/ConfigContexts/Get-NBConfigContext.ps1
+++ b/Functions/Extras/ConfigContexts/Get-NBConfigContext.ps1
@@ -49,6 +49,8 @@
 .EXAMPLE
     Get-NBConfigContext
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/Extras/ConfigContexts/Get-NBConfigContext.ps1
+++ b/Functions/Extras/ConfigContexts/Get-NBConfigContext.ps1
@@ -89,6 +89,9 @@ function Get-NBConfigContext {
     )
 
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving Config Context"
         switch ($PSCmdlet.ParameterSetName) {
             'ById' {

--- a/Functions/Extras/CustomFieldChoiceSets/Get-NBCustomFieldChoiceSet.ps1
+++ b/Functions/Extras/CustomFieldChoiceSets/Get-NBCustomFieldChoiceSet.ps1
@@ -83,6 +83,9 @@ function Get-NBCustomFieldChoiceSet {
     )
 
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving Custom Field Choice Set"
         switch ($PSCmdlet.ParameterSetName) {
             'ById' {

--- a/Functions/Extras/CustomFieldChoiceSets/Get-NBCustomFieldChoiceSet.ps1
+++ b/Functions/Extras/CustomFieldChoiceSets/Get-NBCustomFieldChoiceSet.ps1
@@ -46,6 +46,8 @@
 .EXAMPLE
     Get-NBCustomFieldChoiceSet
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/Extras/CustomFields/Get-NBCustomField.ps1
+++ b/Functions/Extras/CustomFields/Get-NBCustomField.ps1
@@ -95,6 +95,9 @@ function Get-NBCustomField {
     )
 
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving Custom Field"
         switch ($PSCmdlet.ParameterSetName) {
             'ById' {

--- a/Functions/Extras/CustomFields/Get-NBCustomField.ps1
+++ b/Functions/Extras/CustomFields/Get-NBCustomField.ps1
@@ -52,6 +52,8 @@
 .EXAMPLE
     Get-NBCustomField
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/Extras/CustomLinks/Get-NBCustomLink.ps1
+++ b/Functions/Extras/CustomLinks/Get-NBCustomLink.ps1
@@ -49,6 +49,8 @@
 .EXAMPLE
     Get-NBCustomLink
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/Extras/CustomLinks/Get-NBCustomLink.ps1
+++ b/Functions/Extras/CustomLinks/Get-NBCustomLink.ps1
@@ -89,6 +89,9 @@ function Get-NBCustomLink {
     )
 
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving Custom Link"
         switch ($PSCmdlet.ParameterSetName) {
             'ById' {

--- a/Functions/Extras/EventRules/Get-NBEventRule.ps1
+++ b/Functions/Extras/EventRules/Get-NBEventRule.ps1
@@ -107,6 +107,9 @@ function Get-NBEventRule {
     )
 
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving Event Rule"
         switch ($PSCmdlet.ParameterSetName) {
             'ById' {

--- a/Functions/Extras/EventRules/Get-NBEventRule.ps1
+++ b/Functions/Extras/EventRules/Get-NBEventRule.ps1
@@ -58,6 +58,8 @@
 .EXAMPLE
     Get-NBEventRule
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/Extras/ExportTemplates/Get-NBExportTemplate.ps1
+++ b/Functions/Extras/ExportTemplates/Get-NBExportTemplate.ps1
@@ -89,6 +89,9 @@ function Get-NBExportTemplate {
     )
 
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving Export Template"
         switch ($PSCmdlet.ParameterSetName) {
             'ById' {

--- a/Functions/Extras/ExportTemplates/Get-NBExportTemplate.ps1
+++ b/Functions/Extras/ExportTemplates/Get-NBExportTemplate.ps1
@@ -49,6 +49,8 @@
 .EXAMPLE
     Get-NBExportTemplate
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/Extras/ImageAttachments/Get-NBImageAttachment.ps1
+++ b/Functions/Extras/ImageAttachments/Get-NBImageAttachment.ps1
@@ -95,6 +95,9 @@ function Get-NBImageAttachment {
     )
 
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving Image Attachment"
         switch ($PSCmdlet.ParameterSetName) {
             'ById' {

--- a/Functions/Extras/ImageAttachments/Get-NBImageAttachment.ps1
+++ b/Functions/Extras/ImageAttachments/Get-NBImageAttachment.ps1
@@ -52,6 +52,8 @@
 .EXAMPLE
     Get-NBImageAttachment
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/Extras/JournalEntries/Get-NBJournalEntry.ps1
+++ b/Functions/Extras/JournalEntries/Get-NBJournalEntry.ps1
@@ -102,6 +102,9 @@ function Get-NBJournalEntry {
     )
 
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving Journal Entry"
         switch ($PSCmdlet.ParameterSetName) {
             'ById' {

--- a/Functions/Extras/JournalEntries/Get-NBJournalEntry.ps1
+++ b/Functions/Extras/JournalEntries/Get-NBJournalEntry.ps1
@@ -55,6 +55,8 @@
 .EXAMPLE
     Get-NBJournalEntry
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/Extras/SavedFilters/Get-NBSavedFilter.ps1
+++ b/Functions/Extras/SavedFilters/Get-NBSavedFilter.ps1
@@ -61,6 +61,8 @@
 .EXAMPLE
     Get-NBSavedFilter
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/Extras/SavedFilters/Get-NBSavedFilter.ps1
+++ b/Functions/Extras/SavedFilters/Get-NBSavedFilter.ps1
@@ -113,6 +113,9 @@ function Get-NBSavedFilter {
     )
 
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving Saved Filter"
         switch ($PSCmdlet.ParameterSetName) {
             'ById' {

--- a/Functions/Extras/Tags/Get-NBTag.ps1
+++ b/Functions/Extras/Tags/Get-NBTag.ps1
@@ -69,6 +69,9 @@ function Get-NBTag {
     )
 
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving Tag"
         switch ($PSCmdlet.ParameterSetName) {
             'ByID' { foreach ($i in $Id) { InvokeNetboxRequest -URI (BuildNewURI -Segments @('extras', 'tags', $i)) -Raw:$Raw } }

--- a/Functions/Extras/Tags/Get-NBTag.ps1
+++ b/Functions/Extras/Tags/Get-NBTag.ps1
@@ -31,6 +31,8 @@
 .EXAMPLE
     Get-NBTag
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/Extras/Webhooks/Get-NBWebhook.ps1
+++ b/Functions/Extras/Webhooks/Get-NBWebhook.ps1
@@ -49,6 +49,8 @@
 .EXAMPLE
     Get-NBWebhook
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/Extras/Webhooks/Get-NBWebhook.ps1
+++ b/Functions/Extras/Webhooks/Get-NBWebhook.ps1
@@ -89,6 +89,9 @@ function Get-NBWebhook {
     )
 
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving Webhook"
         switch ($PSCmdlet.ParameterSetName) {
             'ById' {

--- a/Functions/IPAM/ASN/Get-NBIPAMASN.ps1
+++ b/Functions/IPAM/ASN/Get-NBIPAMASN.ps1
@@ -62,6 +62,8 @@ function Get-NBIPAMASN {
         Get-NBIPAMASN -ASN 65001
 
         Returns ASN 65001
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 #>
 
     [CmdletBinding(DefaultParameterSetName = 'Query')]

--- a/Functions/IPAM/ASN/Get-NBIPAMASN.ps1
+++ b/Functions/IPAM/ASN/Get-NBIPAMASN.ps1
@@ -108,6 +108,9 @@ function Get-NBIPAMASN {
     )
 
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving IPAM ASN"
         switch ($PSCmdlet.ParameterSetName) {
             'ByID' {

--- a/Functions/IPAM/ASNRange/Get-NBIPAMASNRange.ps1
+++ b/Functions/IPAM/ASNRange/Get-NBIPAMASNRange.ps1
@@ -59,6 +59,8 @@ function Get-NBIPAMASNRange {
         Get-NBIPAMASNRange -Name "Private"
 
         Returns ASN ranges matching the name "Private"
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 #>
 
     [CmdletBinding(DefaultParameterSetName = 'Query')]

--- a/Functions/IPAM/ASNRange/Get-NBIPAMASNRange.ps1
+++ b/Functions/IPAM/ASNRange/Get-NBIPAMASNRange.ps1
@@ -102,6 +102,9 @@ function Get-NBIPAMASNRange {
     )
 
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving IPAM ASN Range"
         switch ($PSCmdlet.ParameterSetName) {
             'ByID' {

--- a/Functions/IPAM/Address/Get-NBIPAMAddress.ps1
+++ b/Functions/IPAM/Address/Get-NBIPAMAddress.ps1
@@ -35,6 +35,8 @@
     Get-NBIPAMAddress -Omit 'comments','description'
     Returns addresses without comments and description fields (Netbox 4.5+).
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/IPAM/Aggregate/Get-NBIPAMAggregate.ps1
+++ b/Functions/IPAM/Aggregate/Get-NBIPAMAggregate.ps1
@@ -31,6 +31,8 @@
 .EXAMPLE
     Get-NBIPAMAggregate
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/IPAM/Aggregate/Get-NBIPAMAggregate.ps1
+++ b/Functions/IPAM/Aggregate/Get-NBIPAMAggregate.ps1
@@ -81,7 +81,11 @@ function Get-NBIPAMAggregate {
         [switch]$Raw
     )
 
-process {
+    process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
+
         Write-Verbose "Retrieving IPAM Aggregate"
 
         switch ($PSCmdlet.ParameterSetName) {

--- a/Functions/IPAM/FHRPGroup/Get-NBIPAMFHRPGroup.ps1
+++ b/Functions/IPAM/FHRPGroup/Get-NBIPAMFHRPGroup.ps1
@@ -31,6 +31,8 @@
 .EXAMPLE
     Get-NBIPAMFHRPGroup
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/IPAM/FHRPGroup/Get-NBIPAMFHRPGroup.ps1
+++ b/Functions/IPAM/FHRPGroup/Get-NBIPAMFHRPGroup.ps1
@@ -61,6 +61,9 @@ function Get-NBIPAMFHRPGroup {
         [switch]$Raw
     )
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving IPAM FHRP Group"
         switch ($PSCmdlet.ParameterSetName) {
             'ByID' {

--- a/Functions/IPAM/FHRPGroupAssignment/Get-NBIPAMFHRPGroupAssignment.ps1
+++ b/Functions/IPAM/FHRPGroupAssignment/Get-NBIPAMFHRPGroupAssignment.ps1
@@ -61,6 +61,9 @@ function Get-NBIPAMFHRPGroupAssignment {
         [switch]$Raw
     )
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving IPAM FHRP Group Assignment"
         switch ($PSCmdlet.ParameterSetName) {
             'ByID' {

--- a/Functions/IPAM/FHRPGroupAssignment/Get-NBIPAMFHRPGroupAssignment.ps1
+++ b/Functions/IPAM/FHRPGroupAssignment/Get-NBIPAMFHRPGroupAssignment.ps1
@@ -31,6 +31,8 @@
 .EXAMPLE
     Get-NBIPAMFHRPGroupAssignment
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/IPAM/Prefix/Get-NBIPAMPrefix.ps1
+++ b/Functions/IPAM/Prefix/Get-NBIPAMPrefix.ps1
@@ -100,6 +100,8 @@ function Get-NBIPAMPrefix {
     .EXAMPLE
         PS C:\> Get-NBIPAMPrefix -Omit 'description','comments'
         Returns prefixes without description and comments fields (Netbox 4.5+).
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 #>
 
     [CmdletBinding(DefaultParameterSetName = 'Query')]

--- a/Functions/IPAM/Prefix/Get-NBIPAMPrefix.ps1
+++ b/Functions/IPAM/Prefix/Get-NBIPAMPrefix.ps1
@@ -193,6 +193,9 @@ function Get-NBIPAMPrefix {
     )
 
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving IPAM Prefix"
 
         switch ($PSCmdlet.ParameterSetName) {

--- a/Functions/IPAM/RIR/Get-NBIPAMRIR.ps1
+++ b/Functions/IPAM/RIR/Get-NBIPAMRIR.ps1
@@ -31,6 +31,8 @@
 .EXAMPLE
     Get-NBIPAMRIR
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/IPAM/RIR/Get-NBIPAMRIR.ps1
+++ b/Functions/IPAM/RIR/Get-NBIPAMRIR.ps1
@@ -61,6 +61,9 @@ function Get-NBIPAMRIR {
         [switch]$Raw
     )
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving IPAM RIR"
         switch ($PSCmdlet.ParameterSetName) {
             'ByID' {

--- a/Functions/IPAM/Range/Get-NBIPAMAddressRange.ps1
+++ b/Functions/IPAM/Range/Get-NBIPAMAddressRange.ps1
@@ -31,6 +31,8 @@
 .EXAMPLE
     Get-NBIPAMAddressRange
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/IPAM/Range/Get-NBIPAMAddressRange.ps1
+++ b/Functions/IPAM/Range/Get-NBIPAMAddressRange.ps1
@@ -102,6 +102,9 @@ function Get-NBIPAMAddressRange {
     )
 
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving IPAM Address Range"
         switch ($PSCmdlet.ParameterSetName) {
         'ById' {

--- a/Functions/IPAM/Role/Get-NBIPAMRole.ps1
+++ b/Functions/IPAM/Role/Get-NBIPAMRole.ps1
@@ -90,6 +90,9 @@ function Get-NBIPAMRole {
     )
 
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving IPAM Role"
         switch ($PSCmdlet.ParameterSetName) {
         'ById' {

--- a/Functions/IPAM/Role/Get-NBIPAMRole.ps1
+++ b/Functions/IPAM/Role/Get-NBIPAMRole.ps1
@@ -50,6 +50,8 @@ function Get-NBIPAMRole {
     .EXAMPLE
         PS C:\> Get-NBIPAMRole
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 #>
 
     [CmdletBinding(DefaultParameterSetName = 'Query')]

--- a/Functions/IPAM/RouteTarget/Get-NBIPAMRouteTarget.ps1
+++ b/Functions/IPAM/RouteTarget/Get-NBIPAMRouteTarget.ps1
@@ -66,6 +66,8 @@ function Get-NBIPAMRouteTarget {
         Get-NBIPAMRouteTarget -Name "65001:100"
 
         Returns route targets matching the specified value
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 #>
 
     [CmdletBinding(DefaultParameterSetName = 'Query')]

--- a/Functions/IPAM/RouteTarget/Get-NBIPAMRouteTarget.ps1
+++ b/Functions/IPAM/RouteTarget/Get-NBIPAMRouteTarget.ps1
@@ -115,6 +115,9 @@ function Get-NBIPAMRouteTarget {
     )
 
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving IPAM Route Target"
         switch ($PSCmdlet.ParameterSetName) {
             'ByID' {

--- a/Functions/IPAM/Service/Get-NBIPAMService.ps1
+++ b/Functions/IPAM/Service/Get-NBIPAMService.ps1
@@ -116,6 +116,9 @@ function Get-NBIPAMService {
     )
 
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving IPAM Service"
         switch ($PSCmdlet.ParameterSetName) {
             'ByID' {

--- a/Functions/IPAM/Service/Get-NBIPAMService.ps1
+++ b/Functions/IPAM/Service/Get-NBIPAMService.ps1
@@ -66,6 +66,8 @@ function Get-NBIPAMService {
         Get-NBIPAMService -Protocol tcp -Port 443
 
         Returns TCP services on port 443
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 #>
 
     [CmdletBinding(DefaultParameterSetName = 'Query')]

--- a/Functions/IPAM/ServiceTemplate/Get-NBIPAMServiceTemplate.ps1
+++ b/Functions/IPAM/ServiceTemplate/Get-NBIPAMServiceTemplate.ps1
@@ -60,6 +60,8 @@ function Get-NBIPAMServiceTemplate {
         Get-NBIPAMServiceTemplate -Name "HTTP"
 
         Returns service templates matching the name "HTTP"
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 #>
 
     [CmdletBinding(DefaultParameterSetName = 'Query')]

--- a/Functions/IPAM/ServiceTemplate/Get-NBIPAMServiceTemplate.ps1
+++ b/Functions/IPAM/ServiceTemplate/Get-NBIPAMServiceTemplate.ps1
@@ -104,6 +104,9 @@ function Get-NBIPAMServiceTemplate {
     )
 
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving IPAM Service Template"
         switch ($PSCmdlet.ParameterSetName) {
             'ByID' {

--- a/Functions/IPAM/VLAN/Get-NBIPAMVLAN.ps1
+++ b/Functions/IPAM/VLAN/Get-NBIPAMVLAN.ps1
@@ -31,6 +31,8 @@
 .EXAMPLE
     Get-NBIPAMVLAN
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/IPAM/VLAN/Get-NBIPAMVLAN.ps1
+++ b/Functions/IPAM/VLAN/Get-NBIPAMVLAN.ps1
@@ -111,6 +111,9 @@ function Get-NBIPAMVLAN {
     )
 
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving IPAM VLAN"
         switch ($PSCmdlet.ParameterSetName) {
         'ById' {

--- a/Functions/IPAM/VLANGroup/Get-NBIPAMVLANGroup.ps1
+++ b/Functions/IPAM/VLANGroup/Get-NBIPAMVLANGroup.ps1
@@ -31,6 +31,8 @@
 .EXAMPLE
     Get-NBIPAMVLANGroup
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/IPAM/VLANGroup/Get-NBIPAMVLANGroup.ps1
+++ b/Functions/IPAM/VLANGroup/Get-NBIPAMVLANGroup.ps1
@@ -64,6 +64,9 @@ function Get-NBIPAMVLANGroup {
         [switch]$Raw
     )
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving IPAM VLAN Group"
         switch ($PSCmdlet.ParameterSetName) {
             'ByID' {

--- a/Functions/IPAM/VLANTranslationPolicy/Get-NBIPAMVLANTranslationPolicy.ps1
+++ b/Functions/IPAM/VLANTranslationPolicy/Get-NBIPAMVLANTranslationPolicy.ps1
@@ -59,6 +59,9 @@ function Get-NBIPAMVLANTranslationPolicy {
         [switch]$Raw
     )
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving IPAM VLAN Translation Policy"
         switch ($PSCmdlet.ParameterSetName) {
             'ByID' {

--- a/Functions/IPAM/VLANTranslationPolicy/Get-NBIPAMVLANTranslationPolicy.ps1
+++ b/Functions/IPAM/VLANTranslationPolicy/Get-NBIPAMVLANTranslationPolicy.ps1
@@ -31,6 +31,8 @@
 .EXAMPLE
     Get-NBIPAMVLANTranslationPolicy
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/IPAM/VLANTranslationRule/Get-NBIPAMVLANTranslationRule.ps1
+++ b/Functions/IPAM/VLANTranslationRule/Get-NBIPAMVLANTranslationRule.ps1
@@ -60,6 +60,9 @@ function Get-NBIPAMVLANTranslationRule {
         [switch]$Raw
     )
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving IPAM VLAN Translation Rule"
         switch ($PSCmdlet.ParameterSetName) {
             'ByID' {

--- a/Functions/IPAM/VLANTranslationRule/Get-NBIPAMVLANTranslationRule.ps1
+++ b/Functions/IPAM/VLANTranslationRule/Get-NBIPAMVLANTranslationRule.ps1
@@ -31,6 +31,8 @@
 .EXAMPLE
     Get-NBIPAMVLANTranslationRule
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/IPAM/VRF/Get-NBIPAMVRF.ps1
+++ b/Functions/IPAM/VRF/Get-NBIPAMVRF.ps1
@@ -119,6 +119,9 @@ function Get-NBIPAMVRF {
     )
 
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving IPAM VRF"
         switch ($PSCmdlet.ParameterSetName) {
             'ByID' {

--- a/Functions/IPAM/VRF/Get-NBIPAMVRF.ps1
+++ b/Functions/IPAM/VRF/Get-NBIPAMVRF.ps1
@@ -70,6 +70,8 @@ function Get-NBIPAMVRF {
         Get-NBIPAMVRF -RD "65001:100"
 
         Returns VRFs with the specified route distinguisher
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 #>
 
     [CmdletBinding(DefaultParameterSetName = 'Query')]

--- a/Functions/Plugins/Branching/Branch/Get-NBBranch.ps1
+++ b/Functions/Plugins/Branching/Branch/Get-NBBranch.ps1
@@ -71,6 +71,8 @@
     Get-NBBranch -Status "ready"
     Get all ready branches.
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     New-NBBranch
     Set-NBBranch

--- a/Functions/Plugins/Branching/Branch/Get-NBBranch.ps1
+++ b/Functions/Plugins/Branching/Branch/Get-NBBranch.ps1
@@ -121,6 +121,9 @@ function Get-NBBranch {
     )
 
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving Branch"
         CheckNetboxIsConnected
 

--- a/Functions/Plugins/Branching/BranchEvent/Get-NBBranchEvent.ps1
+++ b/Functions/Plugins/Branching/BranchEvent/Get-NBBranchEvent.ps1
@@ -88,6 +88,9 @@ function Get-NBBranchEvent {
     )
 
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving Branch Event"
         CheckNetboxIsConnected
 

--- a/Functions/Plugins/Branching/BranchEvent/Get-NBBranchEvent.ps1
+++ b/Functions/Plugins/Branching/BranchEvent/Get-NBBranchEvent.ps1
@@ -54,6 +54,8 @@
     Get-NBBranchEvent -Id 10
     Get specific event by ID.
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     Get-NBBranch
 #>

--- a/Functions/Plugins/Branching/ChangeDiff/Get-NBChangeDiff.ps1
+++ b/Functions/Plugins/Branching/ChangeDiff/Get-NBChangeDiff.ps1
@@ -102,6 +102,9 @@ function Get-NBChangeDiff {
     )
 
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving Change Diff"
         CheckNetboxIsConnected
 

--- a/Functions/Plugins/Branching/ChangeDiff/Get-NBChangeDiff.ps1
+++ b/Functions/Plugins/Branching/ChangeDiff/Get-NBChangeDiff.ps1
@@ -60,6 +60,8 @@
     Get-NBChangeDiff -Branch_Id 1 | Where-Object { $_.conflicts }
     Get conflicting changes in branch.
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     Get-NBBranch
     Merge-NBBranch

--- a/Functions/Setup/Support/Get-NBContentType.ps1
+++ b/Functions/Setup/Support/Get-NBContentType.ps1
@@ -99,6 +99,12 @@ function Get-NBContentType {
         [switch]$Raw
     )
 
-    # Delegate to Get-NBObjectType (the canonical function)
-    Get-NBObjectType @PSBoundParameters
+    process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
+
+        # Delegate to Get-NBObjectType (the canonical function)
+        Get-NBObjectType @PSBoundParameters
+    }
 }

--- a/Functions/Setup/Support/Get-NBContentType.ps1
+++ b/Functions/Setup/Support/Get-NBContentType.ps1
@@ -60,6 +60,7 @@ function Get-NBContentType {
     .NOTES
         This function delegates to Get-NBObjectType.
         Backward compatible with Netbox 4.0+
+        The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 #>
 
     [CmdletBinding(DefaultParameterSetName = 'Query')]

--- a/Functions/Tenancy/ContactAssignment/Get-NBContactAssignment.ps1
+++ b/Functions/Tenancy/ContactAssignment/Get-NBContactAssignment.ps1
@@ -110,6 +110,9 @@ function Get-NBContactAssignment {
     )
 
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving Contact Assignment"
         switch ($PSCmdlet.ParameterSetName) {
         'ById' {

--- a/Functions/Tenancy/ContactAssignment/Get-NBContactAssignment.ps1
+++ b/Functions/Tenancy/ContactAssignment/Get-NBContactAssignment.ps1
@@ -61,6 +61,8 @@ function Get-NBContactAssignment {
     .EXAMPLE
         PS C:\> Get-NBContactAssignment
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 #>
 
     [CmdletBinding(DefaultParameterSetName = 'Query')]

--- a/Functions/Tenancy/ContactRoles/Get-NBContactRole.ps1
+++ b/Functions/Tenancy/ContactRoles/Get-NBContactRole.ps1
@@ -49,6 +49,8 @@ function Get-NBContactRole {
     .EXAMPLE
         PS C:\> Get-NBContactRole
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 #>
 
     [CmdletBinding(DefaultParameterSetName = 'Query')]

--- a/Functions/Tenancy/ContactRoles/Get-NBContactRole.ps1
+++ b/Functions/Tenancy/ContactRoles/Get-NBContactRole.ps1
@@ -92,6 +92,9 @@ function Get-NBContactRole {
     )
 
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving Contact Role"
         switch ($PSCmdlet.ParameterSetName) {
         'ById' {

--- a/Functions/Tenancy/Contacts/Get-NBContact.ps1
+++ b/Functions/Tenancy/Contacts/Get-NBContact.ps1
@@ -66,6 +66,8 @@ function Get-NBContact {
     .EXAMPLE
         PS C:\> Get-NBContact
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 #>
 
     [CmdletBinding(DefaultParameterSetName = 'Query')]

--- a/Functions/Tenancy/Contacts/Get-NBContact.ps1
+++ b/Functions/Tenancy/Contacts/Get-NBContact.ps1
@@ -121,6 +121,9 @@ function Get-NBContact {
     )
 
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving Contact"
         switch ($PSCmdlet.ParameterSetName) {
         'ById' {

--- a/Functions/Tenancy/TenantGroups/Get-NBTenantGroup.ps1
+++ b/Functions/Tenancy/TenantGroups/Get-NBTenantGroup.ps1
@@ -68,6 +68,8 @@
 
     Returns the tenant group with ID 1.
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/models/tenancy/tenantgroup/
 #>

--- a/Functions/Tenancy/TenantGroups/Get-NBTenantGroup.ps1
+++ b/Functions/Tenancy/TenantGroups/Get-NBTenantGroup.ps1
@@ -116,6 +116,9 @@ function Get-NBTenantGroup {
     )
 
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving Tenant Group"
         switch ($PSCmdlet.ParameterSetName) {
             'ByID' { foreach ($i in $Id) { InvokeNetboxRequest -URI (BuildNewURI -Segments @('tenancy', 'tenant-groups', $i)) -Raw:$Raw } }

--- a/Functions/Tenancy/Tenants/Get-NBTenant.ps1
+++ b/Functions/Tenancy/Tenants/Get-NBTenant.ps1
@@ -61,6 +61,8 @@ function Get-NBTenant {
     .EXAMPLE
         PS C:\> Get-NBTenant
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 #>
 
     [CmdletBinding(DefaultParameterSetName = 'Query')]

--- a/Functions/Tenancy/Tenants/Get-NBTenant.ps1
+++ b/Functions/Tenancy/Tenants/Get-NBTenant.ps1
@@ -111,6 +111,9 @@ function Get-NBTenant {
     )
 
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving Tenant"
         switch ($PSCmdlet.ParameterSetName) {
         'ById' {

--- a/Functions/Users/Groups/Get-NBGroup.ps1
+++ b/Functions/Users/Groups/Get-NBGroup.ps1
@@ -83,6 +83,9 @@ function Get-NBGroup {
     )
 
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving Group"
         switch ($PSCmdlet.ParameterSetName) {
             'ById' {

--- a/Functions/Users/Groups/Get-NBGroup.ps1
+++ b/Functions/Users/Groups/Get-NBGroup.ps1
@@ -46,6 +46,8 @@
 .EXAMPLE
     Get-NBGroup
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/Users/OwnerGroups/Get-NBOwnerGroup.ps1
+++ b/Functions/Users/OwnerGroups/Get-NBOwnerGroup.ps1
@@ -52,6 +52,8 @@
 .EXAMPLE
     Get-NBOwnerGroup -Id 5
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/Users/OwnerGroups/Get-NBOwnerGroup.ps1
+++ b/Functions/Users/OwnerGroups/Get-NBOwnerGroup.ps1
@@ -89,6 +89,9 @@ function Get-NBOwnerGroup {
     )
 
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving Owner Group"
         switch ($PSCmdlet.ParameterSetName) {
             'ById' {

--- a/Functions/Users/Owners/Get-NBOwner.ps1
+++ b/Functions/Users/Owners/Get-NBOwner.ps1
@@ -104,6 +104,9 @@ function Get-NBOwner {
     )
 
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving Owner"
         switch ($PSCmdlet.ParameterSetName) {
             'ById' {

--- a/Functions/Users/Owners/Get-NBOwner.ps1
+++ b/Functions/Users/Owners/Get-NBOwner.ps1
@@ -61,6 +61,8 @@
 .EXAMPLE
     Get-NBOwner -Group_Id 2
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/Users/Permissions/Get-NBPermission.ps1
+++ b/Functions/Users/Permissions/Get-NBPermission.ps1
@@ -58,6 +58,8 @@
 .EXAMPLE
     Get-NBPermission
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/Users/Permissions/Get-NBPermission.ps1
+++ b/Functions/Users/Permissions/Get-NBPermission.ps1
@@ -107,6 +107,9 @@ function Get-NBPermission {
     )
 
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving Permission"
         switch ($PSCmdlet.ParameterSetName) {
             'ById' {

--- a/Functions/Users/Tokens/Get-NBToken.ps1
+++ b/Functions/Users/Tokens/Get-NBToken.ps1
@@ -95,6 +95,9 @@ function Get-NBToken {
     )
 
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving Token"
         switch ($PSCmdlet.ParameterSetName) {
             'ById' {

--- a/Functions/Users/Tokens/Get-NBToken.ps1
+++ b/Functions/Users/Tokens/Get-NBToken.ps1
@@ -52,6 +52,8 @@
 .EXAMPLE
     Get-NBToken
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/Users/Users/Get-NBUser.ps1
+++ b/Functions/Users/Users/Get-NBUser.ps1
@@ -128,6 +128,9 @@ function Get-NBUser {
     )
 
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving User"
         switch ($PSCmdlet.ParameterSetName) {
             'ById' {

--- a/Functions/Users/Users/Get-NBUser.ps1
+++ b/Functions/Users/Users/Get-NBUser.ps1
@@ -70,6 +70,8 @@
 .EXAMPLE
     Get-NBUser -Username "admin"
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/VPN/IKEPolicy/Get-NBVPNIKEPolicy.ps1
+++ b/Functions/VPN/IKEPolicy/Get-NBVPNIKEPolicy.ps1
@@ -31,6 +31,8 @@
 .EXAMPLE
     Get-NBVPNIKEPolicy
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/VPN/IKEPolicy/Get-NBVPNIKEPolicy.ps1
+++ b/Functions/VPN/IKEPolicy/Get-NBVPNIKEPolicy.ps1
@@ -65,6 +65,9 @@ function Get-NBVPNIKEPolicy {
     )
 
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving VPN IKE Policy"
 
         switch ($PSCmdlet.ParameterSetName) {

--- a/Functions/VPN/IKEProposal/Get-NBVPNIKEProposal.ps1
+++ b/Functions/VPN/IKEProposal/Get-NBVPNIKEProposal.ps1
@@ -31,6 +31,8 @@
 .EXAMPLE
     Get-NBVPNIKEProposal
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/VPN/IKEProposal/Get-NBVPNIKEProposal.ps1
+++ b/Functions/VPN/IKEProposal/Get-NBVPNIKEProposal.ps1
@@ -65,6 +65,9 @@ function Get-NBVPNIKEProposal {
     )
 
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving VPN IKE Proposal"
 
         switch ($PSCmdlet.ParameterSetName) {

--- a/Functions/VPN/IPSecPolicy/Get-NBVPNIPSecPolicy.ps1
+++ b/Functions/VPN/IPSecPolicy/Get-NBVPNIPSecPolicy.ps1
@@ -31,6 +31,8 @@
 .EXAMPLE
     Get-NBVPNIPSecPolicy
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/VPN/IPSecPolicy/Get-NBVPNIPSecPolicy.ps1
+++ b/Functions/VPN/IPSecPolicy/Get-NBVPNIPSecPolicy.ps1
@@ -65,6 +65,9 @@ function Get-NBVPNIPSecPolicy {
     )
 
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving VPN IPSec Policy"
 
         switch ($PSCmdlet.ParameterSetName) {

--- a/Functions/VPN/IPSecProfile/Get-NBVPNIPSecProfile.ps1
+++ b/Functions/VPN/IPSecProfile/Get-NBVPNIPSecProfile.ps1
@@ -65,6 +65,9 @@ function Get-NBVPNIPSecProfile {
     )
 
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving VPN IPSec Profile"
 
         switch ($PSCmdlet.ParameterSetName) {

--- a/Functions/VPN/IPSecProfile/Get-NBVPNIPSecProfile.ps1
+++ b/Functions/VPN/IPSecProfile/Get-NBVPNIPSecProfile.ps1
@@ -31,6 +31,8 @@
 .EXAMPLE
     Get-NBVPNIPSecProfile
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/VPN/IPSecProposal/Get-NBVPNIPSecProposal.ps1
+++ b/Functions/VPN/IPSecProposal/Get-NBVPNIPSecProposal.ps1
@@ -65,6 +65,9 @@ function Get-NBVPNIPSecProposal {
     )
 
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving VPN IPSec Proposal"
 
         switch ($PSCmdlet.ParameterSetName) {

--- a/Functions/VPN/IPSecProposal/Get-NBVPNIPSecProposal.ps1
+++ b/Functions/VPN/IPSecProposal/Get-NBVPNIPSecProposal.ps1
@@ -31,6 +31,8 @@
 .EXAMPLE
     Get-NBVPNIPSecProposal
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/VPN/L2VPN/Get-NBVPNL2VPN.ps1
+++ b/Functions/VPN/L2VPN/Get-NBVPNL2VPN.ps1
@@ -74,6 +74,9 @@ function Get-NBVPNL2VPN {
     )
 
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving VPN L2VPN"
 
         switch ($PSCmdlet.ParameterSetName) {

--- a/Functions/VPN/L2VPN/Get-NBVPNL2VPN.ps1
+++ b/Functions/VPN/L2VPN/Get-NBVPNL2VPN.ps1
@@ -31,6 +31,8 @@
 .EXAMPLE
     Get-NBVPNL2VPN
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/VPN/L2VPNTermination/Get-NBVPNL2VPNTermination.ps1
+++ b/Functions/VPN/L2VPNTermination/Get-NBVPNL2VPNTermination.ps1
@@ -31,6 +31,8 @@
 .EXAMPLE
     Get-NBVPNL2VPNTermination
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/VPN/L2VPNTermination/Get-NBVPNL2VPNTermination.ps1
+++ b/Functions/VPN/L2VPNTermination/Get-NBVPNL2VPNTermination.ps1
@@ -65,6 +65,9 @@ function Get-NBVPNL2VPNTermination {
     )
 
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving VPN L2VPN Termination"
 
         switch ($PSCmdlet.ParameterSetName) {

--- a/Functions/VPN/Tunnel/Get-NBVPNTunnel.ps1
+++ b/Functions/VPN/Tunnel/Get-NBVPNTunnel.ps1
@@ -31,6 +31,8 @@
 .EXAMPLE
     Get-NBVPNTunnel
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/VPN/TunnelGroup/Get-NBVPNTunnelGroup.ps1
+++ b/Functions/VPN/TunnelGroup/Get-NBVPNTunnelGroup.ps1
@@ -68,6 +68,9 @@ function Get-NBVPNTunnelGroup {
     )
 
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving VPN Tunnel Group"
 
         switch ($PSCmdlet.ParameterSetName) {

--- a/Functions/VPN/TunnelGroup/Get-NBVPNTunnelGroup.ps1
+++ b/Functions/VPN/TunnelGroup/Get-NBVPNTunnelGroup.ps1
@@ -31,6 +31,8 @@
 .EXAMPLE
     Get-NBVPNTunnelGroup
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/VPN/TunnelTermination/Get-NBVPNTunnelTermination.ps1
+++ b/Functions/VPN/TunnelTermination/Get-NBVPNTunnelTermination.ps1
@@ -68,6 +68,9 @@ function Get-NBVPNTunnelTermination {
     )
 
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving VPN Tunnel Termination"
 
         switch ($PSCmdlet.ParameterSetName) {

--- a/Functions/VPN/TunnelTermination/Get-NBVPNTunnelTermination.ps1
+++ b/Functions/VPN/TunnelTermination/Get-NBVPNTunnelTermination.ps1
@@ -31,6 +31,8 @@
 .EXAMPLE
     Get-NBVPNTunnelTermination
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/Virtualization/VirtualMachine/Get-NBVirtualMachine.ps1
+++ b/Functions/Virtualization/VirtualMachine/Get-NBVirtualMachine.ps1
@@ -195,14 +195,24 @@ function Get-NBVirtualMachine {
     )
 
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
+
         Write-Verbose "Retrieving Virtual Machine"
 
-        # Build omit list: add config_context unless explicitly included
+        # Auto-omit config_context only when the user has not otherwise
+        # restricted the projection. -Brief returns a minimal representation
+        # (config_context is never included). -Fields explicitly selects the
+        # returned shape, so the user owns that choice.
+        $inProjectionMode = $PSBoundParameters.ContainsKey('Brief') -or
+                            $PSBoundParameters.ContainsKey('Fields')
+
         $omitFields = @()
         if ($PSBoundParameters.ContainsKey('Omit')) {
             $omitFields += $Omit
         }
-        if (-not $IncludeConfigContext) {
+        if (-not $IncludeConfigContext -and -not $inProjectionMode) {
             $omitFields += 'config_context'
         }
 

--- a/Functions/Virtualization/VirtualMachineInterface/Get-NBVirtualMachineInterface.ps1
+++ b/Functions/Virtualization/VirtualMachineInterface/Get-NBVirtualMachineInterface.ps1
@@ -110,6 +110,9 @@ function Get-NBVirtualMachineInterface {
     )
 
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving Virtual Machine Interface"
         switch ($PSCmdlet.ParameterSetName) {
             'ByID' { foreach ($i in $Id) { InvokeNetboxRequest -URI (BuildNewURI -Segments @('virtualization', 'interfaces', $i)) -Raw:$Raw } }

--- a/Functions/Virtualization/VirtualizationCluster/Get-NBVirtualizationCluster.ps1
+++ b/Functions/Virtualization/VirtualizationCluster/Get-NBVirtualizationCluster.ps1
@@ -120,6 +120,9 @@ function Get-NBVirtualizationCluster {
     )
 
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving Virtualization Cluster"
         switch ($PSCmdlet.ParameterSetName) {
             'ByID' { foreach ($i in $Id) { InvokeNetboxRequest -URI (BuildNewURI -Segments @('virtualization', 'clusters', $i)) -Raw:$Raw } }

--- a/Functions/Virtualization/VirtualizationCluster/Get-NBVirtualizationCluster.ps1
+++ b/Functions/Virtualization/VirtualizationCluster/Get-NBVirtualizationCluster.ps1
@@ -65,6 +65,8 @@ function Get-NBVirtualizationCluster {
 
     .EXAMPLE
         PS C:\> Get-NBVirtualizationCluster
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 #>
 
     [CmdletBinding(DefaultParameterSetName = 'Query')]

--- a/Functions/Virtualization/VirtualizationCluster/Get-NBVirtualizationClusterGroup.ps1
+++ b/Functions/Virtualization/VirtualizationCluster/Get-NBVirtualizationClusterGroup.ps1
@@ -31,6 +31,8 @@
 .EXAMPLE
     Get-NBVirtualizationClusterGroup
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/Virtualization/VirtualizationCluster/Get-NBVirtualizationClusterGroup.ps1
+++ b/Functions/Virtualization/VirtualizationCluster/Get-NBVirtualizationClusterGroup.ps1
@@ -75,6 +75,9 @@ function Get-NBVirtualizationClusterGroup {
     )
 
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving Virtualization Cluster Group"
         switch ($PSCmdlet.ParameterSetName) {
             'ByID' { foreach ($i in $Id) { InvokeNetboxRequest -URI (BuildNewURI -Segments @('virtualization', 'cluster-groups', $i)) -Raw:$Raw } }

--- a/Functions/Virtualization/VirtualizationClusterType/Get-NBVirtualizationClusterType.ps1
+++ b/Functions/Virtualization/VirtualizationClusterType/Get-NBVirtualizationClusterType.ps1
@@ -110,6 +110,9 @@ function Get-NBVirtualizationClusterType {
     )
 
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving Virtualization Cluster Type"
         switch ($PSCmdlet.ParameterSetName) {
             'ByID' { foreach ($i in $Id) { InvokeNetboxRequest -URI (BuildNewURI -Segments @('virtualization', 'cluster-types', $i)) -Raw:$Raw } }

--- a/Functions/Virtualization/VirtualizationClusterType/Get-NBVirtualizationClusterType.ps1
+++ b/Functions/Virtualization/VirtualizationClusterType/Get-NBVirtualizationClusterType.ps1
@@ -65,6 +65,8 @@
 
     Returns the cluster type with ID 1.
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/models/virtualization/clustertype/
 #>

--- a/Functions/Wireless/WirelessLAN/Get-NBWirelessLAN.ps1
+++ b/Functions/Wireless/WirelessLAN/Get-NBWirelessLAN.ps1
@@ -31,6 +31,8 @@
 .EXAMPLE
     Get-NBWirelessLAN
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/Wireless/WirelessLAN/Get-NBWirelessLAN.ps1
+++ b/Functions/Wireless/WirelessLAN/Get-NBWirelessLAN.ps1
@@ -56,6 +56,9 @@ function Get-NBWirelessLAN {
         [uint16]$Limit,[ValidateRange(0, [int]::MaxValue)]
         [uint16]$Offset,[switch]$Raw)
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving Wireless LAN"
         switch ($PSCmdlet.ParameterSetName) {
             'ByID' {

--- a/Functions/Wireless/WirelessLANGroup/Get-NBWirelessLANGroup.ps1
+++ b/Functions/Wireless/WirelessLANGroup/Get-NBWirelessLANGroup.ps1
@@ -31,6 +31,8 @@
 .EXAMPLE
     Get-NBWirelessLANGroup
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Functions/Wireless/WirelessLANGroup/Get-NBWirelessLANGroup.ps1
+++ b/Functions/Wireless/WirelessLANGroup/Get-NBWirelessLANGroup.ps1
@@ -55,6 +55,9 @@ function Get-NBWirelessLANGroup {
         [uint16]$Limit,[ValidateRange(0, [int]::MaxValue)]
         [uint16]$Offset,[switch]$Raw)
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving Wireless LAN Group"
         switch ($PSCmdlet.ParameterSetName) {
             'ByID' {

--- a/Functions/Wireless/WirelessLink/Get-NBWirelessLink.ps1
+++ b/Functions/Wireless/WirelessLink/Get-NBWirelessLink.ps1
@@ -55,6 +55,9 @@ function Get-NBWirelessLink {
         [uint16]$Limit,[ValidateRange(0, [int]::MaxValue)]
         [uint16]$Offset,[switch]$Raw)
     process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
         Write-Verbose "Retrieving Wireless Link"
         switch ($PSCmdlet.ParameterSetName) {
             'ByID' {

--- a/Functions/Wireless/WirelessLink/Get-NBWirelessLink.ps1
+++ b/Functions/Wireless/WirelessLink/Get-NBWirelessLink.ps1
@@ -31,6 +31,8 @@
 .EXAMPLE
     Get-NBWirelessLink
 
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 #>

--- a/Tests/FilterExclusionAuditor.Tests.ps1
+++ b/Tests/FilterExclusionAuditor.Tests.ps1
@@ -1,0 +1,154 @@
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingConvertToSecureStringWithPlainText", "")]
+param()
+
+BeforeAll {
+    $script:AuditorPath = Join-Path (Join-Path $PSScriptRoot "..") "scripts/Verify-FilterExclusion.ps1"
+    if (-not (Test-Path $script:AuditorPath)) {
+        throw "Auditor script not found at $script:AuditorPath"
+    }
+
+    # Per-test workspace for synthetic Get-NB*.ps1 fixtures
+    $script:FixtureRoot = Join-Path ([System.IO.Path]::GetTempPath()) "pn-auditor-tests-$([Guid]::NewGuid().ToString('N'))"
+    New-Item -ItemType Directory -Path $script:FixtureRoot -Force | Out-Null
+}
+
+AfterAll {
+    if ($script:FixtureRoot -and (Test-Path $script:FixtureRoot)) {
+        Remove-Item $script:FixtureRoot -Recurse -Force
+    }
+}
+
+Describe "Verify-FilterExclusion.ps1 auditor" -Tag 'Unit', 'Auditor' {
+
+    BeforeAll {
+        # Helper function for creating fixture files and invoking the auditor.
+        # Declared in BeforeAll so It blocks (Pester v5 isolation) can see them.
+        function script:New-FixtureFile {
+            param(
+                [Parameter(Mandatory)][string]$Name,
+                [Parameter(Mandatory)][string]$Content
+            )
+            $subDir = Join-Path $script:FixtureRoot ([Guid]::NewGuid().ToString('N'))
+            New-Item -ItemType Directory -Path $subDir -Force | Out-Null
+            $path = Join-Path $subDir "$Name.ps1"
+            Set-Content -Path $path -Value $Content -Encoding UTF8
+            return $subDir
+        }
+
+        function script:Invoke-Auditor {
+            param([string]$Path)
+            $json = & $script:AuditorPath -Path $Path -OutputFormat Json -SkipExemptions 2>&1 | Out-String
+            if ([string]::IsNullOrWhiteSpace($json)) { return @() }
+            return $json | ConvertFrom-Json
+        }
+    }
+
+    It "Reports zero findings when the function correctly invokes AssertNBMutualExclusiveParam" {
+        $content = @'
+function Get-NBTestCorrect {
+    param(
+        [switch]$Brief,
+        [string[]]$Fields,
+        [string[]]$Omit
+    )
+    process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
+        # ... rest of function
+    }
+}
+'@
+        $dir = New-FixtureFile -Name 'Get-NBTestCorrect' -Content $content
+        $findings = Invoke-Auditor -Path $dir
+        $findings | Should -BeNullOrEmpty
+    }
+
+    It "Reports a finding when the function declares all three but omits the assertion" {
+        $content = @'
+function Get-NBTestMissing {
+    param(
+        [switch]$Brief,
+        [string[]]$Fields,
+        [string[]]$Omit
+    )
+    process {
+        Write-Verbose "Doing stuff"
+    }
+}
+'@
+        $dir = New-FixtureFile -Name 'Get-NBTestMissing' -Content $content
+        $findings = Invoke-Auditor -Path $dir
+        $findings.Count | Should -Be 1
+        $findings[0].Function | Should -Be 'Get-NBTestMissing'
+        $findings[0].Status | Should -Match 'Missing'
+    }
+
+    It "Skips the function when one of the three parameters is not declared" {
+        $content = @'
+function Get-NBTestOnlyTwo {
+    param(
+        [switch]$Brief,
+        [string[]]$Fields
+    )
+    process {
+        Write-Verbose "Doing stuff"
+    }
+}
+'@
+        $dir = New-FixtureFile -Name 'Get-NBTestOnlyTwo' -Content $content
+        $findings = Invoke-Auditor -Path $dir
+        $findings | Should -BeNullOrEmpty
+    }
+
+    It "Reports a finding when the assertion is inside a comment (not a real invocation)" {
+        $content = @'
+function Get-NBTestCommentedOut {
+    param(
+        [switch]$Brief,
+        [string[]]$Fields,
+        [string[]]$Omit
+    )
+    process {
+        # AssertNBMutualExclusiveParam -BoundParameters $PSBoundParameters -Parameters 'Brief','Fields','Omit'
+        Write-Verbose "Doing stuff"
+    }
+}
+'@
+        $dir = New-FixtureFile -Name 'Get-NBTestCommentedOut' -Content $content
+        $findings = Invoke-Auditor -Path $dir
+        $findings.Count | Should -Be 1
+        $findings[0].Function | Should -Be 'Get-NBTestCommentedOut'
+    }
+
+    It "Reports a finding when the assertion lists the wrong parameter names" {
+        $content = @'
+function Get-NBTestWrongArgs {
+    param(
+        [switch]$Brief,
+        [string[]]$Fields,
+        [string[]]$Omit
+    )
+    process {
+        AssertNBMutualExclusiveParam -BoundParameters $PSBoundParameters -Parameters 'Brief', 'Fields'
+    }
+}
+'@
+        $dir = New-FixtureFile -Name 'Get-NBTestWrongArgs' -Content $content
+        $findings = Invoke-Auditor -Path $dir
+        $findings.Count | Should -Be 1
+        $findings[0].Function | Should -Be 'Get-NBTestWrongArgs'
+    }
+
+    It "Exits with non-zero code under -FailOnMismatch when findings exist" {
+        $content = @'
+function Get-NBTestFailingFast {
+    param([switch]$Brief, [string[]]$Fields, [string[]]$Omit)
+    process { }
+}
+'@
+        $dir = New-FixtureFile -Name 'Get-NBTestFailingFast' -Content $content
+        & $script:AuditorPath -Path $dir -FailOnMismatch -SkipExemptions -OutputFormat Json > $null 2>&1
+        $LASTEXITCODE | Should -Be 1
+    }
+}

--- a/Tests/FilterExclusionAuditor.Tests.ps1
+++ b/Tests/FilterExclusionAuditor.Tests.ps1
@@ -18,7 +18,7 @@ AfterAll {
     }
 }
 
-Describe "Verify-FilterExclusion.ps1 auditor" -Tag 'Unit', 'Auditor' {
+Describe "Verify-FilterExclusion.ps1 auditor" -Tag 'Unit', 'Auditor' -Skip:($PSVersionTable.PSVersion.Major -lt 7) {
 
     BeforeAll {
         # Helper function for creating fixture files and invoking the auditor.

--- a/Tests/Virtualization.Tests.ps1
+++ b/Tests/Virtualization.Tests.ps1
@@ -129,6 +129,38 @@ Describe "Virtualization tests" -Tag 'Virtualization' {
                 $Result.Uri | Should -Match 'status=paused'
             }
         }
+
+        Context "Brief/Fields/Omit interaction with IncludeConfigContext (#397 PR-2)" {
+            It "With -Brief: URI contains brief=True and no config_context omit" {
+                $Result = Get-NBVirtualMachine -Brief
+                $Result.Uri | Should -Match 'brief=True'
+                $Result.Uri | Should -Not -Match 'omit=config_context'
+            }
+
+            It "With -Fields: URI contains the fields parameter and no config_context omit" {
+                $Result = Get-NBVirtualMachine -Fields 'id', 'name'
+                $Result.Uri | Should -Match 'fields=(?=.*id)(?=.*name)'
+                $Result.Uri | Should -Not -Match 'omit=config_context'
+            }
+
+            It "With -Omit: URI contains the user's omit value merged with config_context" {
+                $Result = Get-NBVirtualMachine -Omit 'comments'
+                $Result.Uri | Should -Match 'omit='
+                $Result.Uri | Should -Match 'comments'
+                $Result.Uri | Should -Match 'config_context'
+            }
+
+            It "With -IncludeConfigContext -Brief: URI contains brief=True only (IncludeConfigContext silently ignored)" {
+                $Result = Get-NBVirtualMachine -IncludeConfigContext -Brief
+                $Result.Uri | Should -Match 'brief=True'
+                $Result.Uri | Should -Not -Match 'config_context'
+            }
+
+            It "With no projection flags: URI contains the default config_context auto-omit" {
+                $Result = Get-NBVirtualMachine
+                $Result.Uri | Should -Match 'omit=config_context'
+            }
+        }
     }
 
     Context "Get-NBVirtualMachineInterface" {

--- a/docs/superpowers/specs/2026-04-17-397-filter-exclusion-rollout.md
+++ b/docs/superpowers/specs/2026-04-17-397-filter-exclusion-rollout.md
@@ -1,0 +1,187 @@
+---
+title: "#397 PR-2 — mutex assertion rollout to 121 Get functions + AST auditor"
+status: approved
+date: 2026-04-17
+predecessor: PR #397 (pilot) and design spec docs/superpowers/specs/2026-04-16-filter-exclusion-design.md
+---
+
+# #397 PR-2 — Filter-exclusion rollout + auditor
+
+## Context
+
+PR #397 (merged as `7948512`) introduced the `AssertNBMutualExclusiveParam` helper and applied it to 3 pilot Get functions (`Get-NBDCIMDevice`, `Get-NBIPAMAddress`, `Get-NBVPNTunnel`). This spec covers **PR-2** — the mechanical rollout to the remaining ~121 Get functions, the parallel `IncludeConfigContext` guard on `Get-NBVirtualMachine`, the AST-based `Verify-FilterExclusion.ps1` auditor, and its CI integration.
+
+Per the PR-1 design spec (`2026-04-16-filter-exclusion-design.md` §4 and §7), the audit pattern mirrors `Verify-ValidateSetParity.ps1` (PR #391).
+
+## Decisions
+
+### Scope breakdown
+
+1. **Auditor** (`scripts/Verify-FilterExclusion.ps1`): standalone PowerShell script that AST-parses `Functions/**/Get-NB*.ps1`, identifies Get functions that declare all three `Brief`/`Fields`/`Omit` parameters, and reports any where the `AssertNBMutualExclusiveParam` call is missing from the `process {}` block.
+
+2. **Rollout to 121 Get functions**: add the 4-line `AssertNBMutualExclusiveParam` call at the top of `process {}` for every Get function with all three filter parameters. Use a one-shot PowerShell migration leveraging the auditor's detection logic.
+
+3. **`Get-NBVirtualMachine` special case**: parallel to `Get-NBDCIMDevice` from PR #397, the auto-omit of `config_context` must be guarded by `$inProjectionMode` so it only fires outside `-Brief`/`-Fields` mode. 5 new special-case tests in `Tests/Virtualization.Tests.ps1`.
+
+4. **Per-function `.NOTES` help text**: one-line note added to every Get function that has all three filter parameters:
+   ```
+   .NOTES
+       The -Brief, -Fields, and -Omit parameters are mutually exclusive.
+   ```
+   Inserted just before the `.LINK` block to match existing help-ordering conventions.
+
+5. **CI job**: new job in `.github/workflows/test.yml` that runs `Verify-FilterExclusion.ps1 -FailOnMismatch` so future Get functions cannot regress the invariant.
+
+### Commit structure
+
+Four commits, ordered so each leaves the repo in a consistent state:
+
+| # | Commit | Scope | Rationale |
+|---|---|---|---|
+| 1 | `feat: add Verify-FilterExclusion.ps1 auditor script` | New script + unit tests | Standalone, reviewable in isolation |
+| 2 | `feat: enforce Brief/Fields/Omit mutex on 121 Get functions (#397 PR-2)` | ~121 `.ps1` modifications + `Get-NBVirtualMachine` guard + 5 VM special-case tests | The big mechanical commit |
+| 3 | `docs: per-function .NOTES about Brief/Fields/Omit mutual exclusion` | Help-block additions across 124 Get functions | Kept separate so code-only diff stays clean |
+| 4 | `ci: add filter-exclusion auditor job to test.yml` | CI integration | Landing last ensures CI stays green after commit 2 + 3 |
+
+### Migration implementation
+
+Mechanical. One-shot PowerShell script (not committed — run once during implementation):
+
+```powershell
+$findings = & ./scripts/Verify-FilterExclusion.ps1 -OutputFormat Json -SkipCI | ConvertFrom-Json
+foreach ($finding in $findings) {
+    # Locate the `process {` block, insert the 4-line assertion right after its opening brace
+    # Preserve existing indentation and blank-line conventions per function
+}
+```
+
+**Key subtlety**: per PR #397 code-review feedback (CLAUDE.md memory), each target function's existing blank-line convention between `)` and `process {` varies. The migration must detect and preserve each function's style rather than imposing a uniform template.
+
+### Auditor algorithm
+
+Per design spec §4:
+
+1. Glob `Functions/**/Get-NB*.ps1`.
+2. Parse each file with `[System.Management.Automation.Language.Parser]::ParseFile(...)`.
+3. For each `FunctionDefinitionAst`:
+   a. Read declared parameter names from `ParamBlockAst.Parameters`.
+   b. If the set `{Brief, Fields, Omit}` is not a subset, **skip** (function doesn't need the assertion).
+   c. Find all `CommandAst` nodes in the function body.
+   d. Report a finding if no `CommandAst` has `CommandElements[0]` with value `AssertNBMutualExclusiveParam` AND a `-Parameters` argument containing all three names (`'Brief'`, `'Fields'`, `'Omit'`).
+4. Output:
+   - Default: human-readable table (`File`, `Function`, `Status`).
+   - `-OutputFormat Json`: machine-readable for CI consumption.
+   - `-FailOnMismatch`: exit code ≠ 0 if any findings.
+5. Exemptions file (`scripts/filter-exclusion-exemptions.txt`) reserved for future edge cases; on initial rollout, empty.
+
+### VM special case parallels
+
+Mirror exactly what PR #398 did for `Get-NBDCIMDevice` Mode handling, applied to `Get-NBVirtualMachine`:
+
+```powershell
+process {
+    AssertNBMutualExclusiveParam `
+        -BoundParameters $PSBoundParameters `
+        -Parameters 'Brief', 'Fields', 'Omit'
+
+    $inProjectionMode = $PSBoundParameters.ContainsKey('Brief') -or
+                        $PSBoundParameters.ContainsKey('Fields')
+
+    $omitFields = @()
+    if ($PSBoundParameters.ContainsKey('Omit')) {
+        $omitFields += $Omit
+    }
+    if (-not $IncludeConfigContext -and -not $inProjectionMode) {
+        $omitFields += 'config_context'
+    }
+    # ... rest unchanged
+}
+```
+
+5 new special-case tests matching the Device pattern:
+- `-Brief`: `?brief=True`, no `omit=config_context`
+- `-Fields id,name`: `?fields=...`, no `omit=config_context`
+- `-Omit comments`: `?omit=comments,config_context` (merged)
+- `-IncludeConfigContext -Brief`: `?brief=True` (IncludeConfigContext silently ignored)
+- no flags: `?omit=config_context` (default preserved)
+
+### `.NOTES` insertion placement
+
+All 124 Get functions with all three filter parameters get a `.NOTES` block inserted just before `.LINK` (the end of the help block). Single line:
+
+```powershell
+.NOTES
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
+
+.LINK
+```
+
+Functions that already have a `.NOTES` block get the line appended (not replaced).
+
+### Test counts
+
+| Source | Count |
+|---|---|
+| Auditor unit tests (`Tests/AuditorTests.Tests.ps1`) | 6 (detection scenarios) |
+| VM special-case tests (`Tests/Virtualization.Tests.ps1`) | 5 |
+| Pilot tests from PR #397 (already exist) | 12 |
+| **New tests from this PR** | **11** |
+
+Baseline: **2280** (post-#399 on dev). Target: **2291**.
+
+### CI job
+
+Add to `.github/workflows/test.yml` alongside PSScriptAnalyzer:
+
+```yaml
+filter-exclusion-audit:
+  name: Filter-exclusion audit
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@v4
+    - uses: docker/setup-buildx-action@...
+    - name: Run auditor
+      shell: pwsh
+      run: ./scripts/Verify-FilterExclusion.ps1 -FailOnMismatch
+```
+
+## Architecture
+
+```
+scripts/
+├── Verify-FilterExclusion.ps1          ← NEW: auditor (mirrors Verify-ValidateSetParity.ps1 structure)
+└── filter-exclusion-exemptions.txt     ← NEW: exemptions file (initially empty)
+
+Functions/**/Get-NB*.ps1                ← 121 files: +4-line AssertNBMutualExclusiveParam call
+Functions/Virtualization/VirtualMachine/Get-NBVirtualMachine.ps1
+                                        ← Special: +$inProjectionMode guard on config_context auto-omit
+
+Tests/
+├── AuditorTests.Tests.ps1              ← NEW: 6 unit tests for the auditor
+└── Virtualization.Tests.ps1            ← +5 VM special-case tests
+
+Functions/**/Get-NB*.ps1 (all 124)      ← +.NOTES help text line
+
+.github/workflows/test.yml              ← +filter-exclusion-audit job
+```
+
+## Verification checklist (pre-PR)
+
+1. `Invoke-Pester ./Tests/ -ExcludeTagFilter Integration,Live,Scenario` → 2280 baseline + 11 new = **2291 passed / 0 failed**
+2. `./scripts/Verify-FilterExclusion.ps1` → 0 findings
+3. `./scripts/Verify-FilterExclusion.ps1 -FailOnMismatch` → exit code 0
+4. `./scripts/Verify-ValidateSetParity.ps1 -NetboxVersion v4.5.8` → still 5 findings (unchanged; this PR doesn't touch ValidateSets)
+5. PSScriptAnalyzer on new scripts + modified Get functions → 0 new findings
+
+## Release impact
+
+**Breaking change** (as flagged in PR #397 / v4.5.8.0 release notes). This PR expands the breaking-change surface from 3 pilot functions to all 124 Get functions with Brief/Fields/Omit. Users whose scripts silently combined any two of those parameters across *any* Get function will now see `ParameterBindingException` — but those scripts were already broken (one parameter's effect silently ignored).
+
+Candidate for v4.5.9.0 minor release.
+
+## Out of scope
+
+- Enum null-clearing in Set functions (Branch 3 — `feat/set-interface-enum-null-clearing`)
+- #392 MEDIUM catalog adds (Cable/FrontPort/RearPort Type lists)
+- #392 LOW item (DCIMInterfaceConnection Connection_Status — endpoint possibly deprecated)
+- Netbox 4.6.0-beta1 compat (#395 — explicitly deferred by user)

--- a/scripts/Verify-FilterExclusion.ps1
+++ b/scripts/Verify-FilterExclusion.ps1
@@ -1,0 +1,236 @@
+#Requires -Version 7
+
+<#
+.SYNOPSIS
+    Verify that every Get-NB* function declaring -Brief, -Fields, and -Omit
+    parameters invokes AssertNBMutualExclusiveParam in its process block.
+
+.DESCRIPTION
+    Drift-detection auditor introduced as PR #397 PR-2. The original PR
+    added the AssertNBMutualExclusiveParam helper and applied it to three
+    pilot functions; this script enforces that the invariant holds across
+    every Get function in the codebase.
+
+    Uses the PowerShell AST to locate:
+    - FunctionDefinitionAst nodes whose param block declares all three
+      Brief/Fields/Omit parameters
+    - CommandAst nodes inside process {} that invoke
+      AssertNBMutualExclusiveParam with a -Parameters argument containing
+      all three names
+
+    Reports a finding for every Get function that declares all three
+    filter parameters but does not invoke the assertion correctly.
+
+    Future Get functions cannot silently regress the invariant because
+    this script is gated in CI via .github/workflows/test.yml.
+
+.PARAMETER Path
+    Root directory to scan. Defaults to ./Functions relative to the
+    script's parent.
+
+.PARAMETER OutputFormat
+    'Table' (default, human-readable) or 'Json' (machine-readable for CI).
+
+.PARAMETER FailOnMismatch
+    Exit with non-zero code if any findings are reported. Intended for CI.
+
+.PARAMETER SkipExemptions
+    Bypass the scripts/filter-exclusion-exemptions.txt list. Useful for
+    discovering whether a previously-exempted file should still be exempt.
+
+.EXAMPLE
+    ./scripts/Verify-FilterExclusion.ps1
+
+    Scan all Get-NB* functions and print a human-readable table.
+
+.EXAMPLE
+    ./scripts/Verify-FilterExclusion.ps1 -FailOnMismatch -OutputFormat Json
+
+    CI-ready invocation: exits non-zero on findings, emits JSON.
+
+.NOTES
+    Related: PR #391 (Verify-ValidateSetParity.ps1) — same AST-based
+    auditor pattern applied to a different invariant.
+#>
+
+[CmdletBinding()]
+param(
+    [string]$Path,
+
+    [ValidateSet('Table', 'Json')]
+    [string]$OutputFormat = 'Table',
+
+    [switch]$FailOnMismatch,
+
+    [switch]$SkipExemptions
+)
+
+$ErrorActionPreference = 'Stop'
+
+# Resolve the Functions/ directory relative to the script if not supplied
+if (-not $Path) {
+    $scriptDir = Split-Path -Parent $PSCommandPath
+    $Path = Join-Path (Split-Path -Parent $scriptDir) 'Functions'
+}
+
+if (-not (Test-Path $Path)) {
+    Write-Error "Functions directory not found: $Path"
+    exit 2
+}
+
+# Load exemptions (file paths relative to the repo root, one per line, # for comments)
+$exemptions = @()
+if (-not $SkipExemptions) {
+    $exemptionsFile = Join-Path (Split-Path -Parent $PSCommandPath) 'filter-exclusion-exemptions.txt'
+    if (Test-Path $exemptionsFile) {
+        $exemptions = Get-Content $exemptionsFile |
+            Where-Object { $_ -and -not $_.StartsWith('#') } |
+            ForEach-Object { $_.Trim() }
+    }
+}
+
+# The three required parameter names
+$requiredParams = @('Brief', 'Fields', 'Omit')
+
+function Get-FilterExclusionFinding {
+    <#
+    .SYNOPSIS
+        Inspect one .ps1 file and return zero or more findings.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [string]$FilePath
+    )
+
+    $tokens = $errors = $null
+    $ast = [System.Management.Automation.Language.Parser]::ParseFile(
+        $FilePath,
+        [ref]$tokens,
+        [ref]$errors
+    )
+
+    if ($errors.Count -gt 0) {
+        Write-Warning "Parse errors in $FilePath — skipping: $($errors[0].Message)"
+        return
+    }
+
+    $functions = $ast.FindAll(
+        { param($node) $node -is [System.Management.Automation.Language.FunctionDefinitionAst] },
+        $true
+    )
+
+    foreach ($fn in $functions) {
+        # Only inspect Get-NB* functions
+        if ($fn.Name -notmatch '^Get-NB') { continue }
+
+        # Collect declared parameter names
+        $paramBlock = $fn.Body.ParamBlock
+        if ($null -eq $paramBlock) { continue }
+        $declaredParams = $paramBlock.Parameters | ForEach-Object { $_.Name.VariablePath.UserPath }
+
+        # Must declare all three to be in scope
+        $missingFromDeclared = $requiredParams | Where-Object { $_ -notin $declaredParams }
+        if ($missingFromDeclared.Count -gt 0) { continue }
+
+        # Find all CommandAst nodes in the entire function body (any block, any depth)
+        $commands = $fn.Body.FindAll(
+            { param($node) $node -is [System.Management.Automation.Language.CommandAst] },
+            $true
+        )
+
+        $assertionFound = $false
+        foreach ($cmd in $commands) {
+            $cmdName = $cmd.GetCommandName()
+            if ($cmdName -ne 'AssertNBMutualExclusiveParam') { continue }
+
+            # Extract the -Parameters argument's values
+            $paramsArgValues = @()
+            for ($i = 0; $i -lt $cmd.CommandElements.Count; $i++) {
+                $elem = $cmd.CommandElements[$i]
+                if ($elem -is [System.Management.Automation.Language.CommandParameterAst] -and
+                    $elem.ParameterName -eq 'Parameters') {
+                    # Value is the next element (or multiple, if comma-separated array)
+                    $j = $i + 1
+                    while ($j -lt $cmd.CommandElements.Count) {
+                        $valueElem = $cmd.CommandElements[$j]
+                        if ($valueElem -is [System.Management.Automation.Language.CommandParameterAst]) { break }
+
+                        # Typical form: an ArrayLiteralAst with StringConstantAst children,
+                        # or a sequence of StringConstantAst separated by commas (PowerShell
+                        # parser produces either depending on style).
+                        if ($valueElem -is [System.Management.Automation.Language.ArrayLiteralAst]) {
+                            $paramsArgValues += $valueElem.Elements | ForEach-Object {
+                                if ($_ -is [System.Management.Automation.Language.StringConstantExpressionAst]) {
+                                    $_.Value
+                                }
+                            }
+                        } elseif ($valueElem -is [System.Management.Automation.Language.StringConstantExpressionAst]) {
+                            $paramsArgValues += $valueElem.Value
+                        }
+                        $j++
+                    }
+                    break
+                }
+            }
+
+            # Check that all three required parameter names are present
+            $missingFromArg = $requiredParams | Where-Object { $_ -notin $paramsArgValues }
+            if ($missingFromArg.Count -eq 0) {
+                $assertionFound = $true
+                break
+            }
+        }
+
+        if (-not $assertionFound) {
+            [PSCustomObject]@{
+                File          = $FilePath
+                Function      = $fn.Name
+                DeclaredParams = ($requiredParams -join ', ')
+                Status        = 'Missing AssertNBMutualExclusiveParam'
+            }
+        }
+    }
+}
+
+# Collect findings across all Get-NB* files
+$allFindings = @()
+$targetFiles = Get-ChildItem -Path $Path -Recurse -Filter 'Get-NB*.ps1' -File
+foreach ($file in $targetFiles) {
+    # Normalise path for exemption match (relative to repo root with forward slashes)
+    $repoRoot = Split-Path -Parent (Split-Path -Parent $PSCommandPath)
+    $relativePath = [System.IO.Path]::GetRelativePath($repoRoot, $file.FullName).Replace('\', '/')
+    if ($relativePath -in $exemptions) {
+        continue
+    }
+
+    $findings = Get-FilterExclusionFinding -FilePath $file.FullName
+    if ($findings) { $allFindings += $findings }
+}
+
+# Emit output
+switch ($OutputFormat) {
+    'Json' {
+        $allFindings | ConvertTo-Json -Depth 5
+    }
+    default {
+        if ($allFindings.Count -eq 0) {
+            Write-Host "No missing AssertNBMutualExclusiveParam invocations found." -ForegroundColor Green
+        } else {
+            $allFindings | Format-Table -AutoSize @{
+                Name = 'File'
+                Expression = {
+                    $repoRoot = Split-Path -Parent (Split-Path -Parent $PSCommandPath)
+                    [System.IO.Path]::GetRelativePath($repoRoot, $_.File).Replace('\', '/')
+                }
+            }, Function, Status
+            Write-Host ""
+            Write-Host "Summary: $($allFindings.Count) function(s) missing AssertNBMutualExclusiveParam invocation." -ForegroundColor Yellow
+        }
+    }
+}
+
+# Exit handling for CI
+if ($FailOnMismatch -and $allFindings.Count -gt 0) {
+    exit 1
+}

--- a/scripts/Verify-FilterExclusion.ps1
+++ b/scripts/Verify-FilterExclusion.ps1
@@ -193,12 +193,14 @@ function Get-FilterExclusionFinding {
     }
 }
 
+# Hoist repo-root calculation out of the per-file loop (invariant across iterations)
+$repoRoot = Split-Path -Parent (Split-Path -Parent $PSCommandPath)
+
 # Collect findings across all Get-NB* files
 $allFindings = @()
 $targetFiles = Get-ChildItem -Path $Path -Recurse -Filter 'Get-NB*.ps1' -File
 foreach ($file in $targetFiles) {
     # Normalise path for exemption match (relative to repo root with forward slashes)
-    $repoRoot = Split-Path -Parent (Split-Path -Parent $PSCommandPath)
     $relativePath = [System.IO.Path]::GetRelativePath($repoRoot, $file.FullName).Replace('\', '/')
     if ($relativePath -in $exemptions) {
         continue
@@ -220,7 +222,6 @@ switch ($OutputFormat) {
             $allFindings | Format-Table -AutoSize @{
                 Name = 'File'
                 Expression = {
-                    $repoRoot = Split-Path -Parent (Split-Path -Parent $PSCommandPath)
                     [System.IO.Path]::GetRelativePath($repoRoot, $_.File).Replace('\', '/')
                 }
             }, Function, Status

--- a/scripts/filter-exclusion-exemptions.txt
+++ b/scripts/filter-exclusion-exemptions.txt
@@ -1,0 +1,13 @@
+# Filter-exclusion auditor exemptions
+# =====================================
+# One relative path per line. Lines starting with # are comments.
+# Listed files are skipped by Verify-FilterExclusion.ps1.
+#
+# Only add entries here when a Get-NB* function legitimately should NOT
+# invoke AssertNBMutualExclusiveParam — typically because the function
+# does not expose all three of -Brief, -Fields, -Omit. The auditor already
+# skips functions that don't declare all three, so this file is a last
+# resort for genuine edge cases.
+#
+# When adding an entry, include a brief rationale comment on the line
+# above it so future maintainers understand why the exemption exists.


### PR DESCRIPTION
## Summary

Completes the two-phase rollout described in [`docs/superpowers/specs/2026-04-16-filter-exclusion-design.md`](docs/superpowers/specs/2026-04-16-filter-exclusion-design.md). PR #397 (PR-1, merged as \`7948512\`) introduced the \`AssertNBMutualExclusiveParam\` helper and applied it to 3 pilot Get functions. This PR (PR-2):

- Applies the helper to the remaining **121 Get functions** that declare all three \`-Brief\`, \`-Fields\`, \`-Omit\` parameters
- Adds the same \`\$inProjectionMode\` \`config_context\` guard on \`Get-NBVirtualMachine\` that PR #398 put on \`Get-NBDCIMDevice\`
- Adds an **AST-based auditor** (\`scripts/Verify-FilterExclusion.ps1\`) that detects Get functions missing the assertion
- Wires the auditor into **CI** so future regressions fail the build
- Adds per-function \`.NOTES\` help text documenting the mutual exclusion

After this PR, every Get function in the codebase rejects any two-or-more combination of the three filter parameters with a clear \`ParameterBindingException\`.

## Commits

| # | SHA | Commit |
|---|-----|---|
| 1 | \`412f5a1\` | \`docs: design spec for #397 PR-2\` |
| 2 | \`41f8692\` | \`feat: add Verify-FilterExclusion.ps1 auditor script\` + 6 unit tests |
| 3 | \`ef98f09\` | \`feat: enforce Brief/Fields/Omit mutex on 121 Get functions\` + VM special case + 5 tests |
| 4 | \`cd52eeb\` | \`docs: per-function .NOTES about Brief/Fields/Omit mutual exclusion\` (121 files) |
| 5 | \`f4bc0fb\` | \`ci: add filter-exclusion auditor job\` |

## Breaking change surface

The breaking change itself was shipped in v4.5.8.0 via PR #397 (3 pilot functions). This PR expands that surface to all 124 Get functions with Brief/Fields/Omit. Scripts that previously combined these flags got one parameter's effect and silently ignored the others; they were already broken — now they get a clear error instead.

## Two edge cases handled manually

- \`Functions/IPAM/Aggregate/Get-NBIPAMAggregate.ps1\` had its \`process {\` block at column 0 instead of 4 (pre-existing indentation drift); re-indented during the rollout.
- \`Functions/Setup/Support/Get-NBContentType.ps1\` has no \`process\` block (delegates to \`Get-NBObjectType\` via splatting); wrapped the delegation in a \`process\` block so the assertion runs before the splat passes potentially-conflicting parameters through.

## Verification

- [x] \`./scripts/Verify-FilterExclusion.ps1\` → 0 findings (was 121 before the rollout commit)
- [x] Full unit regression: **2291 passed / 0 failed** (2280 baseline + 6 auditor + 5 VM = 2291)
- [x] PSScriptAnalyzer on modified files: no new findings
- [ ] CI green on PS 5.1 + PS 7 × Linux/macOS/Windows
- [ ] Gemini review clean
- [ ] New \`filter-exclusion.yml\` workflow green on its own

## Release fit

Candidate for **v4.5.9.0** once bundled with Branch 3 (enum null-clearing follow-up to #398) and any other pending work. The net behavior change on top of v4.5.8.0 is: the mutex check extends from 3 pilot Get functions to all 124 Get functions with the three filter parameters.

## Spec reference

- Design: \`docs/superpowers/specs/2026-04-17-397-filter-exclusion-rollout.md\`
- Parent PR-1 spec: \`docs/superpowers/specs/2026-04-16-filter-exclusion-design.md\`