### PR TITLE
docs: SignPath application prep — SECURITY.md, PRIVACY.md, README code-signing section

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,57 @@
+# Privacy Policy
+
+PowerNetbox is a local PowerShell module. It does not collect, transmit,
+or phone home with any user data.
+
+## What PowerNetbox does
+
+- Sends HTTP(S) requests from the user's machine to the NetBox host the
+  user explicitly configured via `Connect-NBAPI`.
+- Reads the NetBox API token the user supplied (from a `PSCredential`,
+  `SecureString`, or environment variable) and includes it in the
+  `Authorization` header of those requests.
+- Writes verbose / debug output to the console when the user opts in via
+  `-Verbose` or `$VerbosePreference`. Tokens are redacted from this output
+  — see `Functions/Helpers/InvokeNetboxRequest.ps1`.
+
+## What PowerNetbox does not do
+
+- No telemetry, analytics, or usage metrics are transmitted anywhere.
+- No data is sent to the module maintainer, PSGallery, GitHub, or any
+  third party.
+- No files are written outside of what the user's own cmdlets produce
+  (e.g. `Export-NBRackElevation` writes to a path the user specified).
+- No network requests are made to hosts the user did not configure.
+
+## Data that does leave the user's machine
+
+Only what is sent to the user-configured NetBox host via the REST API.
+The user controls the host, the token, and every cmdlet invocation.
+PowerNetbox is merely a convenience layer over `Invoke-RestMethod` /
+`Invoke-WebRequest`.
+
+## Logs and diagnostics
+
+- Verbose output goes to the PowerShell console stream only.
+- Debug output similarly console-only.
+- Error objects include the response body for troubleshooting; the
+  Authorization header is redacted from that body. See
+  `BuildDetailedErrorMessage` in `InvokeNetboxRequest.ps1`.
+
+## Credentials
+
+- Tokens supplied via `Connect-NBAPI -Credential` are stored in-memory
+  as `[SecureString]` for the session lifetime.
+- On Windows, SecureString uses DPAPI (process-scoped entropy).
+  On Linux and macOS, PowerShell's SecureString is an obfuscation only
+  — per Microsoft documentation it is **not** a security boundary on
+  non-Windows platforms. Use `.env` with OS file permissions, or a
+  secret manager of your choice, to protect tokens at rest.
+- Tokens are never written to disk by PowerNetbox itself.
+- `Disconnect-NBAPI` clears the in-memory credential.
+
+## Questions
+
+Open a GitHub Discussion or email `31536997+ctrl-alt-automate@users.noreply.github.com`.
+
+_Last updated: 2026-04-18._

