### PR TITLE
ci: pin release deps + Dependabot + build provenance attestation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,20 @@
 # Dependabot configuration for PowerNetbox.
 #
-# - github-actions: keep action SHAs / tags fresh + grouped to reduce PR noise
-# - docker:         Dockerfile.branching's FROM image (netboxcommunity/netbox)
+# Covered ecosystems:
+# - github-actions: action SHAs / tags, grouped to reduce PR noise.
 #
-# Note: Dependabot does not support PSGallery, so Pester / PSScriptAnalyzer
-# version pins in .github/workflows/release.yml are updated manually.
+# NOT covered (documented gaps):
+# - PSGallery modules: Dependabot does not support PSGallery. Pins for
+#   Pester / PSScriptAnalyzer in .github/workflows/release.yml are
+#   bumped manually.
+# - Dockerfile.branching FROM image: the `docker` ecosystem only
+#   recognises files named exactly `Dockerfile` (or standard
+#   docker-compose filenames). Our build-arg-driven
+#   `Dockerfile.branching` + docker-compose.ci.yml are invisible to it.
+#   Renaming to satisfy Dependabot would hurt project clarity more than
+#   the manual NETBOX_VERSION bump cost saves. The netbox-docker image
+#   is tracked manually against the CI matrix in compatibility.yml /
+#   integration.yml.
 
 version: 2
 
@@ -29,18 +39,3 @@ updates:
     labels:
       - "dependencies"
       - "ci"
-
-  - package-ecosystem: "docker"
-    directory: "/"
-    schedule:
-      interval: "monthly"
-      day: "monday"
-      time: "06:00"
-      timezone: "Europe/Amsterdam"
-    open-pull-requests-limit: 2
-    commit-message:
-      prefix: "ci"
-      include: "scope"
-    labels:
-      - "dependencies"
-      - "docker"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,46 @@
+# Dependabot configuration for PowerNetbox.
+#
+# - github-actions: keep action SHAs / tags fresh + grouped to reduce PR noise
+# - docker:         Dockerfile.branching's FROM image (netboxcommunity/netbox)
+#
+# Note: Dependabot does not support PSGallery, so Pester / PSScriptAnalyzer
+# version pins in .github/workflows/release.yml are updated manually.
+
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/Amsterdam"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+    groups:
+      actions-minor-patch:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+    labels:
+      - "dependencies"
+      - "ci"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/Amsterdam"
+    open-pull-requests-limit: 2
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "docker"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,12 @@ on:
 permissions:
   contents: read
 
+env:
+  # Pinned PSGallery dependency versions. Bump deliberately after review
+  # (Dependabot does not cover PSGallery, so updates are manual).
+  PESTER_VERSION: '5.7.1'
+  PSSA_VERSION:   '1.25.0'
+
 jobs:
   test:
     name: Pre-release Tests
@@ -18,10 +24,13 @@ jobs:
 
       - name: Install dependencies
         shell: pwsh
+        env:
+          PESTER_VERSION: ${{ env.PESTER_VERSION }}
+          PSSA_VERSION:   ${{ env.PSSA_VERSION }}
         run: |
           Set-PSRepository PSGallery -InstallationPolicy Trusted
-          Install-Module Pester -Force -Scope CurrentUser -MinimumVersion 5.0.0
-          Install-Module PSScriptAnalyzer -Force -Scope CurrentUser
+          Install-Module Pester           -Force -Scope CurrentUser -RequiredVersion $env:PESTER_VERSION
+          Install-Module PSScriptAnalyzer -Force -Scope CurrentUser -RequiredVersion $env:PSSA_VERSION
 
       - name: Build module (production)
         shell: pwsh
@@ -47,6 +56,10 @@ jobs:
     name: Publish to PSGallery
     runs-on: ubuntu-latest
     needs: test
+    permissions:
+      contents:     read
+      id-token:     write    # needed by attest-build-provenance for OIDC
+      attestations: write    # needed by attest-build-provenance to write the attestation
 
     steps:
       - name: Checkout repository
@@ -54,9 +67,11 @@ jobs:
 
       - name: Install dependencies
         shell: pwsh
+        env:
+          PSSA_VERSION: ${{ env.PSSA_VERSION }}
         run: |
           Set-PSRepository PSGallery -InstallationPolicy Trusted
-          Install-Module PSScriptAnalyzer -Force -Scope CurrentUser
+          Install-Module PSScriptAnalyzer -Force -Scope CurrentUser -RequiredVersion $env:PSSA_VERSION
 
       - name: Build module (production)
         shell: pwsh
@@ -70,6 +85,18 @@ jobs:
           Write-Host "Module: $($manifest.Name)"
           Write-Host "Version: $($manifest.Version)"
           Write-Host "Functions: $($manifest.ExportedFunctions.Count)"
+
+      - name: Generate build provenance attestation
+        # Creates a cryptographic attestation that this PowerNetbox.psd1 +
+        # PowerNetbox.psm1 were built by THIS workflow run. Consumers can
+        # verify via `gh attestation verify`. Free alternative to a paid
+        # Authenticode code-signing certificate (SignPath application is
+        # in progress separately for the full signature chain).
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: |
+            ./PowerNetbox/PowerNetbox.psd1
+            ./PowerNetbox/PowerNetbox.psm1
 
       - name: Publish to PowerShell Gallery
         shell: pwsh


### PR DESCRIPTION
## Summary

Wraps up the three Tier 2 follow-ups that were documented-not-fixed in PR #404's review doc. Pure CI/release-pipeline hardening — no runtime module code changes.

## What's changed

### 1. Pin Pester + PSScriptAnalyzer in \`release.yml\` (MEDIUM — DS-1)

Previously \`Install-Module Pester -MinimumVersion 5.0.0\` and \`Install-Module PSScriptAnalyzer\` (no constraint). Both now use \`-RequiredVersion\` from a workflow-level \`env:\` block:

\`\`\`yaml
env:
  PESTER_VERSION: '5.7.1'    # current latest on PSGallery
  PSSA_VERSION:   '1.25.0'   # current latest on PSGallery
\`\`\`

Protects the runner that holds \`secrets.PSGALLERY_API_KEY\` from a supply-chain compromise against either module.

### 2. \`.github/dependabot.yml\` — new (LOW)

- **github-actions** ecosystem — weekly, grouped minor/patch updates to reduce PR noise. Addresses the Tier 1 MEDIUM about unpinned \`actions/*\` references.
- Note: PSGallery is **not** supported by Dependabot, so module pins in release.yml remain manual (header comment documents this).
- Note: the \`docker\` ecosystem was initially included but is a no-op — Dependabot only scans files named exactly \`Dockerfile\`. Our \`Dockerfile.branching\` is invisible to it, and the netbox-docker image is already tracked manually against the CI matrix. Documented as a known gap instead of forcing a rename.

### 3. Build provenance attestation (bonus)

\`actions/attest-build-provenance@v2\` step before \`Publish-Module\`, producing a cryptographic attestation that the published \`.psd1\` + \`.psm1\` were built by this workflow run. Complements the in-progress SignPath application (full Authenticode signature chain still TBD).

Consumer verification once a signed release lands:

\`\`\`bash
gh attestation verify ./PowerNetbox.psd1 --repo ctrl-alt-automate/PowerNetbox
\`\`\`

## Test plan

- [ ] Gitleaks CI green
- [ ] Pester × 4 OSes green (no runtime code changes)
- [ ] Dependabot config validates on GitHub — first PRs should appear within ~1h after merge if syntax is OK
- [ ] Next release (v4.6.0) will be the first to produce an attestation