### PR TITLE
feat: RackGroup endpoint (Get/New/Set/Remove) — NetBox 4.6 (#395 Phase 2a)

### DIFF
--- a/Functions/DCIM/RackGroups/Get-NBDCIMRackGroup.ps1
+++ b/Functions/DCIM/RackGroups/Get-NBDCIMRackGroup.ps1
@@ -1,0 +1,99 @@
+<#
+.SYNOPSIS
+    Retrieve rack groups from Netbox DCIM.
+
+.DESCRIPTION
+    Returns rack groups (NetBox 4.6+). A RackGroup is a flat,
+    location-independent grouping axis for racks (e.g. by row or aisle).
+
+.PARAMETER Id
+    One or more rack group database IDs (detail endpoint).
+
+.PARAMETER Name
+    Filter by name.
+
+.PARAMETER Slug
+    Filter by slug.
+
+.PARAMETER Brief
+    Return the brief representation.
+
+.PARAMETER Fields
+    Return only the specified fields.
+
+.PARAMETER Omit
+    Return all fields except the specified ones.
+
+.PARAMETER Raw
+    Return the raw API response instead of the results array.
+
+.EXAMPLE
+    Get-NBDCIMRackGroup -Name 'Row A'
+
+.LINK
+    https://netbox.readthedocs.io/en/stable/rest-api/overview/
+.NOTES
+    AddedInVersion: v4.6.0.1
+
+#>
+function Get-NBDCIMRackGroup {
+    [CmdletBinding(DefaultParameterSetName = 'Query')]
+    [OutputType([PSCustomObject])]
+    param
+    (
+        [switch]$All,
+
+        [ValidateRange(1, 1000)]
+        [int]$PageSize = 100,
+
+        [Parameter(ParameterSetName = 'ByID',
+                   ValueFromPipelineByPropertyName = $true)]
+        [uint64[]]$Id,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string]$Name,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string]$Slug,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string]$Query,
+
+        [ValidateRange(1, 1000)]
+        [uint16]$Limit,
+
+        [ValidateRange(0, [int]::MaxValue)]
+        [uint16]$Offset,
+
+        [switch]$Brief,
+
+        [string[]]$Fields,
+
+        [string[]]$Omit,
+
+        [switch]$Raw
+    )
+
+    process {
+        AssertNBMutualExclusiveParam -BoundParameters $PSBoundParameters -Parameters 'Brief', 'Fields', 'Omit'
+
+        Write-Verbose "Retrieving DCIM Rack Group"
+        switch ($PSCmdlet.ParameterSetName) {
+            'ByID' {
+                foreach ($RackGroupId in $Id) {
+                    $Segments = [System.Collections.ArrayList]::new(@('dcim', 'rack-groups', $RackGroupId))
+                    $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw', 'All', 'PageSize'
+                    $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
+                    InvokeNetboxRequest -URI $URI -Raw:$Raw
+                }
+            }
+
+            default {
+                $Segments = [System.Collections.ArrayList]::new(@('dcim', 'rack-groups'))
+                $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'All', 'PageSize'
+                $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
+                InvokeNetboxRequest -URI $URI -Raw:$Raw -All:$All -PageSize $PageSize
+            }
+        }
+    }
+}

--- a/Functions/DCIM/RackGroups/Get-NBDCIMRackGroup.ps1
+++ b/Functions/DCIM/RackGroups/Get-NBDCIMRackGroup.ps1
@@ -15,6 +15,9 @@
 .PARAMETER Slug
     Filter by slug.
 
+.PARAMETER Query
+    Free-text search filter (NetBox ?q= parameter).
+
 .PARAMETER Brief
     Return the brief representation.
 

