### PR TITLE
fix: exempt enum null-clearing sentinel '' from parity tool (#401 follow-up)

### DIFF
--- a/scripts/validateset-parity-exclusions.txt
+++ b/scripts/validateset-parity-exclusions.txt
@@ -44,3 +44,15 @@ Extras/CustomLinks/Set-NBCustomLink.ps1::Button_Class
 # '100', '200', '300', '400' — translate to: 'access', 'tagged', 'tagged-all', 'q-in-q'.
 DCIM/Interfaces/New-NBDCIMInterface.ps1::Mode
 DCIM/Interfaces/Set-NBDCIMInterface.ps1::Mode
+
+# ---------------------------------------------------------------------------
+# Parameters that include '' as an empty-string sentinel for null-clearing
+# on PATCH. Translated to $null in process {} before the JSON body is built
+# (see PR #401 — Set-NBDCIMInterface enum null-clearing follow-up to PR #398).
+# The '' is a PowerNetbox UX choice, not a value NetBox actually accepts —
+# so the parity tool flags it as "Extra in PowerNetbox". That's expected.
+# ---------------------------------------------------------------------------
+DCIM/Interfaces/Set-NBDCIMInterface.ps1::Duplex
+DCIM/Interfaces/Set-NBDCIMInterface.ps1::POE_Mode
+DCIM/Interfaces/Set-NBDCIMInterface.ps1::POE_Type
+DCIM/Interfaces/Set-NBDCIMInterface.ps1::RF_Role


### PR DESCRIPTION
## Summary

PR #401 added \`''\` to the ValidateSet of 4 enum parameters on \`Set-NBDCIMInterface\` as an empty-string sentinel for null-clearing. The parity tool (\`scripts/Verify-ValidateSetParity.ps1\`) flagged these as "Extra in PowerNetbox" because \`''\` is not a real NetBox enum value — it's translated to \`\$null\` in \`process {}\` before the JSON body is built.

This is expected, not drift. Four exemption lines added to \`scripts/validateset-parity-exclusions.txt\` with a comment pointing at the PR #401 mechanism.

## Result

Parity count drops from 8 → 5 against both \`v4.5.8\` and \`v4.6.0-beta1\`. The remaining 5 findings are:

- \`Cable/FrontPort/RearPort -Type\` catalog-adds (#392 MEDIUM items 7-8, separate follow-up)
- \`DCIMInterfaceConnection -Connection_Status decommissioning\` (#392 LOW item 9)
- \`Get-NBBranch -Status\` wrong-class-match (long-standing tool matching quirk; plugin choices not in NetBox core)

## RF_Role preventive exemption

PR #401 added \`''\` to \`-RF_Role\` too, but the parity tool's score heuristic didn't surface it as a finding against v4.5.8 or v4.6.0-beta1. Added the exemption preventively — if a future NetBox change shifts the match score above threshold, the exemption is already in place.

## Why not fix the tool instead

The tool's job is "show values PN has that NetBox doesn't" — it's doing that correctly. Teaching it to recognize \`''\` as a clearing sentinel would require pattern-specific logic that coupling it to this particular PowerNetbox UX convention. The exemption file exists exactly for this scenario.

## Verification

- \`scripts/Verify-ValidateSetParity.ps1 -NetboxVersion v4.5.8\` → 5 findings
- \`scripts/Verify-ValidateSetParity.ps1 -NetboxVersion v4.6.0-beta1\` → 5 findings
- No code paths changed; exclusions file only.