### PR TITLE
ci: add patterns: ['*'] to dependabot actions-minor-patch group (#406 follow-up)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,6 +33,12 @@ updates:
     groups:
       actions-minor-patch:
         applies-to: version-updates
+        # Dependabot requires at least one of `patterns`, `exclude-patterns`,
+        # or `dependency-type` for the group to match anything. Without it,
+        # the group silently matches zero dependencies and every update
+        # opens its own PR — exactly the noise we meant to avoid.
+        patterns:
+          - "*"
         update-types:
           - "minor"
           - "patch"


### PR DESCRIPTION
## Summary

Fixup for PR #406. Gemini caught this ~1 min after that PR merged.

## Issue

The \`actions-minor-patch\` group in \`.github/dependabot.yml\` has no selection criterion (\`patterns\`, \`exclude-patterns\`, or \`dependency-type\`). Per GitHub Dependabot docs, a group without at least one of these silently matches zero dependencies — so the grouping has no effect and every update would still open its own PR.

## Fix

Added \`patterns: ['*']\` to match all GitHub Actions in the group, plus an inline comment explaining why the selector is required (so future contributors don't make the same mistake).

## Test plan

- [ ] GitHub Dependabot API validates the config (runs as a status check on the PR)
- [ ] Standard Pester / Gitleaks CI pass (no behavioural changes)
- [ ] First real-world verification: aankomende maandag 06:00 NL-tijd — we should see one grouped PR instead of one-per-action