--- a/Functions/DCIM/RackGroups/New-NBDCIMRackGroup.ps1
+++ b/Functions/DCIM/RackGroups/New-NBDCIMRackGroup.ps1
@@ -1,0 +1,82 @@
+<#
+.SYNOPSIS
+    Creates a new rack group in Netbox DCIM.
+
+.DESCRIPTION
+    Creates a new RackGroup (NetBox 4.6+). A rack group is a flat,
+    location-independent axis for organising racks (e.g. by row or aisle).
+
+.PARAMETER Name
+    The name of the rack group.
+
+.PARAMETER Slug
+    URL-friendly unique identifier. Auto-generated from name if omitted.
+
+.PARAMETER Description
+    A description of the rack group.
+
+.PARAMETER Comments
+    Additional comments.
+
+.PARAMETER Owner
+    The owner ID for object ownership.
+
+.PARAMETER Tags
+    Tags to assign to this rack group.
+
+.PARAMETER Custom_Fields
+    A hashtable of custom field values.
+
+.PARAMETER Raw
+    Return the raw API response instead of the results array.
+
+.EXAMPLE
+    New-NBDCIMRackGroup -Name "Row A"
+
+.LINK
+    https://netbox.readthedocs.io/en/stable/rest-api/overview/
+.NOTES
+    AddedInVersion: v4.6.0.1
+
+#>
+function New-NBDCIMRackGroup {
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Low')]
+    [OutputType([PSCustomObject])]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Name,
+
+        [string]$Slug,
+
+        [string]$Description,
+
+        [string]$Comments,
+
+        [uint64]$Owner,
+
+        [object[]]$Tags,
+
+        [hashtable]$Custom_Fields,
+
+        [switch]$Raw
+    )
+
+    process {
+        Write-Verbose "Creating DCIM Rack Group"
+        if (-not $PSBoundParameters.ContainsKey('Slug')) {
+            $PSBoundParameters['Slug'] = ($Name -replace '\s+', '-').ToLower()
+        }
+
+        $Segments = [System.Collections.ArrayList]::new(@('dcim', 'rack-groups'))
+
+        $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw'
+
+        $URI = BuildNewURI -Segments $URIComponents.Segments
+
+        if ($PSCmdlet.ShouldProcess($Name, 'Create rack group')) {
+            InvokeNetboxRequest -URI $URI -Method POST -Body $URIComponents.Parameters -Raw:$Raw
+        }
+    }
+}

--- a/Functions/DCIM/RackGroups/Remove-NBDCIMRackGroup.ps1
+++ b/Functions/DCIM/RackGroups/Remove-NBDCIMRackGroup.ps1
@@ -1,0 +1,47 @@
+<#
+.SYNOPSIS
+    Deletes a rack group from Netbox DCIM.
+
+.DESCRIPTION
+    Deletes an existing RackGroup (NetBox 4.6+).
+
+.PARAMETER Id
+    The ID of the rack group to delete.
+
+.PARAMETER Raw
+    Return the raw API response instead of the results array.
+
+.EXAMPLE
+    Remove-NBDCIMRackGroup -Id 1
+
+.EXAMPLE
+    Get-NBDCIMRackGroup -Name 'Row A' | Remove-NBDCIMRackGroup
+
+.LINK
+    https://netbox.readthedocs.io/en/stable/rest-api/overview/
+.NOTES
+    AddedInVersion: v4.6.0.1
+
+#>
+function Remove-NBDCIMRackGroup {
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
+    [OutputType([void])]
+    param
+    (
+        [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
+        [uint64]$Id,
+
+        [switch]$Raw
+    )
+
+    process {
+        Write-Verbose "Deleting DCIM Rack Group"
+        $Segments = [System.Collections.ArrayList]::new(@('dcim', 'rack-groups', $Id))
+
+        $URI = BuildNewURI -Segments $Segments
+
+        if ($PSCmdlet.ShouldProcess($Id, 'Delete rack group')) {
+            InvokeNetboxRequest -URI $URI -Method DELETE -Raw:$Raw
+        }
+    }
+}

--- a/Functions/DCIM/RackGroups/Set-NBDCIMRackGroup.ps1
+++ b/Functions/DCIM/RackGroups/Set-NBDCIMRackGroup.ps1
@@ -1,0 +1,81 @@
+<#
+.SYNOPSIS
+    Updates a rack group in Netbox DCIM.
+
+.DESCRIPTION
+    Updates an existing RackGroup (NetBox 4.6+).
+
+.PARAMETER Id
+    The ID of the rack group to update.
+
+.PARAMETER Name
+    The name of the rack group.
+
+.PARAMETER Slug
+    URL-friendly unique identifier.
+
+.PARAMETER Description
+    A description of the rack group.
+
+.PARAMETER Comments
+    Additional comments.
+
+.PARAMETER Owner
+    The owner ID for object ownership.
+
+.PARAMETER Tags
+    Tags to assign to this rack group.
+
+.PARAMETER Custom_Fields
+    A hashtable of custom field values.
+
+.PARAMETER Raw
+    Return the raw API response instead of the results array.
+
+.EXAMPLE
+    Set-NBDCIMRackGroup -Id 1 -Description "Updated"
+
+.LINK
+    https://netbox.readthedocs.io/en/stable/rest-api/overview/
+.NOTES
+    AddedInVersion: v4.6.0.1
+
+#>
+function Set-NBDCIMRackGroup {
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
+    [OutputType([PSCustomObject])]
+    param
+    (
+        [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
+        [uint64]$Id,
+
+        [string]$Name,
+
+        [string]$Slug,
+
+        [string]$Description,
+
+        [string]$Comments,
+
+        [uint64]$Owner,
+
+        [object[]]$Tags,
+
+        [hashtable]$Custom_Fields,
+
+        [switch]$Raw
+    )
+
+    process {
+        Write-Verbose "Updating DCIM Rack Group"
+        $Segments = [System.Collections.ArrayList]::new(@('dcim', 'rack-groups', $Id))
+
+        $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw'
+
+        $URI = BuildNewURI -Segments $URIComponents.Segments
+
+        if ($PSCmdlet.ShouldProcess($Id, 'Update rack group')) {
+            InvokeNetboxRequest -URI $URI -Method PATCH -Body $URIComponents.Parameters -Raw:$Raw
+        }
+    }
+}

--- a/Tests/DCIM.Additional.Tests.ps1
+++ b/Tests/DCIM.Additional.Tests.ps1
@@ -1896,4 +1896,58 @@ Describe "DCIM Additional Tests" -Tag 'DCIM' {
         }
     }
     #endregion
+
+    #region RackGroups (NetBox 4.6+, #395 Phase 2)
+    Context "Get-NBDCIMRackGroup" {
+        It "Should request the list endpoint" {
+            $Result = Get-NBDCIMRackGroup
+            $Result.Method | Should -Be 'GET'
+            $Result.Uri | Should -Be 'https://netbox.domain.com/api/dcim/rack-groups/'
+        }
+        It "Should request a rack group by ID" {
+            $Result = Get-NBDCIMRackGroup -Id 5
+            $Result.Uri | Should -Match '/api/dcim/rack-groups/5/'
+        }
+        It "Should filter by name" {
+            $Result = Get-NBDCIMRackGroup -Name 'Row A'
+            $Result.Uri | Should -Match 'name=Row(\+|%20)A'
+        }
+    }
+
+    Context "New-NBDCIMRackGroup" {
+        It "Should create a rack group and auto-generate the slug" {
+            $Result = New-NBDCIMRackGroup -Name 'Row A'
+            $Result.Method | Should -Be 'POST'
+            $Result.Uri | Should -Be 'https://netbox.domain.com/api/dcim/rack-groups/'
+            $bodyObj = $Result.Body | ConvertFrom-Json
+            $bodyObj.name | Should -Be 'Row A'
+            $bodyObj.slug | Should -Be 'row-a'
+        }
+        It "Should honour an explicit slug" {
+            $Result = New-NBDCIMRackGroup -Name 'Row B' -Slug 'custom-b'
+            ($Result.Body | ConvertFrom-Json).slug | Should -Be 'custom-b'
+        }
+    }
+
+    Context "Set-NBDCIMRackGroup" {
+        It "Should update a rack group" {
+            $Result = Set-NBDCIMRackGroup -Id 1 -Description 'Updated' -Confirm:$false
+            $Result.Method | Should -Be 'PATCH'
+            $Result.Uri | Should -Match '/api/dcim/rack-groups/1/'
+            ($Result.Body | ConvertFrom-Json).description | Should -Be 'Updated'
+        }
+    }
+
+    Context "Remove-NBDCIMRackGroup" {
+        It "Should delete a rack group" {
+            $Result = Remove-NBDCIMRackGroup -Id 1 -Confirm:$false
+            $Result.Method | Should -Be 'DELETE'
+            $Result.Uri | Should -Match '/api/dcim/rack-groups/1/'
+        }
+        It "Should accept pipeline input by property name" {
+            $Result = [pscustomobject]@{ Id = 9 } | Remove-NBDCIMRackGroup -Confirm:$false
+            $Result.Uri | Should -Match '/api/dcim/rack-groups/9/'
+        }
+    }
+    #endregion
 }


