### PR TITLE
Allow null for integer parameters and add Description parameter

### DIFF
--- a/Functions/DCIM/Devices/Get-NBDCIMDevice.ps1
+++ b/Functions/DCIM/Devices/Get-NBDCIMDevice.ps1
@@ -182,7 +182,8 @@ function Get-NBDCIMDevice {
         [uint64]$Virtual_Chassis_Id,
 
         [Parameter(ParameterSetName = 'Query')]
-        [uint16]$Position,
+        [ValidateRange(0.5, 100)]
+        [double]$Position,
 
         [Parameter(ParameterSetName = 'Query')]
         [string]$Serial,

--- a/Functions/DCIM/Devices/New-NBDCIMDevice.ps1
+++ b/Functions/DCIM/Devices/New-NBDCIMDevice.ps1
@@ -20,8 +20,86 @@
 .PARAMETER Device_Type
     The device type ID. Required for single device creation.
 
+.PARAMETER Tenant
+    The tenant ID.
+
+.PARAMETER Platform
+    The platform ID.
+
+.PARAMETER Serial
+    The device serial number.
+
+.PARAMETER Asset_Tag
+    The device asset tag.
+
 .PARAMETER Site
     The site ID. Required for single device creation.
+
+.PARAMETER Location
+    The location ID.
+
+.PARAMETER Rack
+    The rack ID.
+
+.PARAMETER Postiton
+    The position within the rack (Valid range: 0.5-100).
+
+.PARAMETER Face
+    The rack face (front or rear).
+
+.PARAMETER Latitude
+    The latitude coordinate for the device's location.
+
+.PARAMETER Longitude
+    The longitude coordinate for the device's location.
+
+.PARAMETER Status
+    The device status. Optional for single device creation.
+    Valid values: offline, active, planned, staged, failed, inventory, decommissioning
+    Default: active
+
+.PARAMETER Airflow
+    The device airflow direction.
+    Valid values: front-to-rear, rear-to-front, left-to-right, right-to-left, side-to-rear, rear-to-side, bottom-to-top, top-to-bottom,passive, mixed
+
+.PARAMETER Primary_IP4
+    The primary IPv4 address ID.
+
+.PARAMETER Primary_IP6
+    The primary IPv6 address ID.
+
+.PARAMETER OOB_IP.
+    The out-of-band management IP address ID.
+
+.PARAMETER Cluster
+    The cluster ID.
+
+.PARAMETER Virtual_Chassis
+    The virtual chassis ID.
+
+.PARAMETER VC_Position
+    The virtual chassis position.
+
+.PARAMETER VC_Priority
+    The virtual chassis priority.
+
+.PARAMETER Description
+    A description of the device.
+
+.PARAMETER Comments
+    Additional comments about the device.
+
+.PARAMETER Config_template
+    The configuration template ID to associate with the device.
+
+.PARAMETER Local_Context_Data
+    The local context data for the device.
+
+.PARAMETER Tags
+    An array of tag names or IDs to assign to the device.
+
+.PARAMETER Custom_Fields
+    A hashtable of custom field values, where keys are field names and values are the corresponding values.
 
 .PARAMETER InputObject
     Pipeline input for bulk operations. Each object should contain
@@ -92,8 +170,15 @@ function New-NBDCIMDevice {
         [uint64]$Site,
 
         [Parameter(ParameterSetName = 'Single')]
+        [string]$Description,
+
+        [Parameter(ParameterSetName = 'Single')]
         [ValidateSet('offline', 'active', 'planned', 'staged', 'failed', 'inventory', 'decommissioning', IgnoreCase = $true)]
         [string]$Status = 'active',
+
+        [Parameter(ParameterSetName = 'Single')]
+        [ValidateSet('front-to-rear', 'rear-to-front', 'left-to-right', 'right-to-left', 'side-to-rear', 'rear-to-side', 'bottom-to-top', 'top-to-bottom','passive','mixed', IgnoreCase = $true)]
+        [string]$Airflow,
 
         [Parameter(ParameterSetName = 'Single')]
         [uint64]$Platform,
@@ -105,14 +190,24 @@ function New-NBDCIMDevice {
         [uint64]$Cluster,
 
         [Parameter(ParameterSetName = 'Single')]
+        [uint64]$Location,
+
+        [Parameter(ParameterSetName = 'Single')]
         [uint64]$Rack,
 
         [Parameter(ParameterSetName = 'Single')]
-        [uint16]$Position,
+        [ValidateRange(0.5, 100)]
+        [double]$Position,
 
         [Parameter(ParameterSetName = 'Single')]
         [ValidateSet('front', 'rear', IgnoreCase = $true)]
         [string]$Face,
+
+        [Parameter(ParameterSetName = 'Single')]
+        [double]$Latitude,
+
+        [Parameter(ParameterSetName = 'Single')]
+        [double]$Longitude,
 
         [Parameter(ParameterSetName = 'Single')]
         [string]$Serial,
@@ -136,7 +231,16 @@ function New-NBDCIMDevice {
         [uint64]$Primary_IP6,
 
         [Parameter(ParameterSetName = 'Single')]
+        [uint64]$OOB_ID,
+
+        [Parameter(ParameterSetName = 'Single')]
         [string]$Comments,
+
+        [Parameter(ParameterSetName = 'Single')]
+        [uint64]$Config_Template,
+
+        [Parameter(ParameterSetName = 'Single')]
+        [hashtable]$Local_Context_Data,
 
         [Parameter(ParameterSetName = 'Single')]
         [hashtable]$Custom_Fields,

--- a/Functions/DCIM/Devices/Set-NBDCIMDevice.ps1
+++ b/Functions/DCIM/Devices/Set-NBDCIMDevice.ps1
@@ -13,52 +13,100 @@
     The database ID of the device to update. Required for single updates.
 
 .PARAMETER Name
-    The new name for the device.
+    The name of the device. Required for single device creation.
+
 .PARAMETER Description
     The new description for the device.
 
 .PARAMETER Role
-    The device role ID.
-    Alias: Device_Role (backwards compatibility)
+    The device role ID or name. Required for single device creation.
+    Alias: Device_Role (backwards compatibility with Netbox 3.x)
 
 .PARAMETER Device_Type
-    The device type ID.
+    The device type ID. Required for single device creation.
 
-.PARAMETER Site
-    The site ID.
 
-.PARAMETER Status
-    Status of the device.
-
-.PARAMETER Platform
-    The platform ID.
 
 .PARAMETER Tenant
     The tenant ID.
 
-.PARAMETER Cluster
-    The cluster ID.
+.PARAMETER Platform
+    The platform ID.
+
+.PARAMETER Serial
+    The device serial number.
+
+.PARAMETER Asset_Tag
+    The device asset tag.
+
+.PARAMETER Site
+    The site ID. Required for single device creation.
+
+.PARAMETER Location
+    The location ID.
 
 .PARAMETER Rack
     The rack ID.
 
-.PARAMETER Position
-    Position in the rack.
+.PARAMETER Postiton
+    The position within the rack (Valid range: 0.5-100).
 
 .PARAMETER Face
-    Face of the device in the rack.
+    The rack face (front or rear).
 
-.PARAMETER Serial
-    Serial number.
+.PARAMETER Latitude
+    The latitude coordinate for the device's location.
 
-.PARAMETER Asset_Tag
-    Asset tag.
+.PARAMETER Longitude
+    The longitude coordinate for the device's location.
+
+.PARAMETER Status
+    The device status. Optional for single device creation.
+    Valid values: offline, active, planned, staged, failed, inventory, decommissioning
+    Default: active
+
+.PARAMETER Airflow
+    The device airflow direction.
+    Valid values: front-to-rear, rear-to-front, left-to-right, right-to-left, side-to-rear, rear-to-side, bottom-to-top, top-to-bottom,passive, mixed
+
+.PARAMETER Primary_IP4
+    The primary IPv4 address ID.
+
+.PARAMETER Primary_IP6
+    The primary IPv6 address ID.
+
+.PARAMETER OOB_IP.
+    The out-of-band management IP address ID.
+
+.PARAMETER Cluster
+    The cluster ID.
+
+.PARAMETER Virtual_Chassis
+    The virtual chassis ID.
+
+.PARAMETER VC_Position
+    The virtual chassis position.
+
+.PARAMETER VC_Priority
+    The virtual chassis priority.
+
+.PARAMETER Description
+    A description of the device.
 
 .PARAMETER Comments
-    Comments about the device.
+    Additional comments about the device.
+
+.PARAMETER Config_template
+    The configuration template ID to associate with the device.
+
+.PARAMETER Local_Context_Data
+    The local context data for the device.
+
+.PARAMETER Tags
+    An array of tag names or IDs to assign to the device.
 
 .PARAMETER Custom_Fields
-    Hashtable of custom field values.
+    A hashtable of custom field values, where keys are field names and values are the corresponding values.
 
 .PARAMETER Owner
     The owner ID for object ownership (Netbox 4.5+ only).
@@ -132,6 +180,10 @@ function Set-NBDCIMDevice {
         [string]$Status,
 
         [Parameter(ParameterSetName = 'Single')]
+        [ValidateSet('front-to-rear', 'rear-to-front', 'left-to-right', 'right-to-left', 'side-to-rear', 'rear-to-side', 'bottom-to-top', 'top-to-bottom','passive','mixed','', IgnoreCase = $true)]
+        [string]$Airflow,
+
+        [Parameter(ParameterSetName = 'Single')]
         [Nullable[uint64]]$Platform,
 
         [Parameter(ParameterSetName = 'Single')]
@@ -144,11 +196,17 @@ function Set-NBDCIMDevice {
         [Nullable[uint64]]$Rack,
 
         [Parameter(ParameterSetName = 'Single')]
-        [Nullable[uint16]]$Position,
+        [Nullable[double]]$Position,
 
         [Parameter(ParameterSetName = 'Single')]
         [ValidateSet('front', 'rear', IgnoreCase = $true)]
         [string]$Face,
+
+        [Parameter(ParameterSetName = 'Single')]
+        [Nullable[double]]$Latitude,
+
+        [Parameter(ParameterSetName = 'Single')]
+        [Nullable[double]]$Longitude,
 
         [Parameter(ParameterSetName = 'Single')]
         [string]$Serial,
@@ -172,7 +230,16 @@ function Set-NBDCIMDevice {
         [Nullable[uint64]]$Primary_IP6,
 
         [Parameter(ParameterSetName = 'Single')]
+        [Nullable[uint64]]$OOB_IP,
+
+        [Parameter(ParameterSetName = 'Single')]
         [string]$Comments,
+
+        [Parameter(ParameterSetName = 'Single')]
+        [Nullable[uint64]]$Config_Template,
+
+        [Parameter(ParameterSetName = 'Single')]
+        [hashtable]$Local_Context_Data,
 
         [Parameter(ParameterSetName = 'Single')]
         [hashtable]$Custom_Fields,

--- a/Functions/DCIM/Devices/Set-NBDCIMDevice.ps1
+++ b/Functions/DCIM/Devices/Set-NBDCIMDevice.ps1
@@ -25,8 +25,6 @@
 .PARAMETER Device_Type
     The device type ID. Required for single device creation.
 
-
-
 .PARAMETER Tenant
     The tenant ID.
 

--- a/Functions/DCIM/Devices/Set-NBDCIMDevice.ps1
+++ b/Functions/DCIM/Devices/Set-NBDCIMDevice.ps1
@@ -113,6 +113,9 @@ function Set-NBDCIMDevice {
         [string]$Name,
 
         [Parameter(ParameterSetName = 'Single')]
+        [string]$Description,
+
+        [Parameter(ParameterSetName = 'Single')]
         [Alias('Device_Role')]
         [object]$Role,
 
@@ -127,19 +130,19 @@ function Set-NBDCIMDevice {
         [string]$Status,
 
         [Parameter(ParameterSetName = 'Single')]
-        [uint64]$Platform,
+        [Nullable[uint64]]$Platform,
 
         [Parameter(ParameterSetName = 'Single')]
-        [uint64]$Tenant,
+        [Nullable[uint64]]$Tenant,
 
         [Parameter(ParameterSetName = 'Single')]
-        [uint64]$Cluster,
+        [Nullable[uint64]]$Cluster,
 
         [Parameter(ParameterSetName = 'Single')]
-        [uint64]$Rack,
+        [Nullable[uint64]]$Rack,
 
         [Parameter(ParameterSetName = 'Single')]
-        [uint16]$Position,
+        [Nullable[uint16]]$Position,
 
         [Parameter(ParameterSetName = 'Single')]
         [ValidateSet('front', 'rear', IgnoreCase = $true)]
@@ -152,19 +155,19 @@ function Set-NBDCIMDevice {
         [string]$Asset_Tag,
 
         [Parameter(ParameterSetName = 'Single')]
-        [uint64]$Virtual_Chassis,
+        [Nullable[uint64]]$Virtual_Chassis,
 
         [Parameter(ParameterSetName = 'Single')]
-        [uint64]$VC_Priority,
+        [Nullable[uint64]]$VC_Priority,
 
         [Parameter(ParameterSetName = 'Single')]
-        [uint64]$VC_Position,
+        [Nullable[uint64]]$VC_Position,
 
         [Parameter(ParameterSetName = 'Single')]
-        [uint64]$Primary_IP4,
+        [Nullable[uint64]]$Primary_IP4,
 
         [Parameter(ParameterSetName = 'Single')]
-        [uint64]$Primary_IP6,
+        [Nullable[uint64]]$Primary_IP6,
 
         [Parameter(ParameterSetName = 'Single')]
         [string]$Comments,
@@ -173,7 +176,7 @@ function Set-NBDCIMDevice {
         [hashtable]$Custom_Fields,
 
         [Parameter(ParameterSetName = 'Single')]
-        [uint64]$Owner,
+        [Nullable[uint64]]$Owner,
 
         # Bulk mode parameters
         [Parameter(ParameterSetName = 'Bulk', Mandatory = $true, ValueFromPipeline = $true)]

--- a/Functions/DCIM/Devices/Set-NBDCIMDevice.ps1
+++ b/Functions/DCIM/Devices/Set-NBDCIMDevice.ps1
@@ -14,6 +14,8 @@
 
 .PARAMETER Name
     The new name for the device.
+.PARAMETER Description
+    The new description for the device.
 
 .PARAMETER Role
     The device role ID.


### PR DESCRIPTION
Allow null for integer parameters and add Description parameter
This Change includes modifications to the `Set-NBDCIMDevice.ps1` function. The following changes were made:
1. The `Description` parameter was added to the function, allowing users to update the description of a device.
2. The various integer parameters were modified to allow null values, providing more flexibility when updating device information.
- Platform
- Tenant
- Cluster
- Rack
- Position
- Virtual_Chassis
- VC_Priority
- VC_Position
- Primary_IP4
- Primary_IP6
- Owner

## Description

This PR adds the ablity to set a devices description, and set the fields list above to a null value

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] CI/CD or build changes

## Related Issues

https://github.com/ctrl-alt-automate/PowerNetbox/issues/409

Fixes #

## Checklist

<!-- Ensure all items are checked before requesting review -->

### Code Quality
- [X] Code follows the [PowerShell Practice and Style Guidelines](https://poshcode.gitbook.io/powershell-practice-and-style/)
- [X] Functions use `[CmdletBinding()]` attribute
- [X] State-changing functions use `SupportsShouldProcess`
- [X] No hardcoded paths or credentials
- [X] `Write-Verbose` used for debugging (not `Write-Host`)

### Testing
- [ ] Existing tests pass (`Invoke-Pester ./Tests/`)
- [ ] New tests added for new functionality
- [X] Tested manually against Netbox instance (if applicable)

### Documentation
- [X] Function has proper comment-based help (`.SYNOPSIS`, `.DESCRIPTION`, `.EXAMPLE`)
- [ ] README updated (if needed)
- [ ] Wiki updated (if needed)

## Testing Performed

Tested setting various parameters to null against my instance of Netbox which is currently at 4.5.8

- Netbox version tested:4.5.8
- PowerShell version: 5.1.26100.7705
- Platform (Windows/Linux/macOS):Windows

## Screenshots (if applicable)

<!-- Add screenshots for UI-related changes -->

## Additional Notes

<!-- Any additional context or notes for reviewers -->
