### PR TITLE
Fix/contact assignments

### DIFF
--- a/Functions/Tenancy/ContactAssignment/Get-NBContactAssignment.ps1
+++ b/Functions/Tenancy/ContactAssignment/Get-NBContactAssignment.ps1
@@ -14,11 +14,11 @@ function Get-NBContactAssignment {
     .PARAMETER Id
         The database ID of the contact assignment.
 
-    .PARAMETER Content_Type_Id
-        Filter by content type database ID.
+    .PARAMETER Object_Type_Id
+        Filter by object type database ID.
 
-    .PARAMETER Content_Type
-        Filter by content type name (e.g., 'dcim.device', 'dcim.site').
+    .PARAMETER Object_Type
+        Filter by object type name (e.g., 'dcim.device', 'dcim.site').
 
     .PARAMETER Object_Id
         Filter by the assigned object's database ID.
@@ -88,10 +88,10 @@ function Get-NBContactAssignment {
         [uint64[]]$Id,
 
         [Parameter(ParameterSetName = 'Query')]
-        [uint64]$Content_Type_Id,
+        [uint64]$Object_Type_Id,
 
         [Parameter(ParameterSetName = 'Query')]
-        [string]$Content_Type,
+        [string]$Object_Type,
 
         [Parameter(ParameterSetName = 'Query')]
         [uint64]$Object_Id,

--- a/Functions/Tenancy/ContactAssignment/Get-NBContactAssignment.ps1
+++ b/Functions/Tenancy/ContactAssignment/Get-NBContactAssignment.ps1
@@ -88,9 +88,11 @@ function Get-NBContactAssignment {
         [uint64[]]$Id,
 
         [Parameter(ParameterSetName = 'Query')]
+        [Alias('Content_Type_Id')]
         [uint64]$Object_Type_Id,
 
         [Parameter(ParameterSetName = 'Query')]
+        [Alias('Content_Type')]
         [string]$Object_Type,
 
         [Parameter(ParameterSetName = 'Query')]

--- a/Functions/Tenancy/ContactAssignment/New-NBContactAssignment.ps1
+++ b/Functions/Tenancy/ContactAssignment/New-NBContactAssignment.ps1
@@ -7,8 +7,8 @@ function New-NBContactAssignment {
     .DESCRIPTION
         Creates a new contact role assignment in Netbox
 
-    .PARAMETER Content_Type
-        The content type for this assignment.
+    .PARAMETER Object_Type
+        The type of the object for this assignment.
 
     .PARAMETER Object_Id
         ID of the object to assign.
@@ -26,10 +26,10 @@ function New-NBContactAssignment {
         Return the unparsed data from the HTTP request
 
     .EXAMPLE
-        PS C:\> New-NBContactAssignment -Content_Type 'dcim.location' -Object_id 10 -Contact 15 -Role 10 -Priority 'Primary'
+        PS C:\> New-NBContactAssignment -Object_Type 'dcim.location' -Object_Id 10 -Contact 15 -Role 10 -Priority 'Primary'
 
     .NOTES
-        Valid content types: https://docs.netbox.dev/en/stable/features/contacts/#contacts_1
+        Valid object types: https://docs.netbox.dev/en/stable/features/contacts/#contacts_1
 #>
 
     [CmdletBinding(ConfirmImpact = 'Low',
@@ -40,7 +40,8 @@ function New-NBContactAssignment {
         [Parameter(Mandatory = $true,
                    ValueFromPipelineByPropertyName = $true)]
         [ValidateSet('circuits.circuit', 'circuits.provider', 'circuits.provideraccount', 'dcim.device', 'dcim.location', 'dcim.manufacturer', 'dcim.powerpanel', 'dcim.rack', 'dcim.region', 'dcim.site', 'dcim.sitegroup', 'tenancy.tenant', 'virtualization.cluster', 'virtualization.clustergroup', 'virtualization.virtualmachine', IgnoreCase = $true)]
-        [string]$Content_Type,
+        [Alias('Content_Type')]
+        [string]$Object_Type,
 
         [Parameter(Mandatory = $true)]
         [uint64]$Object_Id,
@@ -68,7 +69,7 @@ function New-NBContactAssignment {
 
         $URI = BuildNewURI -Segments $URIComponents.Segments
 
-        if ($PSCmdlet.ShouldProcess($Content_Type, 'Create new contact assignment')) {
+        if ($PSCmdlet.ShouldProcess($Object_Type, 'Create new contact assignment')) {
             InvokeNetboxRequest -URI $URI -Method POST -Body $URIComponents.Parameters -Raw:$Raw
         }
     }

--- a/Functions/Tenancy/ContactAssignment/Set-NBContactAssignment.ps1
+++ b/Functions/Tenancy/ContactAssignment/Set-NBContactAssignment.ps1
@@ -46,6 +46,7 @@ function Set-NBContactAssignment {
         [uint64]$Id,
 
         [Parameter(ValueFromPipelineByPropertyName = $true)]
+        [Alias('Content_Type')]
         [ValidateSet('circuits.circuit', 'circuits.provider', 'circuits.provideraccount', 'dcim.device', 'dcim.location', 'dcim.manufacturer', 'dcim.powerpanel', 'dcim.rack', 'dcim.region', 'dcim.site', 'dcim.sitegroup', 'tenancy.tenant', 'virtualization.cluster', 'virtualization.clustergroup', 'virtualization.virtualmachine', IgnoreCase = $true)]
         [string]$Object_Type,
 

--- a/Functions/Tenancy/ContactAssignment/Set-NBContactAssignment.ps1
+++ b/Functions/Tenancy/ContactAssignment/Set-NBContactAssignment.ps1
@@ -8,8 +8,11 @@ function Set-NBContactAssignment {
     .DESCRIPTION
         Updates a contact role assignment in Netbox
 
-    .PARAMETER Content_Type
-        The content type for this assignment.
+    .PARAMETER Id
+        The database ID of the contact assignment to update.
+
+    .PARAMETER Object_Type
+        The object type for this assignment.
 
     .PARAMETER Object_Id
         ID of the object to assign.
@@ -27,10 +30,10 @@ function Set-NBContactAssignment {
         Return the unparsed data from the HTTP request
 
     .EXAMPLE
-        PS C:\> Set-NBContactAssignment -Id 11 -Content_Type 'dcim.location' -Object_id 10 -Contact 15 -Role 10 -Priority 'Primary'
+        PS C:\> Set-NBContactAssignment -Id 11 -Object_Type 'dcim.location' -Object_id 10 -Contact 15 -Role 10 -Priority 'Primary'
 
     .NOTES
-        Valid content types: https://docs.netbox.dev/en/stable/features/contacts/#contacts_1
+        Valid object types: https://docs.netbox.dev/en/stable/features/contacts/#contacts_1
 #>
 
     [CmdletBinding(ConfirmImpact = 'Medium',
@@ -44,7 +47,7 @@ function Set-NBContactAssignment {
 
         [Parameter(ValueFromPipelineByPropertyName = $true)]
         [ValidateSet('circuits.circuit', 'circuits.provider', 'circuits.provideraccount', 'dcim.device', 'dcim.location', 'dcim.manufacturer', 'dcim.powerpanel', 'dcim.rack', 'dcim.region', 'dcim.site', 'dcim.sitegroup', 'tenancy.tenant', 'virtualization.cluster', 'virtualization.clustergroup', 'virtualization.virtualmachine', IgnoreCase = $true)]
-        [string]$Content_Type,
+        [string]$Object_Type,
 
         [uint64]$Object_Id,
 

--- a/Tests/Integration.Tests.ps1
+++ b/Tests/Integration.Tests.ps1
@@ -391,22 +391,25 @@ Describe "Live Integration Tests" -Tag 'Integration', 'Live' -Skip:(-not $script
         # Track created resources for cleanup (order matters - delete dependents first)
         $script:CreatedResources = @{
             # Level 1: Most dependent resources (delete first)
-            Devices         = [System.Collections.ArrayList]::new()
-            VMs             = [System.Collections.ArrayList]::new()
-            Interfaces      = [System.Collections.ArrayList]::new()
+            Devices             = [System.Collections.ArrayList]::new()
+            ContactAssignments  = [System.Collections.ArrayList]::new()
+            VMs                 = [System.Collections.ArrayList]::new()
+            Interfaces          = [System.Collections.ArrayList]::new()
             # Level 2: Mid-level resources
-            Addresses       = [System.Collections.ArrayList]::new()
-            Prefixes        = [System.Collections.ArrayList]::new()
-            VLANs           = [System.Collections.ArrayList]::new()
+            Addresses           = [System.Collections.ArrayList]::new()
+            Prefixes            = [System.Collections.ArrayList]::new()
+            VLANs               = [System.Collections.ArrayList]::new()
             # Level 3: Reference data
-            DeviceTypes     = [System.Collections.ArrayList]::new()
-            DeviceRoles     = [System.Collections.ArrayList]::new()
-            Manufacturers   = [System.Collections.ArrayList]::new()
-            Clusters        = [System.Collections.ArrayList]::new()
-            ClusterTypes    = [System.Collections.ArrayList]::new()
-            Sites           = [System.Collections.ArrayList]::new()
-            Tenants         = [System.Collections.ArrayList]::new()
-            Tags            = [System.Collections.ArrayList]::new()
+            DeviceTypes         = [System.Collections.ArrayList]::new()
+            DeviceRoles         = [System.Collections.ArrayList]::new()
+            Manufacturers       = [System.Collections.ArrayList]::new()
+            Clusters            = [System.Collections.ArrayList]::new()
+            ClusterTypes        = [System.Collections.ArrayList]::new()
+            Sites               = [System.Collections.ArrayList]::new()
+            Tenants             = [System.Collections.ArrayList]::new()
+            Tags                = [System.Collections.ArrayList]::new()
+            Contacts            = [System.Collections.ArrayList]::new()
+            ContactRoles        = [System.Collections.ArrayList]::new()
         }
 
         Write-Host "Test Run ID: $script:TestRunId" -ForegroundColor Cyan
@@ -440,6 +443,9 @@ Describe "Live Integration Tests" -Tag 'Integration', 'Live' -Skip:(-not $script
         }
         foreach ($id in $script:CreatedResources.Interfaces) {
             Remove-TestResource -ResourceType 'Interface' -Id $id -RemoveCommand { param($Id, $Confirm, $ErrorAction) Remove-NBDCIMInterface -Id $Id -Confirm:$Confirm -ErrorAction $ErrorAction }
+        }
+        foreach ($id in $script:CreatedResources.ContactAssignments) {
+            Remove-TestResource -ResourceType 'ContactAssignment' -Id $id -RemoveCommand { param($Id, $Confirm, $ErrorAction) Remove-NBContactAssignment -Id $Id -Confirm:$Confirm -ErrorAction $ErrorAction }
         }
 
         # Level 2: Mid-level resources
@@ -477,6 +483,12 @@ Describe "Live Integration Tests" -Tag 'Integration', 'Live' -Skip:(-not $script
         }
         foreach ($id in $script:CreatedResources.Tags) {
             Remove-TestResource -ResourceType 'Tag' -Id $id -RemoveCommand { param($Id, $Confirm, $ErrorAction) Remove-NBTag -Id $Id -Confirm:$Confirm -ErrorAction $ErrorAction }
+        }
+        foreach ($id in $script:CreatedResources.Contacts) {
+             Remove-TestResource -ResourceType 'Contact' -Id $id -RemoveCommand { param($Id, $Confirm, $ErrorAction) Remove-NBContact -Id $Id -Confirm:$Confirm -ErrorAction $ErrorAction }
+        }
+        foreach ($id in $script:CreatedResources.ContactRoles) {
+            Remove-TestResource -ResourceType 'ContactRole' -Id $id -RemoveCommand { param($Id, $Confirm, $ErrorAction) Remove-NBContactRole -Id $Id -Confirm:$Confirm -ErrorAction $ErrorAction }
         }
 
         # Report any cleanup errors
@@ -1188,6 +1200,153 @@ Describe "Live Integration Tests" -Tag 'Integration', 'Live' -Skip:(-not $script
             { Remove-NBTag -Id $script:TestTagId -Confirm:$false } | Should -Not -Throw
 
             $script:CreatedResources.Tags.Remove($script:TestTagId)
+        }
+    }
+
+    Context "Contact Role CRUD" {
+        BeforeAll {
+            $script:TestContactRoleName = "$($script:TestPrefix)-ContactRole"
+            $script:TestContactRoleSlug = $script:TestContactRoleName.ToLower() -replace '[^a-z0-9-]', '-'
+        }
+
+        It "Should create a contact role" {
+            $role = New-NBContactRole -Name $script:TestContactRoleName -Slug $script:TestContactRoleSlug
+
+            $role | Should -Not -BeNullOrEmpty
+            $role.name | Should -Be $script:TestContactRoleName
+
+            $script:TestContactRoleId = $role.id
+            [void]$script:CreatedResources.ContactRoles.Add($role.id)
+
+            Write-Host "  Created contact role: $($role.name) (ID: $($role.id))" -ForegroundColor Green
+        }
+
+        It "Should get contact role by ID" {
+            $role = Get-NBContactRole -Id $script:TestContactRoleId
+
+            $role | Should -Not -BeNullOrEmpty
+            $role.id | Should -Be $script:TestContactRoleId
+            $role.name | Should -Be $script:TestContactRoleName
+        }
+
+        It "Should update contact role" {
+            $role = Set-NBContactRole -Id $script:TestContactRoleId -Description "$script:TestPrefix - Updated Contact Role"
+
+            $role.description | Should -BeLike "*Updated*"
+        }
+    }
+
+    Context "Contact CRUD" {
+        BeforeAll {
+            $script:TestContactName = "$($script:TestPrefix)-Contact"
+            $script:TestContactSlug = $script:TestContactName.ToLower() -replace '[^a-z0-9-]', '-'
+        }
+
+        It "Should create a contact" {
+            $contact = New-NBContact -Name $script:TestContactName
+
+            $contact | Should -Not -BeNullOrEmpty
+            $contact.name | Should -Be $script:TestContactName
+
+            $script:TestContactId = $contact.id
+            [void]$script:CreatedResources.Contacts.Add($contact.id)
+
+            Write-Host "  Created contact: $($contact.name) (ID: $($contact.id))" -ForegroundColor Green
+        }
+
+        It "Should get contact by ID" {
+            $contact = Get-NBContact -Id $script:TestContactId
+
+            $contact | Should -Not -BeNullOrEmpty
+            $contact.id | Should -Be $script:TestContactId
+            $contact.name | Should -Be $script:TestContactName
+        }
+
+        It "Should update contact" {
+            $contact = Set-NBContact -Id $script:TestContactId -Description "$script:TestPrefix - Updated Contact"
+
+            $contact.description | Should -BeLike "*Updated*"
+        }
+    }
+
+    Context "Contact Assignment CRUD" {
+        BeforeAll {}
+
+        It "Should create a contact assignment to a site" {
+            $assignment = New-NBContactAssignment -Object_Type 'dcim.site' -Object_Id $script:TestSiteId -Contact $script:TestContactId -Role $script:TestContactRoleId
+
+            $assignment | Should -Not -BeNullOrEmpty
+            $assignment.contact.id | Should -Be $script:TestContactId
+            $assignment.role.id | Should -Be $script:TestContactRoleId
+            $assignment.priority | Should -BeNullOrEmpty
+
+            $script:TestContactAssignmentId = $assignment.id
+            [void]$script:CreatedResources.ContactAssignments.Add($assignment.id)
+
+            Write-Host "  Created contact assignment (ID: $($assignment.id))" -ForegroundColor Green
+        }
+
+        It "Should get contact assignment by ID" {
+            $assignment = Get-NBContactAssignment -Id $script:TestContactAssignmentId
+
+            $assignment | Should -Not -BeNullOrEmpty
+            $assignment.id | Should -Be $script:TestContactAssignmentId
+            $assignment.contact.id | Should -Be $script:TestContactId
+            $assignment.role.id | Should -Be $script:TestContactRoleId
+        }
+
+        It "Should get contact assignment by Contact_ID" {
+            $assignment = Get-NBContactAssignment -Contact_Id $script:TestContactId
+
+            $assignment | Should -Not -BeNullOrEmpty
+            $assignment.id | Should -Be $script:TestContactAssignmentId
+            $assignment.contact.id | Should -Be $script:TestContactId
+            $assignment.role.id | Should -Be $script:TestContactRoleId
+        }
+
+        It "Should get contact assignment by Object_ID" {
+            $assignment = Get-NBContactAssignment -Object_Id $script:TestSiteId
+
+            $assignment | Should -Not -BeNullOrEmpty
+            $assignment.id | Should -Be $script:TestContactAssignmentId
+            $assignment.contact.id | Should -Be $script:TestContactId
+            $assignment.role.id | Should -Be $script:TestContactRoleId
+        }
+
+        It "Should get contact assignment by Object_Type_ID" {
+            $objectType = Get-NBObjectType -App_Label 'dcim' -model 'site'
+            $assignment = Get-NBContactAssignment -Object_Type_Id $objectType.id
+
+            $assignment | Should -Not -BeNullOrEmpty
+            $assignment.id | Should -Be $script:TestContactAssignmentId
+            $assignment.contact.id | Should -Be $script:TestContactId
+            $assignment.role.id | Should -Be $script:TestContactRoleId
+        }
+
+        It "Should get contact assignment by Object_Type" {
+            $assignment = Get-NBContactAssignment -Object_Type 'dcim.site'
+
+            $assignment | Should -Not -BeNullOrEmpty
+            $assignment.id | Should -Be $script:TestContactAssignmentId
+            $assignment.contact.id | Should -Be $script:TestContactId
+            $assignment.role.id | Should -Be $script:TestContactRoleId
+        }
+
+        It "Should update contact assignment" {
+            $splat = @{
+                Id       = $script:TestContactAssignmentId
+                Priority = 'secondary'
+                Content_Type = 'dcim.site'
+            }
+            $assignment = Set-NBContactAssignment @splat
+
+            $assignment.priority.value | Should -Be 'secondary'
+        }
+
+        It "Should delete contact assignment" {
+            { Remove-NBContactAssignment -Id $script:TestContactAssignmentId -Confirm:$false } | Should -Not -Throw
+
+            $script:CreatedResources.ContactAssignments.Remove($script:TestContactAssignmentId)
         }
     }
 

--- a/Tests/Integration.Tests.ps1
+++ b/Tests/Integration.Tests.ps1
@@ -1336,7 +1336,7 @@ Describe "Live Integration Tests" -Tag 'Integration', 'Live' -Skip:(-not $script
             $splat = @{
                 Id       = $script:TestContactAssignmentId
                 Priority = 'secondary'
-                Content_Type = 'dcim.site'
+                Object_Type = 'dcim.site'
             }
             $assignment = Set-NBContactAssignment @splat
 

--- a/Tests/Integration.Tests.ps1
+++ b/Tests/Integration.Tests.ps1
@@ -435,6 +435,11 @@ Describe "Live Integration Tests" -Tag 'Integration', 'Live' -Skip:(-not $script
         # Cleanup in reverse dependency order (most dependent first)
 
         # Level 1: Most dependent resources
+        # ContactAssignments first — NetBox cascades them when their target (Device/VM/Site/…) is removed,
+        # so deleting the target before the assignment causes the explicit cleanup to 404.
+        foreach ($id in $script:CreatedResources.ContactAssignments) {
+            Remove-TestResource -ResourceType 'ContactAssignment' -Id $id -RemoveCommand { param($Id, $Confirm, $ErrorAction) Remove-NBContactAssignment -Id $Id -Confirm:$Confirm -ErrorAction $ErrorAction }
+        }
         foreach ($id in $script:CreatedResources.Devices) {
             Remove-TestResource -ResourceType 'Device' -Id $id -RemoveCommand { param($Id, $Confirm, $ErrorAction) Remove-NBDCIMDevice -Id $Id -Confirm:$Confirm -ErrorAction $ErrorAction }
         }
@@ -443,9 +448,6 @@ Describe "Live Integration Tests" -Tag 'Integration', 'Live' -Skip:(-not $script
         }
         foreach ($id in $script:CreatedResources.Interfaces) {
             Remove-TestResource -ResourceType 'Interface' -Id $id -RemoveCommand { param($Id, $Confirm, $ErrorAction) Remove-NBDCIMInterface -Id $Id -Confirm:$Confirm -ErrorAction $ErrorAction }
-        }
-        foreach ($id in $script:CreatedResources.ContactAssignments) {
-            Remove-TestResource -ResourceType 'ContactAssignment' -Id $id -RemoveCommand { param($Id, $Confirm, $ErrorAction) Remove-NBContactAssignment -Id $Id -Confirm:$Confirm -ErrorAction $ErrorAction }
         }
 
         # Level 2: Mid-level resources

--- a/Tests/Tenancy.Tests.ps1
+++ b/Tests/Tenancy.Tests.ps1
@@ -341,11 +341,11 @@ Describe "Tenancy Module Tests" -Tag 'Tenancy' {
 
     Context "New-NBContactAssignment" {
         It "Should create a contact assignment" {
-            $Result = New-NBContactAssignment -Content_Type 'dcim.site' -Object_Id 1 -Contact 5 -Role 2
+            $Result = New-NBContactAssignment -Object_Type 'dcim.site' -Object_Id 1 -Contact 5 -Role 2
             $Result.Method | Should -Be 'POST'
             $Result.Uri | Should -Be 'https://netbox.domain.com/api/tenancy/contact-assignments/'
             $bodyObj = $Result.Body | ConvertFrom-Json
-            $bodyObj.content_type | Should -Be 'dcim.site'
+            $bodyObj.object_type | Should -Be 'dcim.site'
             $bodyObj.object_id | Should -Be 1
             $bodyObj.contact | Should -Be 5
             $bodyObj.role | Should -Be 2

--- a/Tests/Tenancy.Tests.ps1
+++ b/Tests/Tenancy.Tests.ps1
@@ -385,7 +385,7 @@ Describe "Tenancy Module Tests" -Tag 'Tenancy' {
     Context "WhatIf Support" {
         $whatIfTestCases = @(
             @{ Command = 'New-NBContact'; Parameters = @{ Name = 'whatif-test' } }
-            @{ Command = 'New-NBContactAssignment'; Parameters = @{ Content_Type = 'dcim.device'; Object_Id = 1; Contact = 1; Role = 1 } }
+            @{ Command = 'New-NBContactAssignment'; Parameters = @{ Object_Type = 'dcim.device'; Object_Id = 1; Contact = 1; Role = 1 } }
             @{ Command = 'New-NBContactRole'; Parameters = @{ Name = 'whatif-test'; Slug = 'whatif-test' } }
             @{ Command = 'New-NBTenant'; Parameters = @{ Name = 'whatif-test'; Slug = 'whatif-test' } }
             @{ Command = 'New-NBTenantGroup'; Parameters = @{ Name = 'whatif-test' } }


### PR DESCRIPTION
## Description

Fixing the API calls for New/Set-NBContactAssignment (Issue #414).
Adding integration tests for New/Get/Set/Remove-NBContactAssignment.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] CI/CD or build changes

## Related Issues

Fixes #414

## Checklist

### Code Quality
- [x] Code follows the [PowerShell Practice and Style Guidelines](https://poshcode.gitbook.io/powershell-practice-and-style/)
- [x] Functions use `[CmdletBinding()]` attribute
- [x] State-changing functions use `SupportsShouldProcess`
- [x] No hardcoded paths or credentials
- [x] `Write-Verbose` used for debugging (not `Write-Host`)

### Testing
- [x] Existing tests pass (`Invoke-Pester ./Tests/`)
- [x] New tests added for new functionality
- [x] Tested manually against Netbox instance (if applicable)

Pls see additional notes.

### Documentation
- [x] Function has proper comment-based help (`.SYNOPSIS`, `.DESCRIPTION`, `.EXAMPLE`)
- [ ] README updated (if needed)
- [ ] Wiki updated (if needed)

## Testing Performed

- Netbox version tested: 4.4.9 (Docker) and 4.5.3
- PowerShell version: 7.6.1
- Platform (Windows/Linux/macOS): Windows

## Screenshots (if applicable)

N/A

## Additional Notes

- I did classify it as a non-breaking change, because IMO it could not have work before
  If this is not fine, I could add an Alias for the changed parameters.
- Some tests fail when using local Docker. 
  This only happens to tests not related with the functions modified.
  A first check indicates, the reason might be, that connection parameters are retrieved in differrent ways. This will be investigated further in the next days.