--- a/README.md
+++ b/README.md
@@ -322,6 +322,46 @@ We welcome contributions! Please follow these guidelines:
 3. Follow [PowerShell Practice and Style Guidelines](https://poshcode.gitbook.io/powershell-practice-and-style/)
 4. Submit a pull request against the `dev` branch
 
+See also [CONTRIBUTING.md](CONTRIBUTING.md) and [SECURITY.md](SECURITY.md).
+
+## Security and privacy
+
+- **Vulnerability reporting:** see [SECURITY.md](SECURITY.md). Use GitHub
+  Security Advisories for private disclosure.
+- **Privacy policy:** see [PRIVACY.md](PRIVACY.md). Short version:
+  PowerNetbox sends requests only to the NetBox host you configure — no
+  telemetry, no analytics.
+- **Recent security reviews:** `docs/superpowers/reviews/`.
+
+## Code signing policy
+
+PowerNetbox follows the [SignPath.io](https://signpath.org) code signing
+model (application in progress with the SignPath Foundation free open
+source tier). Once active:
+
+- Every published release on PSGallery will be signed with a certificate
+  issued to **ctrl-alt-automate / PowerNetbox** via SignPath.
+- Consumers can verify authenticity with:
+
+  ```powershell
+  $module = Get-Module -ListAvailable PowerNetbox | Select-Object -First 1
+  Get-AuthenticodeSignature (Join-Path $module.ModuleBase 'PowerNetbox.psm1')
+  ```
+
+- Team roles for signing governance:
+  - **Author / Reviewer / Approver:** ctrl-alt-automate (solo
+    maintainer; external contributions are reviewed and merged by the
+    same maintainer before a signed release is cut).
+
+Until SignPath signing is live, the module is distributed unsigned on
+PSGallery. Trust anchors meanwhile are the PSGallery publisher identity
+(`ctrl-alt-automate`), signed git tags, and the public MIT-licensed
+source at each release tag.
+
+Credit: code signing sponsored by
+[SignPath Foundation](https://signpath.org) via
+[SignPath.io](https://signpath.io).
+
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.

--- a/README.md
+++ b/README.md
@@ -344,8 +344,12 @@ source tier). Once active:
 - Consumers can verify authenticity with:
 
   ```powershell
-  $module = Get-Module -ListAvailable PowerNetbox | Select-Object -First 1
-  Get-AuthenticodeSignature (Join-Path $module.ModuleBase 'PowerNetbox.psm1')
+  $module = Get-Module -ListAvailable PowerNetbox |
+      Sort-Object Version -Descending |
+      Select-Object -First 1
+  if ($module) {
+      Get-AuthenticodeSignature (Join-Path $module.ModuleBase 'PowerNetbox.psd1')
+  }
   ```
 
 - Team roles for signing governance:

--- a/README.md
+++ b/README.md
@@ -348,7 +348,7 @@ source tier). Once active:
       Sort-Object Version -Descending |
       Select-Object -First 1
   if ($module) {
-      Get-AuthenticodeSignature (Join-Path $module.ModuleBase 'PowerNetbox.psd1')
+      Get-AuthenticodeSignature $module.Path
   }
   ```
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,90 @@
+# Security Policy
+
+## Supported versions
+
+Only the latest released version of PowerNetbox receives security updates.
+Older versions are not patched retroactively. Upgrade via:
+
+```powershell
+Update-Module -Name PowerNetbox
+```
+
+## Reporting a vulnerability
+
+**Please do not report security issues via public GitHub issues.**
+
+Preferred channel: [GitHub Security Advisories](https://github.com/ctrl-alt-automate/PowerNetbox/security/advisories/new)
+— this creates a private advisory thread between you and the maintainer.
+
+Fallback: email `31536997+ctrl-alt-automate@users.noreply.github.com` with
+subject line starting `[SECURITY]`.
+
+## What to include
+
+- PowerNetbox version (`Get-Module PowerNetbox | Select-Object Version`)
+- NetBox server version (if relevant)
+- PowerShell edition + version (`$PSVersionTable`)
+- Clear reproduction steps and the observed impact
+- Whether you need credit in the advisory
+
+## What to expect
+
+- Acknowledgement within 5 business days
+- Triage and initial severity assessment within 10 business days
+- Fix timeline scaled to severity (CRITICAL issues aim for 7 days; LOW may
+  be bundled with a regular release)
+- Credit in the advisory + release notes unless you request otherwise
+
+## Scope
+
+**In scope:**
+
+- PowerNetbox cmdlet code (`Functions/**`)
+- Authentication and token handling (`Functions/Setup/**`, `Functions/Helpers/InvokeNetboxRequest.ps1`)
+- Request construction and response parsing
+- Build and release pipeline (`.github/workflows/`)
+- Dependencies declared by this module
+
+**Out of scope:**
+
+- Vulnerabilities in NetBox itself — report to
+  [netbox-community/netbox](https://github.com/netbox-community/netbox/security)
+- Vulnerabilities in PowerShell or .NET — report upstream
+- Social engineering, physical access, or denial-of-service via sheer
+  volume (PowerNetbox inherits NetBox's rate limiting)
+- Issues that require an already-compromised host / session
+
+## Security posture
+
+PowerNetbox publishes security review documents in
+[`docs/superpowers/reviews/`](docs/superpowers/reviews/). Recent reviews:
+
+- **2026-04-18 Tier 1** — secret scanning, GitHub Actions workflow hardening, cryptographic delta audit since PR #377
+- **2026-04-18 Tier 2** — STRIDE threat model, OWASP API Top 10 (client-side), dependency / supply-chain audit
+
+Current hardening includes:
+
+- HTTPS by default with plaintext-HTTP warning
+- Central `Authorization: Bearer` header construction with v1/v2 token support
+- Token redaction in verbose / error output
+- Cross-origin validation on pagination `.next` URLs (PR #404)
+- `gitleaks` CI + `.gitleaks-baseline.json` + pre-commit hook (PR #403)
+- Restricted GitHub Actions permissions (`contents: read` default)
+- Max upload size (10 MB) on image attachments; max bulk-operation item cap
+
+## Code signing
+
+The published module on PSGallery is **not yet code-signed**. An
+application with [SignPath Foundation](https://signpath.org) for free
+open-source code signing is in progress. Until then, consumers can
+verify authenticity via:
+
+1. **PSGallery publisher:** modules are published only by the
+   `ctrl-alt-automate` publisher account.
+2. **Git tag SHA:** each release tag matches a commit on `main`; you
+   can verify by inspecting `git log` on your local clone.
+3. **Review the source:** PowerNetbox is MIT-licensed; the full source
+   of every released version is public at the matching tag.
+
+Once SignPath signing is live this section will be updated with
+`Get-AuthenticodeSignature` verification steps.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -70,7 +70,7 @@ Current hardening includes:
 - Cross-origin validation on pagination `.next` URLs (PR #404)
 - `gitleaks` CI + `.gitleaks-baseline.json` + pre-commit hook (PR #403)
 - Restricted GitHub Actions permissions (`contents: read` default)
-- Max upload size (10 MB) on image attachments; max bulk-operation item cap
+- Client-side 10 MB upload cap on `New-NBImageAttachment` (see `Functions/Extras/ImageAttachments/New-NBImageAttachment.ps1`); client-side default 10 000-item cap on `Send-NBBulkRequest` via `-MaxItems` (see `Functions/Helpers/Send-NBBulkRequest.ps1`). Both are local guards that throw before any network call — server-side limits from NetBox apply on top.
 
 ## Code signing
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -21,7 +21,7 @@ subject line starting `[SECURITY]`.
 
 ## What to include
 
-- PowerNetbox version (`Get-Module PowerNetbox | Select-Object Version`)
+- PowerNetbox version (`Get-Module -ListAvailable PowerNetbox | Select-Object -ExpandProperty Version`)
 - NetBox server version (if relevant)
 - PowerShell edition + version (`$PSVersionTable`)
 - Clear reproduction steps and the observed impact

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -86,5 +86,7 @@ verify authenticity via:
 3. **Review the source:** PowerNetbox is MIT-licensed; the full source
    of every released version is public at the matching tag.
 
-Once SignPath signing is live this section will be updated with
-`Get-AuthenticodeSignature` verification steps.
+Once SignPath signing is live, use the `Get-AuthenticodeSignature`
+snippet in [README.md → Code signing policy](README.md#code-signing-policy)
+to verify a local install. Signature verification steps are maintained
+in a single location to avoid drift.


### PR DESCRIPTION
## Summary

Pure documentation PR preparing PowerNetbox for the SignPath Foundation free open source code signing application. None of these change runtime behaviour.

## What's new

- **\`SECURITY.md\`** — disclosure policy (GitHub Security Advisories preferred, email fallback), supported-versions statement, in-scope/out-of-scope list, pointers to the Tier 1 + Tier 2 security reviews.
- **\`PRIVACY.md\`** — ~1-page statement: no telemetry, no phone-home, tokens in-memory only. Explicitly notes PowerShell SecureString caveats on Linux/macOS so users can make informed token-storage decisions.
- **\`README.md\`** — new \"Security and privacy\" section linking both files, plus a \"Code signing policy\" section declaring the SignPath model, team roles (solo maintainer fills all three governance roles), and \`Get-AuthenticodeSignature\` verification steps for when signing goes live. Credit line for SignPath.io / SignPath Foundation included per their terms.

## Why now

SignPath Foundation's [terms](https://signpath.org/terms) require applicants to publish:

1. A public code-signing policy on the project homepage
2. A privacy policy
3. Team role disclosure (Authors / Reviewers / Approvers)
4. Credit line for SignPath.io and SignPath Foundation

This PR satisfies (1)-(4) upfront so the SignPath application can be submitted without further blockers. The \"code signing in progress\" language in README + SECURITY.md is honest about current state — we'll flip the language once SignPath accepts + the first signed release ships.

## Out of scope (separate PRs)

Items from the Tier 2 follow-ups list still pending:

- **MEDIUM:** Pin \`Pester\` / \`PSScriptAnalyzer\` to \`RequiredVersion\` in \`release.yml\`
- **LOW:** \`.github/dependabot.yml\` for github-actions + docker ecosystems
- **LOW:** GitHub Artifact Attestations in release workflow (provenance without paid cert)

These can land in a follow-up PR once the user confirms scope.

## Test plan

- [ ] CI green (Pester × 4 OSes + Gitleaks — pure docs should not break tests)
- [ ] Gitleaks CI passes (new files contain no secrets)
- [ ] Gemini review for fact-accuracy on SECURITY.md scope claims