### PR TITLE
docs: add new-netbox-endpoint reference skill (.claude/skills/)

### DIFF
--- a/.claude/skills/new-netbox-endpoint/SKILL.md
+++ b/.claude/skills/new-netbox-endpoint/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: new-netbox-endpoint
-description: Use when adding a new NetBox REST API endpoint to PowerNetbox as a set of PowerShell cmdlets (Get / New / Set / Remove). Covers function templates, parameter conventions, test patterns, ValidateSet parity checks, and the PS 5.1 / Nullable / Tags gotchas that recur on this codebase.
+description: Use when adding or porting a PowerShell cmdlet that wraps a NetBox REST API endpoint in PowerNetbox — creating a Get-NB, New-NB, Set-NB, or Remove-NB function for a new or missing resource, touching a ValidateSet on an existing one, or writing the matching Pester tests.
 ---
 
 # Adding a new NetBox endpoint to PowerNetbox
@@ -52,6 +52,15 @@ logging (never `Write-Host` in non-interactive paths).
 
 ### GET
 
+Add query filter parameters (`-Label`, `-Parent`, `-Status`, etc.) inside
+the `ParameterSet = 'Query'` group — they flow through `BuildURIComponents`
+automatically and appear as `?name=value` query params. Match the NetBox
+API field name one-to-one (e.g. API field `mark_utilized` → PS param
+`Mark_Utilized`; snake→PascalCase via underscore). Type-check each:
+numeric IDs as `[uint64]`, booleans as `[bool]` (never `[switch]`), arrays
+as `[string[]]` or `[uint64[]]` depending on whether the API filter
+expects names or IDs.
+
 ```powershell
 function Get-NB[Module][Resource] {
     [CmdletBinding(DefaultParameterSetName = 'Query')]
@@ -63,6 +72,10 @@ function Get-NB[Module][Resource] {
         [uint64[]]$Id,
         [Parameter(ParameterSetName = 'Query')]
         [string]$Name,
+        # [Parameter(ParameterSetName = 'Query')]
+        # [string]$Status,                                # <-- filter params go here
+        # [Parameter(ParameterSetName = 'Query')]
+        # [uint64]$Site_Id,
         [uint16]$Limit,
         [uint16]$Offset,
         [switch]$Brief,
@@ -71,12 +84,13 @@ function Get-NB[Module][Resource] {
         [switch]$Raw
     )
     process {
-        # Enforce mutual exclusion — user can pick ONE projection strategy.
-        # See Functions/Helpers/AssertNBMutualExclusiveParam.ps1 (PR #397/#400).
+        # MANDATORY on every Get cmdlet since PR #397/#400.
+        # User picks exactly one projection — Brief, Fields, OR Omit.
         AssertNBMutualExclusiveParam `
             -BoundParameters $PSBoundParameters `
             -Parameters 'Brief', 'Fields', 'Omit'
 
+        Write-Verbose "Retrieving <Resource>"
         switch ($PSCmdlet.ParameterSetName) {
             'ByID' {
                 foreach ($i in $Id) {
@@ -105,10 +119,14 @@ function New-NB[Module][Resource] {
     param (
         [Parameter(Mandatory)]
         [string]$Name,
-        [object[]]$Tags,   # prefer [object[]] over [string[]] / [uint64[]] — see Pitfalls
+        # Prefer [object[]] for Tags — it accepts both IDs (uint64) and
+        # strings. Older cmdlets use [string[]] or [uint64[]] and are
+        # kept as-is for back-compat, but new code should use [object[]].
+        [object[]]$Tags,
         [switch]$Raw
     )
     process {
+        Write-Verbose "Creating <Resource>: $Name"
         $Segments = [System.Collections.ArrayList]::new(@('<module>', '<resource>'))
         $URIComponents = BuildURIComponents -URISegments $Segments.Clone() `
             -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw'