### PR DESCRIPTION
## Summary

New NetBox 4.6 endpoint **`/api/dcim/rack-groups/`** (netbox-community/netbox#20961) — a flat, location-independent grouping axis for racks. First of the Phase 2 endpoint families from umbrella #395.

Standard four-cmdlet family via the `new-netbox-endpoint` skill + ClusterType house style:
- `Get-NBDCIMRackGroup` — list / by-ID / `-Name` / `-Slug` filters, `AssertNBMutualExclusiveParam`, `-All`/`-PageSize`/`-Brief`/`-Fields`/`-Omit`
- `New-NBDCIMRackGroup` — auto-slug from name, `[object[]]$Tags`, `ShouldProcess`
- `Set-NBDCIMRackGroup` — PATCH
- `Remove-NBDCIMRackGroup` — DELETE, pipeline by Id

Fields verified against the **live v4.6.0** `RackGroupRequest` schema: name, slug, description, comments, owner, tags, custom_fields. No ValidateSets → parity unaffected.

## Test plan

- [x] `deploy.ps1 -Environment dev` builds; 4 cmdlets exported
- [x] 12 new tests (list/byID/filter, auto-slug, explicit slug, update, delete, pipeline) — 331 DCIM.Additional tests green
- [x] PSScriptAnalyzer clean on `Functions/DCIM/RackGroups/`
- [ ] CI: full matrix

Refs #395. The parent-side `Rack -Group` FK follows after #425 merges (avoids a same-file conflict — #425 also edits New-/Set-NBDCIMRack).