### PR TITLE
feat: NetBox 4.6 field additions — ASN role, ModuleBay enabled, VM device/type, Rack airflow/form_factor (#395 Phase 1)

### DIFF
--- a/Functions/DCIM/ModuleBays/New-NBDCIMModuleBay.ps1
+++ b/Functions/DCIM/ModuleBays/New-NBDCIMModuleBay.ps1
@@ -6,6 +6,9 @@
     Creates a new DCIM ModuleBay in Netbox DCIM module.
     Supports pipeline input for Id parameter where applicable.
 
+.PARAMETER Enabled
+    Whether the module bay is enabled (NetBox 4.6+). Defaults to true server-side.
+
 .PARAMETER Raw
     Return the raw API response instead of the results array.
 
@@ -28,6 +31,7 @@ function New-NBDCIMModuleBay {
         [Parameter(Mandatory = $true)][string]$Name,
         [string]$Label,
         [string]$Position,
+        [bool]$Enabled,
         [string]$Description,
         [string[]]$Tags,
         [hashtable]$Custom_Fields,

--- a/Functions/DCIM/ModuleBays/Set-NBDCIMModuleBay.ps1
+++ b/Functions/DCIM/ModuleBays/Set-NBDCIMModuleBay.ps1
@@ -6,6 +6,9 @@
     Updates an existing DCIM ModuleBay in Netbox DCIM module.
     Supports pipeline input for Id parameter where applicable.
 
+.PARAMETER Enabled
+    Whether the module bay is enabled (NetBox 4.6+).
+
 .PARAMETER Raw
     Return the raw API response instead of the results array.
 
@@ -29,6 +32,7 @@ function Set-NBDCIMModuleBay {
         [string]$Name,
         [string]$Label,
         [string]$Position,
+        [bool]$Enabled,
         [string]$Description,
         [string[]]$Tags,
         [hashtable]$Custom_Fields,

--- a/Functions/DCIM/Racks/New-NBDCIMRack.ps1
+++ b/Functions/DCIM/Racks/New-NBDCIMRack.ps1
@@ -33,6 +33,12 @@ function New-NBDCIMRack {
     .PARAMETER Rack_Type
         The rack type ID
 
+    .PARAMETER Airflow
+        The rack airflow direction (NetBox 4.6+): 'front-to-rear' or 'rear-to-front'.
+
+    .PARAMETER Form_Factor
+        The rack form factor (NetBox 4.6+), e.g. '2-post-frame', '4-post-cabinet', 'wall-cabinet'.
+
     .PARAMETER Width
         The rack width (10 or 19 inches)
 

--- a/Functions/DCIM/Racks/New-NBDCIMRack.ps1
+++ b/Functions/DCIM/Racks/New-NBDCIMRack.ps1
@@ -121,6 +121,12 @@ function New-NBDCIMRack {
 
         [uint64]$Rack_Type,
 
+        [ValidateSet('front-to-rear', 'rear-to-front', IgnoreCase = $true)]
+        [string]$Airflow,
+
+        [ValidateSet('2-post-frame', '4-post-frame', '4-post-cabinet', 'wall-frame', 'wall-frame-vertical', 'wall-cabinet', 'wall-cabinet-vertical', IgnoreCase = $true)]
+        [string]$Form_Factor,
+
         [ValidateSet(10, 19, 21, 23)]
         [uint16]$Width,
 

--- a/Functions/DCIM/Racks/Set-NBDCIMRack.ps1
+++ b/Functions/DCIM/Racks/Set-NBDCIMRack.ps1
@@ -36,6 +36,14 @@ function Set-NBDCIMRack {
     .PARAMETER Rack_Type
         The rack type ID
 
+    .PARAMETER Airflow
+        The rack airflow direction (NetBox 4.6+): 'front-to-rear' or 'rear-to-front'.
+        Pass '' to clear the field server-side (sent as JSON null).
+
+    .PARAMETER Form_Factor
+        The rack form factor (NetBox 4.6+), e.g. '2-post-frame', '4-post-cabinet'.
+        Pass '' to clear the field server-side (sent as JSON null).
+
     .PARAMETER Width
         The rack width (10 or 19 inches)
 

--- a/Functions/DCIM/Racks/Set-NBDCIMRack.ps1
+++ b/Functions/DCIM/Racks/Set-NBDCIMRack.ps1
@@ -121,6 +121,14 @@ function Set-NBDCIMRack {
 
         [uint64]$Rack_Type,
 
+        [AllowEmptyString()]
+        [ValidateSet('front-to-rear', 'rear-to-front', '', IgnoreCase = $true)]
+        [string]$Airflow,
+
+        [AllowEmptyString()]
+        [ValidateSet('2-post-frame', '4-post-frame', '4-post-cabinet', 'wall-frame', 'wall-frame-vertical', 'wall-cabinet', 'wall-cabinet-vertical', '', IgnoreCase = $true)]
+        [string]$Form_Factor,
+
         [ValidateSet(10, 19, 21, 23)]
         [uint16]$Width,
 
@@ -165,6 +173,16 @@ function Set-NBDCIMRack {
 
     process {
         Write-Verbose "Updating DCIM Rack"
+
+        # Translate '' -> $null for clearable enum params BEFORE
+        # BuildURIComponents, so the PATCH body carries JSON null
+        # (NetBox rejects "" for these nullable enum fields).
+        foreach ($p in @('Airflow', 'Form_Factor')) {
+            if ($PSBoundParameters.ContainsKey($p) -and $PSBoundParameters[$p] -eq '') {
+                $PSBoundParameters[$p] = $null
+            }
+        }
+
         foreach ($RackId in $Id) {
 
             if ($Force -or $PSCmdlet.ShouldProcess("ID $RackId", "Update rack")) {

--- a/Functions/IPAM/ASN/Get-NBIPAMASN.ps1
+++ b/Functions/IPAM/ASN/Get-NBIPAMASN.ps1
@@ -101,6 +101,9 @@ function Get-NBIPAMASN {
         [Parameter(ParameterSetName = 'Query')]
         [uint64]$Site_Id,
 
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64]$Role_Id,
+
         [ValidateRange(1, 1000)]
         [uint16]$Limit,
 

--- a/Functions/IPAM/ASN/Get-NBIPAMASN.ps1
+++ b/Functions/IPAM/ASN/Get-NBIPAMASN.ps1
@@ -24,6 +24,9 @@ function Get-NBIPAMASN {
     .PARAMETER Site_Id
         Filter by site ID
 
+    .PARAMETER Role_Id
+        Filter by role ID (NetBox 4.6+)
+
     .PARAMETER Limit
         Limit the number of results
 

--- a/Functions/IPAM/ASN/New-NBIPAMASN.ps1
+++ b/Functions/IPAM/ASN/New-NBIPAMASN.ps1
@@ -15,6 +15,9 @@ function New-NBIPAMASN {
     .PARAMETER Tenant
         The tenant ID
 
+    .PARAMETER Role
+        The role ID assigned to this ASN (NetBox 4.6+)
+
     .PARAMETER Description
         A description of the ASN
 
@@ -52,6 +55,8 @@ function New-NBIPAMASN {
         [uint64]$RIR,
 
         [uint64]$Tenant,
+
+        [uint64]$Role,
 
         [string]$Description,
 

--- a/Functions/IPAM/ASN/Set-NBIPAMASN.ps1
+++ b/Functions/IPAM/ASN/Set-NBIPAMASN.ps1
@@ -18,6 +18,9 @@ function Set-NBIPAMASN {
     .PARAMETER Tenant
         The tenant ID
 
+    .PARAMETER Role
+        The role ID assigned to this ASN (NetBox 4.6+). Pass $null to clear.
+
     .PARAMETER Description
         A description of the ASN
 
@@ -52,6 +55,8 @@ function Set-NBIPAMASN {
         [uint64]$RIR,
 
         [uint64]$Tenant,
+
+        [Nullable[uint64]]$Role,
 
         [string]$Description,
 

--- a/Functions/Virtualization/VirtualMachine/New-NBVirtualMachine.ps1
+++ b/Functions/Virtualization/VirtualMachine/New-NBVirtualMachine.ps1
@@ -19,6 +19,13 @@
 .PARAMETER Cluster
     The cluster ID. Optional - VMs can be standalone in Netbox 4.x.
 
+.PARAMETER Device
+    The device ID to attach this VM to (NetBox 4.6+). Allows a clusterless,
+    device-bound VM.
+
+.PARAMETER Virtual_Machine_Type
+    The virtual machine type ID (NetBox 4.6+).
+
 .PARAMETER Tenant
     The tenant ID.
 

--- a/Functions/Virtualization/VirtualMachine/New-NBVirtualMachine.ps1
+++ b/Functions/Virtualization/VirtualMachine/New-NBVirtualMachine.ps1
@@ -115,6 +115,12 @@ function New-NBVirtualMachine {
         [uint64]$Cluster,
 
         [Parameter(ParameterSetName = 'Single')]
+        [uint64]$Device,
+
+        [Parameter(ParameterSetName = 'Single')]
+        [uint64]$Virtual_Machine_Type,
+
+        [Parameter(ParameterSetName = 'Single')]
         [uint64]$Tenant,
 
         [Parameter(ParameterSetName = 'Single')]

--- a/Functions/Virtualization/VirtualMachine/Set-NBVirtualMachine.ps1
+++ b/Functions/Virtualization/VirtualMachine/Set-NBVirtualMachine.ps1
@@ -21,6 +21,12 @@
 .PARAMETER Cluster
     The cluster ID.
 
+.PARAMETER Device
+    The device ID to attach this VM to (NetBox 4.6+). Pass $null to clear.
+
+.PARAMETER Virtual_Machine_Type
+    The virtual machine type ID (NetBox 4.6+). Pass $null to clear.
+
 .PARAMETER Status
     Status of the VM.
 

--- a/Functions/Virtualization/VirtualMachine/Set-NBVirtualMachine.ps1
+++ b/Functions/Virtualization/VirtualMachine/Set-NBVirtualMachine.ps1
@@ -116,6 +116,12 @@ function Set-NBVirtualMachine {
         [uint64]$Cluster,
 
         [Parameter(ParameterSetName = 'Single')]
+        [Nullable[uint64]]$Device,
+
+        [Parameter(ParameterSetName = 'Single')]
+        [Nullable[uint64]]$Virtual_Machine_Type,
+
+        [Parameter(ParameterSetName = 'Single')]
         [ValidateSet('offline', 'active', 'planned', 'staged', 'failed', 'decommissioning', 'paused', IgnoreCase = $true)]
         [string]$Status,
 

--- a/Tests/DCIM.Additional.Tests.ps1
+++ b/Tests/DCIM.Additional.Tests.ps1
@@ -1128,6 +1128,11 @@ Describe "DCIM Additional Tests" -Tag 'DCIM' {
             $Result.Method | Should -Be 'POST'
             $Result.Uri | Should -Be 'https://netbox.domain.com/api/dcim/module-bays/'
         }
+
+        It "Should send enabled (NetBox 4.6+, #395 Phase 1)" {
+            $Result = New-NBDCIMModuleBay -Device 1 -Name 'ModBay1' -Enabled $false
+            ($Result.Body | ConvertFrom-Json).enabled | Should -Be $false
+        }
     }
 
     Context "Set-NBDCIMModuleBay" {
@@ -1141,6 +1146,11 @@ Describe "DCIM Additional Tests" -Tag 'DCIM' {
             $Result = Set-NBDCIMModuleBay -Id 1 -Description 'Updated' -Confirm:$false
             $Result.Method | Should -Be 'PATCH'
             $Result.Uri | Should -Match '/api/dcim/module-bays/1/'
+        }
+
+        It "Should set enabled (NetBox 4.6+, #395 Phase 1)" {
+            $Result = Set-NBDCIMModuleBay -Id 1 -Enabled $false -Confirm:$false
+            ($Result.Body | ConvertFrom-Json).enabled | Should -Be $false
         }
     }
 

--- a/Tests/DCIM.Racks.Tests.ps1
+++ b/Tests/DCIM.Racks.Tests.ps1
@@ -64,6 +64,20 @@ Describe "DCIM Racks Tests" -Tag 'DCIM', 'Racks' {
                 ($Result.Body | ConvertFrom-Json).status | Should -Be 'available'
             }
         }
+
+        Context "NetBox 4.6 airflow / form_factor (#395 Phase 1)" {
+            It "Should send airflow" {
+                $Result = New-NBDCIMRack -Name 'rack' -Site 1 -Airflow 'front-to-rear'
+                ($Result.Body | ConvertFrom-Json).airflow | Should -Be 'front-to-rear'
+            }
+            It "Should send form_factor" {
+                $Result = New-NBDCIMRack -Name 'rack' -Site 1 -Form_Factor '4-post-cabinet'
+                ($Result.Body | ConvertFrom-Json).form_factor | Should -Be '4-post-cabinet'
+            }
+            It "Should reject an invalid form_factor" {
+                { New-NBDCIMRack -Name 'rack' -Site 1 -Form_Factor 'bogus' } | Should -Throw
+            }
+        }
     }
 
     Context "Set-NBDCIMRack" {
@@ -77,6 +91,24 @@ Describe "DCIM Racks Tests" -Tag 'DCIM', 'Racks' {
             It "Should accept -Status 'available'" {
                 $Result = Set-NBDCIMRack -Id 1 -Status 'available' -Confirm:$false
                 ($Result.Body | ConvertFrom-Json).status | Should -Be 'available'
+            }
+        }
+
+        Context "NetBox 4.6 airflow / form_factor null-clearing (#395 Phase 1)" {
+            It "Should set airflow" {
+                $Result = Set-NBDCIMRack -Id 1 -Airflow 'rear-to-front' -Confirm:$false
+                ($Result.Body | ConvertFrom-Json).airflow | Should -Be 'rear-to-front'
+            }
+            It "Should clear airflow with '' sentinel (JSON null)" {
+                $Result = Set-NBDCIMRack -Id 1 -Airflow '' -Confirm:$false
+                $bodyObj = $Result.Body | ConvertFrom-Json
+                # property present and explicitly null
+                $bodyObj.PSObject.Properties.Name | Should -Contain 'airflow'
+                $bodyObj.airflow | Should -BeNullOrEmpty
+            }
+            It "Should clear form_factor with '' sentinel" {
+                $Result = Set-NBDCIMRack -Id 1 -Form_Factor '' -Confirm:$false
+                ($Result.Body | ConvertFrom-Json).form_factor | Should -BeNullOrEmpty
             }
         }
     }

--- a/Tests/IPAM.Tests.ps1
+++ b/Tests/IPAM.Tests.ps1
@@ -670,6 +670,12 @@ Describe "IPAM tests" -Tag 'Ipam' {
             $bodyObj = $Result.Body | ConvertFrom-Json
             $bodyObj.asn | Should -Be 65000
         }
+
+        It "Should send the role (NetBox 4.6+)" {
+            $Result = New-NBIPAMASN -ASN 65001 -Role 3
+            $bodyObj = $Result.Body | ConvertFrom-Json
+            $bodyObj.role | Should -Be 3
+        }
     }
 
     Context "Set-NBIPAMASN" {
@@ -677,6 +683,16 @@ Describe "IPAM tests" -Tag 'Ipam' {
             $Result = Set-NBIPAMASN -Id 1 -Description 'Updated' -Confirm:$false
             $Result.Method | Should -Be 'PATCH'
             $Result.Uri | Should -Match '/api/ipam/asns/1/'
+        }
+
+        It "Should set the role (NetBox 4.6+)" {
+            $Result = Set-NBIPAMASN -Id 1 -Role 5 -Confirm:$false
+            ($Result.Body | ConvertFrom-Json).role | Should -Be 5
+        }
+
+        It "Should clear the role with `$null (NetBox 4.6+)" {
+            $Result = Set-NBIPAMASN -Id 1 -Role $null -Confirm:$false
+            $Result.Body | ConvertFrom-Json | Select-Object -ExpandProperty role | Should -BeNullOrEmpty
         }
     }
 

--- a/Tests/Virtualization.Tests.ps1
+++ b/Tests/Virtualization.Tests.ps1
@@ -300,6 +300,18 @@ Describe "Virtualization tests" -Tag 'Virtualization' {
             $bodyObj.cluster | Should -Be 1
         }
 
+        It "Should create a device-attached VM without a cluster (NetBox 4.6+, #12024)" {
+            $Result = New-NBVirtualMachine -Name 'edge-vm' -Device 7
+            $bodyObj = $Result.Body | ConvertFrom-Json
+            $bodyObj.device | Should -Be 7
+            $bodyObj.PSObject.Properties.Name | Should -Not -Contain 'cluster'
+        }
+
+        It "Should send virtual_machine_type (NetBox 4.6+, #5795)" {
+            $Result = New-NBVirtualMachine -Name 'typed-vm' -Cluster 1 -Virtual_Machine_Type 4
+            ($Result.Body | ConvertFrom-Json).virtual_machine_type | Should -Be 4
+        }
+
         It "Should create a VM with CPUs, Memory, Disk, tenancy, and comments" {
             $Result = New-NBVirtualMachine -Name 'testvm' -Cluster 1 -Status Active -vCPUs 4 -Memory 4096 -Tenant 11 -Disk 50 -Comments "these are comments"
             $Result.Method | Should -Be 'POST'
@@ -386,6 +398,20 @@ Describe "Virtualization tests" -Tag 'Virtualization' {
             $Result.Method | Should -Be 'PATCH'
             $Result.URI | Should -Be 'https://netbox.domain.com/api/virtualization/virtual-machines/1234/'
             $Result.Body | Should -Be '{"name":"newtestname"}'
+        }
+
+        It "Should set device + virtual_machine_type (NetBox 4.6+)" {
+            $Result = Set-NBVirtualMachine -Id 1234 -Device 7 -Virtual_Machine_Type 4 -Confirm:$false
+            $bodyObj = $Result.Body | ConvertFrom-Json
+            $bodyObj.device | Should -Be 7
+            $bodyObj.virtual_machine_type | Should -Be 4
+        }
+
+        It "Should clear device with `$null (NetBox 4.6+)" {
+            $Result = Set-NBVirtualMachine -Id 1234 -Device $null -Confirm:$false
+            $bodyObj = $Result.Body | ConvertFrom-Json
+            $bodyObj.PSObject.Properties.Name | Should -Contain 'device'
+            $bodyObj.device | Should -BeNullOrEmpty
         }
 
         It "Should set a VM with a new name, cluster, platform, and status" {

--- a/scripts/validateset-parity-exclusions.txt
+++ b/scripts/validateset-parity-exclusions.txt
@@ -63,3 +63,6 @@ DCIM/Interfaces/Set-NBDCIMInterface.ps1::Duplex
 DCIM/Interfaces/Set-NBDCIMInterface.ps1::POE_Mode
 DCIM/Interfaces/Set-NBDCIMInterface.ps1::POE_Type
 DCIM/Interfaces/Set-NBDCIMInterface.ps1::RF_Role
+# NetBox 4.6 Rack airflow/form_factor (#395 Phase 1) — same '' sentinel pattern.
+DCIM/Racks/Set-NBDCIMRack.ps1::Airflow
+DCIM/Racks/Set-NBDCIMRack.ps1::Form_Factor


### PR DESCRIPTION
## Summary

Phase 1 of the NetBox 4.6 coverage work (umbrella #395). Additive, non-breaking parameters for fields NetBox 4.6 added to **existing** models — verified live against the NetBox 4.6.0 OpenAPI schema (not release notes).

| Model | Param(s) | Type | NetBox ref |
|---|---|---|---|
| ASN | `New/Set -Role`, `Get -Role_Id` | `[uint64]` / `[Nullable[uint64]]` (clear) | #17654 |
| ModuleBay | `New/Set -Enabled` | `[bool]` | #20152 |
| VirtualMachine | `New/Set -Device`, `-Virtual_Machine_Type` | `[uint64]` / `[Nullable[uint64]]` (clear) | #12024, #5795 |
| Rack | `New/Set -Airflow`, `-Form_Factor` | `[ValidateSet][string]` (+ `''` clear sentinel on Set) | 4.6 RackAirflow/FormFactor |

Notes:
- `New-NBVirtualMachine -Cluster` was already optional (no `[Parameter(Mandatory)]`), so #12024 ("cluster optional") needed **no parameter-set redesign** — just the two additive FKs.
- Rack `-Airflow`/`-Form_Factor` on `Set-` use the `''` empty-string sentinel → `$null` translation pattern from PR #401 (`Set-NBDCIMInterface`) so callers can clear the field server-side. Parity exemptions added mirroring that precedent.

## Test plan

- [x] `Verify-ValidateSetParity.ps1 -NetboxVersion v4.6.0` — clean (14 exemptions)
- [x] 736 tests green: IPAM / DCIM.Racks / DCIM.Additional / Virtualization
- [x] New cases cover send + null-clear for role/device/vm_type and `''`-clear for airflow/form_factor, plus invalid-value rejection
- [ ] CI: full matrix on PR

Refs #395. Phase 2 (new endpoint families RackGroup / VirtualMachineType / CableBundle / VirtualDisk) follows as separate PRs.