@@ -133,6 +151,7 @@ function Set-NB[Module][Resource] {
         [switch]$Raw
     )
     process {
+        Write-Verbose "Updating <Resource> ID $Id"
         $Segments = [System.Collections.ArrayList]::new(@('<module>', '<resource>', $Id))
         $URIComponents = BuildURIComponents -URISegments $Segments.Clone() `
             -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw'
@@ -157,6 +176,7 @@ function Remove-NB[Module][Resource] {
         [switch]$Raw
     )
     process {
+        Write-Verbose "Deleting <Resource> ID $Id"
         if ($PSCmdlet.ShouldProcess($Id, 'Delete <Resource>')) {
             InvokeNetboxRequest `
                 -URI (BuildNewURI -Segments @('<module>', '<resource>', $Id)) `

--- a/.claude/skills/new-netbox-endpoint/SKILL.md
+++ b/.claude/skills/new-netbox-endpoint/SKILL.md
@@ -77,7 +77,7 @@ function Get-NB[Module][Resource] {
         # [Parameter(ParameterSetName = 'Query')]
         # [uint64]$Site_Id,
         [uint16]$Limit,
-        [uint16]$Offset,
+        [uint32]$Offset,   # uint32, not uint16 — NetBox datasets (IPAM, Circuits) exceed 65 535 items
         [switch]$Brief,
         [string[]]$Fields,
         [string[]]$Omit,
@@ -93,8 +93,19 @@ function Get-NB[Module][Resource] {
         Write-Verbose "Retrieving <Resource>"
         switch ($PSCmdlet.ParameterSetName) {
             'ByID' {
+                # Pass projection params (Brief / Fields / Omit) through on
+                # detail endpoints too — NetBox supports ?brief=1 / ?fields=
+                # / ?omit= on /api/<module>/<resource>/<id>/ (not just on
+                # list endpoints). Call BuildURIComponents with 'Id', 'Raw',
+                # 'All', 'PageSize' skipped so only Brief/Fields/Omit and any
+                # other meaningful flags end up as query params.
                 foreach ($i in $Id) {
-                    InvokeNetboxRequest -URI (BuildNewURI -Segments @('<module>', '<resource>', $i)) -Raw:$Raw
+                    $Segments = [System.Collections.ArrayList]::new(@('<module>', '<resource>', $i))
+                    $URIComponents = BuildURIComponents -URISegments $Segments.Clone() `
+                        -ParametersDictionary $PSBoundParameters `
+                        -SkipParameterByName 'Id', 'Raw', 'All', 'PageSize'
+                    $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
+                    InvokeNetboxRequest -URI $URI -Raw:$Raw
                 }
             }
             default {

--- a/.claude/skills/new-netbox-endpoint/SKILL.md
+++ b/.claude/skills/new-netbox-endpoint/SKILL.md
@@ -175,6 +175,60 @@ function Set-NB[Module][Resource] {
 }
 ```
 
+#### SET — null-clearing for enum string parameters
+
+When a `Set-*` function's parameter has `[ValidateSet]` and the user needs
+to be able to *clear* that field server-side (send JSON `null`), the
+`[AllowNull()] [ValidateSet] [string]` combination doesn't work —
+PowerShell coerces `$null` to `""` at bind time and then ValidateSet
+rejects the empty string (see Pitfalls row 3).
+
+Pattern used on `Set-NBDCIMInterface` (`Duplex`, `POE_Mode`, `POE_Type`,
+`RF_Role`, `Mode`) from PR #401 — add `''` to the ValidateSet as a
+caller-visible sentinel, use `[AllowEmptyString()]`, then translate `''`
+→ `$null` in `process {}` **before** `BuildURIComponents` so the PATCH
+body carries a literal JSON `null`:
+
+```powershell
+function Set-NB[Module][Resource] {
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Medium')]
+    param (
+        [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
+        [uint64]$Id,
+
+        [AllowEmptyString()]
+        [ValidateSet('full', 'half', 'auto', '', IgnoreCase = $true)]
+        [string]$Duplex,                 # pass '' to clear server-side
+
+        [switch]$Raw
+    )
+    process {
+        # Translate '' → $null for the clearable enum params BEFORE
+        # BuildURIComponents, so the PATCH body becomes {"duplex": null}
+        # rather than {"duplex": ""} (which NetBox rejects).
+        $clearable = @('Duplex')
+        foreach ($p in $clearable) {
+            if ($PSBoundParameters.ContainsKey($p) -and $PSBoundParameters[$p] -eq '') {
+                $PSBoundParameters[$p] = $null
+            }
+        }
+
+        $Segments = [System.Collections.ArrayList]::new(@('<module>', '<resource>', $Id))
+        $URIComponents = BuildURIComponents -URISegments $Segments.Clone() `
+            -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw'
+        if ($PSCmdlet.ShouldProcess($Id, 'Update <Resource>')) {
+            InvokeNetboxRequest `
+                -URI (BuildNewURI -Segments $URIComponents.Segments) `
+                -Method PATCH -Body $URIComponents.Parameters -Raw:$Raw
+        }
+    }
+}
+```
+
+Numeric parameters needing null-clearing use `[Nullable[T]]` instead —
+see Pitfalls row 2 for the `[ValidateRange]` + `[Nullable[int]]` conflict
+and PR #398 for the rollout across 9 numeric Interface parameters.
+
 ### REMOVE
 
 ```powershell

--- a/.claude/skills/new-netbox-endpoint/SKILL.md
+++ b/.claude/skills/new-netbox-endpoint/SKILL.md
@@ -1,0 +1,274 @@
+---
+name: new-netbox-endpoint
+description: Use when adding a new NetBox REST API endpoint to PowerNetbox as a set of PowerShell cmdlets (Get / New / Set / Remove). Covers function templates, parameter conventions, test patterns, ValidateSet parity checks, and the PS 5.1 / Nullable / Tags gotchas that recur on this codebase.
+---
+
+# Adding a new NetBox endpoint to PowerNetbox
+
+## Overview
+
+Each NetBox endpoint maps to up to four cmdlets: `Get-NB*`, `New-NB*`,
+`Set-NB*`, `Remove-NB*`. Each cmdlet is one file under
+`Functions/<Module>/<Resource>/`, and all four share a consistent shape
+driven by a central `InvokeNetboxRequest` + `BuildURIComponents` helpers.
+The job of this skill is to make the fifth, fiftieth, and five-hundredth
+endpoint look identical.
+
+## When this applies
+
+- NetBox ships a new API endpoint (e.g. new minor release adds `/api/dcim/<x>/`).
+- An issue asks for a missing resource (pattern seen on #356, #362-#364, #383).
+- A drift report from `scripts/Verify-ValidateSetParity.ps1` flags a new
+  enum you want to expose.
+- You are porting a cmdlet from community code (e.g. NetboxPS) to PowerNetbox conventions.
+
+## Workflow (in order)
+
+1. **Scope** — Is the endpoint read-only, read-write, or read-only-and-ephemeral (job-style)?
+   That decides how many of the four cmdlets you need. Get-only is fine; you
+   don't need `New`/`Set`/`Remove` if NetBox doesn't expose POST/PATCH/DELETE.
+2. **Research** — skim the NetBox OpenAPI spec at
+   `https://<host>/api/schema/` (or for dev: use
+   `/.claude/commands/netbox-api.md` shorthand). Note every required field,
+   every ChoiceSet, every pagination quirk.
+3. **ValidateSet parity** — for every `ValidateSet` attribute you add,
+   run `scripts/Verify-ValidateSetParity.ps1 -Function <Name>` against the
+   NetBox version you target. Drift is the single most common bug class on
+   this codebase (#360, #365, #385, #389, #392).
+4. **Implement** — one file per cmdlet, copy from the templates below.
+5. **Test** — one `Context "<cmdlet>"` per cmdlet in
+   `Tests/<Module>.Tests.ps1`. Mock at the `InvokeNetboxRequest` level,
+   not `Invoke-RestMethod`, unless the cmdlet bypasses it (file uploads, SVG).
+6. **Build + verify** — `./deploy.ps1 -Environment dev -SkipVersion`,
+   then `Invoke-Pester ./Tests/<Module>.Tests.ps1`.
+7. **Revert build artefacts before commit** —
+   `git checkout PowerNetbox.psd1` (deploy.ps1 updates its date).
+
+## Cmdlet templates
+
+All four templates share: `[CmdletBinding()]`, explicit `process {}` for
+pipeline support, `-Raw` switch, `Write-Verbose` for any operational
+logging (never `Write-Host` in non-interactive paths).
+
+### GET
+
+```powershell
+function Get-NB[Module][Resource] {
+    [CmdletBinding(DefaultParameterSetName = 'Query')]
+    param (
+        [switch]$All,
+        [ValidateRange(1, 1000)]
+        [int]$PageSize = 100,
+        [Parameter(ParameterSetName = 'ByID', ValueFromPipelineByPropertyName)]
+        [uint64[]]$Id,
+        [Parameter(ParameterSetName = 'Query')]
+        [string]$Name,
+        [uint16]$Limit,
+        [uint16]$Offset,
+        [switch]$Brief,
+        [string[]]$Fields,
+        [string[]]$Omit,
+        [switch]$Raw
+    )
+    process {
+        # Enforce mutual exclusion — user can pick ONE projection strategy.
+        # See Functions/Helpers/AssertNBMutualExclusiveParam.ps1 (PR #397/#400).
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
+
+        switch ($PSCmdlet.ParameterSetName) {
+            'ByID' {
+                foreach ($i in $Id) {
+                    InvokeNetboxRequest -URI (BuildNewURI -Segments @('<module>', '<resource>', $i)) -Raw:$Raw
+                }
+            }
+            default {
+                $Segments = [System.Collections.ArrayList]::new(@('<module>', '<resource>'))
+                $URIComponents = BuildURIComponents -URISegments $Segments.Clone() `
+                    -ParametersDictionary $PSBoundParameters `
+                    -SkipParameterByName 'Raw', 'All', 'PageSize'
+                InvokeNetboxRequest `
+                    -URI (BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters) `
+                    -Raw:$Raw -All:$All -PageSize $PageSize
+            }
+        }
+    }
+}
+```
+
+### NEW
+
+```powershell
+function New-NB[Module][Resource] {
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Low')]
+    param (
+        [Parameter(Mandatory)]
+        [string]$Name,
+        [object[]]$Tags,   # prefer [object[]] over [string[]] / [uint64[]] — see Pitfalls
+        [switch]$Raw
+    )
+    process {
+        $Segments = [System.Collections.ArrayList]::new(@('<module>', '<resource>'))
+        $URIComponents = BuildURIComponents -URISegments $Segments.Clone() `
+            -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw'
+        if ($PSCmdlet.ShouldProcess($Name, 'Create <Resource>')) {
+            InvokeNetboxRequest `
+                -URI (BuildNewURI -Segments $URIComponents.Segments) `
+                -Method POST -Body $URIComponents.Parameters -Raw:$Raw
+        }
+    }
+}
+```
+
+### SET (PATCH)
+
+```powershell
+function Set-NB[Module][Resource] {
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Medium')]
+    param (
+        [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
+        [uint64]$Id,
+        [string]$Name,
+        [switch]$Raw
+    )
+    process {
+        $Segments = [System.Collections.ArrayList]::new(@('<module>', '<resource>', $Id))
+        $URIComponents = BuildURIComponents -URISegments $Segments.Clone() `
+            -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw'
+        if ($PSCmdlet.ShouldProcess($Id, 'Update <Resource>')) {
+            InvokeNetboxRequest `
+                -URI (BuildNewURI -Segments $URIComponents.Segments) `
+                -Method PATCH -Body $URIComponents.Parameters -Raw:$Raw
+        }
+    }
+}
+```
+
+### REMOVE
+
+```powershell
+function Remove-NB[Module][Resource] {
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
+    [OutputType([void])]
+    param (
+        [Parameter(Mandatory, ValueFromPipelineByPropertyName)]
+        [uint64]$Id,
+        [switch]$Raw
+    )
+    process {
+        if ($PSCmdlet.ShouldProcess($Id, 'Delete <Resource>')) {
+            InvokeNetboxRequest `
+                -URI (BuildNewURI -Segments @('<module>', '<resource>', $Id)) `
+                -Method DELETE -Raw:$Raw
+        }
+    }
+}
+```
+
+## Test pattern
+
+Most test files mock at the **module API surface** — that is,
+`InvokeNetboxRequest` — not the lower-level `Invoke-RestMethod`. Nice
+side effect: your test doesn't care about auth headers, retry logic,
+or cross-platform HTTP differences.
+
+```powershell
+Describe "<Module> tests" -Tag '<Module>' {
+    BeforeAll {
+        Mock -CommandName 'CheckNetboxIsConnected' -ModuleName 'PowerNetbox' -MockWith { return $true }
+        Mock -CommandName 'InvokeNetboxRequest'    -ModuleName 'PowerNetbox' -MockWith {
+            return [ordered]@{
+                'Method' = if ($Method) { $Method } else { 'GET' }   # defaults don't apply to mocks
+                'Uri'    = $URI.Uri.AbsoluteUri                        # AbsoluteUri encodes spaces as %20
+                'Body'   = if ($Body) { $Body | ConvertTo-Json -Compress } else { $null }
+            }
+        }
+        InModuleScope -ModuleName 'PowerNetbox' {
+            $script:NetboxConfig.Hostname = 'netbox.domain.com'
+            $script:NetboxConfig.HostScheme = 'https'
+            $script:NetboxConfig.HostPort = 443
+        }
+    }
+
+    Context "Get-NB<Module><Resource>" {
+        It "Should request the list endpoint" {
+            $r = Get-NB<Module><Resource>
+            $r.Method | Should -Be 'GET'
+            $r.Uri    | Should -Be 'https://netbox.domain.com/api/<module>/<resource>/'
+        }
+    }
+}
+```
+
+Mock at `Invoke-RestMethod` level only when the cmdlet bypasses
+`InvokeNetboxRequest`: `New-NBImageAttachment` (multipart form),
+`Export-NBRackElevation` SVG mode, `ErrorHandling.Tests.ps1`,
+`Setup.Tests.ps1`, `CrossPlatform.Tests.ps1`, `Branching.Tests.ps1`.
+
+## ValidateSet parity — run it
+
+Every time you add or edit a `ValidateSet`:
+
+```pwsh
+./scripts/Verify-ValidateSetParity.ps1 -NetboxVersion v<x.y.z>
+# Or scope to the cmdlet you touched:
+./scripts/Verify-ValidateSetParity.ps1 -Function New-NBDCIMInterface
+```
+
+If your parameter deliberately has values NetBox's choices.py doesn't have
+(e.g. the `''` empty-string sentinel for PATCH null-clearing, or local
+meta-values like `'Both'` for rack elevation), add an exemption to
+`scripts/validateset-parity-exclusions.txt` with a comment explaining why.
+
+## Pitfalls (things that have bitten us more than once)
+
+| Pitfall | Cause | Fix |
+|---|---|---|
+| Windows PS 5.1 CI fails with "Missing closing '}'" at some line far from the real issue | Non-ASCII char (em-dash U+2014, arrows, curly quotes) in a `.ps1` file without a UTF-8 BOM — PS 5.1 parses as Windows-1252 | Stay ASCII in `.ps1` identifiers and test titles. Markdown `.md` files are unaffected. (Recurring: PR #398, PR #404) |
+| `[ValidateRange]` + `[Nullable[int]]` throws `ValidationMetadataException` on `$null` | ValidateRange binds before Nullable wrapping | Drop `[ValidateRange]` on `Set-*` versions that need null-clearing; rely on server-side validation (PR #398) |
+| `[AllowNull()] [ValidateSet(...)] [string]$X` rejects `$null` | PS coerces `$null` → `""` before ValidateSet runs | Use `[AllowEmptyString()] [ValidateSet('a','b','',...)]` and translate `''` → `$null` in `process{}` before `BuildURIComponents` (PR #401) |
+| Pester mock gets `$null` for default-valued params | Default values do not apply inside `MockWith` | Add explicit defaults inside the mock (see test template above) |
+| `ConvertTo-Json` mangles nested objects at the default depth | `ConvertTo-Json` defaults to `-Depth 2` | Pass `-Depth 10` explicitly when needed |
+| PSCustomObject iterated like a hashtable throws | PSCustomObject is not a hashtable | Use `$obj.PSObject.Properties` to iterate |
+| Build artefact noise in git diff | `deploy.ps1` updates `PowerNetbox.psd1` date on every build | `git checkout PowerNetbox.psd1` before staging |
+| Bulk operations pipeline runs unboundedly | No client throttle by default | `Send-NBBulkRequest` has `MaxItems = 10000` cap; pass `-BatchSize` to size each POST |
+| Pagination `.next` follow to wrong host | Server-controlled URL could be attacker-controlled | `InvokeNetboxRequest` validates origin against original URI via `GetLeftPart(Authority)` (PR #404) |
+
+## Parameter naming conventions
+
+- **Snake-case** in the cmdlet body: parameters map 1:1 to NetBox API fields.
+  `Device_Type` (PS) → `device_type` (API) — done automatically by `BuildURIComponents`.
+- `Id` (not `ID`) for PowerShell consistency with pipeline binding.
+- `Tags` should be `[object[]]` — see Pitfalls. Older cmdlets use
+  `[string[]]` or `[uint64[]]`; left as-is for compat, but new code uses `[object[]]`.
+- `-Raw` switch on every cmdlet (returns the full response object rather than
+  the `.results` array).
+- Boolean API fields: use `[bool]`, not `[switch]`. Switches mean "omitted
+  vs supplied" but NetBox treats missing vs false differently.
+
+## Verification before PR
+
+- [ ] `./deploy.ps1 -Environment dev -SkipVersion` — build succeeds, no duplicate function names
+- [ ] `Invoke-Pester ./Tests/<Module>.Tests.ps1` — all green
+- [ ] `Invoke-ScriptAnalyzer -Path ./Functions/<Module>/<new file>.ps1` — clean
+- [ ] `./scripts/Verify-ValidateSetParity.ps1` — no new drift findings
+- [ ] `./scripts/Verify-FilterExclusion.ps1` — if you touched any `Get-NB*.ps1`, see `docs/guides/` if unfamiliar
+- [ ] `grep -nP "[^\x00-\x7F]" Functions/... Tests/...` — no non-ASCII in `.ps1` files
+- [ ] `git checkout PowerNetbox.psd1` — revert build-artefact drift before committing
+
+## Pointers
+
+| Topic | File |
+|---|---|
+| Central HTTP helper | `Functions/Helpers/InvokeNetboxRequest.ps1` |
+| Body + URL parameter assembly | `Functions/Helpers/BuildURIComponents.ps1` |
+| URL builder | `Functions/Helpers/BuildNewURI.ps1` |
+| Auth header construction (v1 vs v2) | `Functions/Helpers/Get-NBRequestHeaders.ps1` |
+| Mutex helper for Brief / Fields / Omit | `Functions/Helpers/AssertNBMutualExclusiveParam.ps1` |
+| Bulk operations | `Functions/Helpers/Send-NBBulkRequest.ps1` |
+| ValidateSet parity script | `scripts/Verify-ValidateSetParity.ps1` |
+| ValidateSet parity exceptions | `scripts/validateset-parity-exclusions.txt` |
+| Filter exclusion auditor | `scripts/Verify-FilterExclusion.ps1` |
+| Exemption file for filter auditor | `scripts/filter-exclusion-exemptions.txt` |
+| NetBox best-practices reference | `../netbox-best-practices/` (parent project dir) |

--- a/.claude/skills/new-netbox-endpoint/SKILL.md
+++ b/.claude/skills/new-netbox-endpoint/SKILL.md
@@ -201,7 +201,7 @@ Describe "<Module> tests" -Tag '<Module>' {
             return [ordered]@{
                 'Method' = if ($Method) { $Method } else { 'GET' }   # defaults don't apply to mocks
                 'Uri'    = $URI.Uri.AbsoluteUri                        # AbsoluteUri encodes spaces as %20
-                'Body'   = if ($Body) { $Body | ConvertTo-Json -Compress } else { $null }
+                'Body'   = if ($Body) { $Body | ConvertTo-Json -Compress -Depth 10 } else { $null }
             }
         }
         InModuleScope -ModuleName 'PowerNetbox' {
@@ -252,6 +252,7 @@ meta-values like `'Both'` for rack elevation), add an exemption to
 | `ConvertTo-Json` mangles nested objects at the default depth | `ConvertTo-Json` defaults to `-Depth 2` | Pass `-Depth 10` explicitly when needed |
 | PSCustomObject iterated like a hashtable throws | PSCustomObject is not a hashtable | Use `$obj.PSObject.Properties` to iterate |
 | Build artefact noise in git diff | `deploy.ps1` updates `PowerNetbox.psd1` date on every build | `git checkout PowerNetbox.psd1` before staging |
+| `-Tags` parameter accepts only names or only IDs, not both | Older cmdlets type `Tags` as `[string[]]` (names) or `[uint64[]]` (IDs) — mutually exclusive | New cmdlets: `[object[]]$Tags` so callers can pass a mix. Legacy cmdlets left as-is for back-compat; add `[object[]]` only on new code |
 | Bulk operations pipeline runs unboundedly | No client throttle by default | `Send-NBBulkRequest` has `MaxItems = 10000` cap; pass `-BatchSize` to size each POST |
 | Pagination `.next` follow to wrong host | Server-controlled URL could be attacker-controlled | `InvokeNetboxRequest` validates origin against original URI via `GetLeftPart(Authority)` (PR #404) |
 

--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,9 @@ concatenated.ps1
 *.apikey
 
 # Development files (keep in dev branch only)
-.claude/
+.claude/*
+!.claude/skills/
+!.claude/skills/**
 CLAUDE.md
 Connect-DevNetbox.ps1
 .vscode/


### PR DESCRIPTION
## Summary

New project-scoped Claude Code skill codifying the repeatable workflow for adding a NetBox REST API endpoint to PowerNetbox as a set of cmdlets (Get / New / Set / Remove) with tests. Auto-discovered by Claude Code at \`.claude/skills/new-netbox-endpoint/SKILL.md\`; humans can read it as a regular markdown doc.

## Why

Five months of releases show the endpoint-addition workflow is the single most repeated pattern (#360, #365, #371, #381, #389, #394, PR #398, PR #401). Every time, someone pieces the same steps together from CLAUDE.md templates + memory notes + recent PR examples. The skill consolidates all of that into one coherent document.

Parallel benefit: community contributors get the same guidance automatically when their IDE/AI-assistant is pointed at this repo.

## What's in the skill

- **All 4 cmdlet templates** with parameter-set layout, pipeline input, Write-Verbose logging, SupportsShouldProcess, \`-Raw\` switch
- **Query-filter parameter placement** in the Get template
- **Test pattern** (mock at \`InvokeNetboxRequest\`, not \`Invoke-RestMethod\`) + Pester/UriBuilder/JSON-depth gotchas
- **MANDATORY** \`AssertNBMutualExclusiveParam\` on every Get cmdlet (per PR #397/#400)
- **ValidateSet parity** workflow against \`scripts/Verify-ValidateSetParity.ps1\`
- **Recurring pitfalls** table — PS 5.1 non-ASCII parse bug, \`[ValidateRange]\` + \`[Nullable[T]]\` conflict, empty-string sentinel for null-clearing, pagination \`.next\` origin validation, build-artefact drift
- **Parameter naming** conventions (snake_case → PascalCase via underscore, \`[object[]]$Tags\` for new cmdlets, \`[bool]\` not \`[switch]\` for API booleans)
- **Verification checklist** before PR

## Process

Used \`superpowers:writing-skills\` (TDD for skills). Dispatched an \`Explore\` subagent to cross-check templates against \`Functions/Extras/EventRules/*\` (known-good recent endpoint) + cross-reference with CLAUDE.md "Common Issues". Addressed three valid gaps in iteration 1:

- Added \`Write-Verbose\` to New/Set/Remove templates (actual repo code has it; my v1 didn't)
- Added query-filter placeholder block to the Get template
- Made the Brief/Fields/Omit mutex check explicitly MANDATORY

## .gitignore change

\`.claude/\` remains ignored for personal slash commands and \`settings.local.json\`, but \`.claude/skills/**\` is un-ignored so the skill tree is tracked and distributed with the repo.

## Not in this PR

CLAUDE.md refresh (removing duplicated templates, compressing 239 lines of old release notes to a one-line table, adding a "Security & reviews" section pointing at PRs #403-#407) was done as a local workstation change. CLAUDE.md is intentionally outside the git repo per \`.gitignore:26\`, so it doesn't participate in this PR.

## Test plan

- [ ] Gitleaks CI green (the skill contains example code blocks — should not trip)
- [ ] Pester × 4 OSes green (no runtime code changes)
- [ ] PSScriptAnalyzer green
- [ ] \`git check-ignore\` confirms the skill file is committed (not ignored by \`.claude/\` rule anymore)
- [ ] Gemini review for factual accuracy vs repo conventions