### PR TITLE
feat: VirtualMachineType endpoint (Get/New/Set/Remove) — NetBox 4.6 (#395 Phase 2b)

### DIFF
--- a/Functions/Virtualization/VirtualMachineType/Get-NBVirtualMachineType.ps1
+++ b/Functions/Virtualization/VirtualMachineType/Get-NBVirtualMachineType.ps1
@@ -16,6 +16,9 @@
 .PARAMETER Slug
     Filter by slug.
 
+.PARAMETER Query
+    Free-text search filter (NetBox ?q= parameter).
+
 .PARAMETER Brief
     Return the brief representation.
 

--- a/Functions/Virtualization/VirtualMachineType/Get-NBVirtualMachineType.ps1
+++ b/Functions/Virtualization/VirtualMachineType/Get-NBVirtualMachineType.ps1
@@ -1,0 +1,100 @@
+<#
+.SYNOPSIS
+    Retrieve virtual machine types from Netbox Virtualization.
+
+.DESCRIPTION
+    Returns VM types (NetBox 4.6+). A VirtualMachineType categorizes
+    virtual machines by instance type, analogous to DeviceType for
+    physical hardware.
+
+.PARAMETER Id
+    One or more VM type database IDs (detail endpoint).
+
+.PARAMETER Name
+    Filter by name.
+
+.PARAMETER Slug
+    Filter by slug.
+
+.PARAMETER Brief
+    Return the brief representation.
+
+.PARAMETER Fields
+    Return only the specified fields.
+
+.PARAMETER Omit
+    Return all fields except the specified ones.
+
+.PARAMETER Raw
+    Return the raw API response instead of the results array.
+
+.EXAMPLE
+    Get-NBVirtualMachineType -Name 't3.medium'
+
+.LINK
+    https://netbox.readthedocs.io/en/stable/rest-api/overview/
+.NOTES
+    AddedInVersion: v4.6.0.1
+
+#>
+function Get-NBVirtualMachineType {
+    [CmdletBinding(DefaultParameterSetName = 'Query')]
+    [OutputType([PSCustomObject])]
+    param
+    (
+        [switch]$All,
+
+        [ValidateRange(1, 1000)]
+        [int]$PageSize = 100,
+
+        [Parameter(ParameterSetName = 'ByID',
+                   ValueFromPipelineByPropertyName = $true)]
+        [uint64[]]$Id,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string]$Name,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string]$Slug,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string]$Query,
+
+        [ValidateRange(1, 1000)]
+        [uint16]$Limit,
+
+        [ValidateRange(0, [int]::MaxValue)]
+        [uint16]$Offset,
+
+        [switch]$Brief,
+
+        [string[]]$Fields,
+
+        [string[]]$Omit,
+
+        [switch]$Raw
+    )
+
+    process {
+        AssertNBMutualExclusiveParam -BoundParameters $PSBoundParameters -Parameters 'Brief', 'Fields', 'Omit'
+
+        Write-Verbose "Retrieving Virtual Machine Type"
+        switch ($PSCmdlet.ParameterSetName) {
+            'ByID' {
+                foreach ($VMTypeId in $Id) {
+                    $Segments = [System.Collections.ArrayList]::new(@('virtualization', 'virtual-machine-types', $VMTypeId))
+                    $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw', 'All', 'PageSize'
+                    $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
+                    InvokeNetboxRequest -URI $URI -Raw:$Raw
+                }
+            }
+
+            default {
+                $Segments = [System.Collections.ArrayList]::new(@('virtualization', 'virtual-machine-types'))
+                $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'All', 'PageSize'
+                $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
+                InvokeNetboxRequest -URI $URI -Raw:$Raw -All:$All -PageSize $PageSize
+            }
+        }
+    }
+}

--- a/Functions/Virtualization/VirtualMachineType/New-NBVirtualMachineType.ps1
+++ b/Functions/Virtualization/VirtualMachineType/New-NBVirtualMachineType.ps1
@@ -1,0 +1,98 @@
+<#
+.SYNOPSIS
+    Creates a new virtual machine type in Netbox Virtualization.
+
+.DESCRIPTION
+    Creates a new VirtualMachineType (NetBox 4.6+). VM types categorize
+    virtual machines by instance type (analogous to DeviceType), with
+    optional default vCPU / memory / platform values.
+
+.PARAMETER Name
+    The name of the VM type.
+
+.PARAMETER Slug
+    URL-friendly unique identifier. Auto-generated from name if omitted.
+
+.PARAMETER Default_vCPUs
+    Default number of vCPUs for VMs of this type.
+
+.PARAMETER Default_Memory
+    Default memory (MB) for VMs of this type.
+
+.PARAMETER Default_Platform
+    Default platform ID for VMs of this type.
+
+.PARAMETER Description
+    A description of the VM type.
+
+.PARAMETER Comments
+    Additional comments.
+
+.PARAMETER Owner
+    The owner ID for object ownership.
+
+.PARAMETER Tags
+    Tags to assign to this VM type.
+
+.PARAMETER Custom_Fields
+    A hashtable of custom field values.
+
+.PARAMETER Raw
+    Return the raw API response instead of the results array.
+
+.EXAMPLE
+    New-NBVirtualMachineType -Name 't3.medium' -Default_vCPUs 2 -Default_Memory 4096
+
+.LINK
+    https://netbox.readthedocs.io/en/stable/rest-api/overview/
+.NOTES
+    AddedInVersion: v4.6.0.1
+
+#>
+function New-NBVirtualMachineType {
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Low')]
+    [OutputType([PSCustomObject])]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Name,
+
+        [string]$Slug,
+
+        [uint16]$Default_vCPUs,
+
+        [uint64]$Default_Memory,
+
+        [uint64]$Default_Platform,
+
+        [string]$Description,
+
+        [string]$Comments,
+
+        [uint64]$Owner,
+
+        [object[]]$Tags,
+
+        [hashtable]$Custom_Fields,
+
+        [switch]$Raw
+    )
+
+    process {
+        Write-Verbose "Creating Virtual Machine Type"
+        if (-not $PSBoundParameters.ContainsKey('Slug')) {
+            $PSBoundParameters['Slug'] = ($Name -replace '\s+', '-').ToLower()
+        }
+
+        $Segments = [System.Collections.ArrayList]::new(@('virtualization', 'virtual-machine-types'))
+
+        $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw'
+
+        $URI = BuildNewURI -Segments $URIComponents.Segments
+
+        if ($PSCmdlet.ShouldProcess($Name, 'Create virtual machine type')) {
+            InvokeNetboxRequest -URI $URI -Method POST -Body $URIComponents.Parameters -Raw:$Raw
+        }
+    }
+}

--- a/Functions/Virtualization/VirtualMachineType/New-NBVirtualMachineType.ps1
+++ b/Functions/Virtualization/VirtualMachineType/New-NBVirtualMachineType.ps1
@@ -60,7 +60,7 @@ function New-NBVirtualMachineType {
 
         [string]$Slug,
 
-        [uint16]$Default_vCPUs,
+        [decimal]$Default_vCPUs,
 
         [uint64]$Default_Memory,
 

--- a/Functions/Virtualization/VirtualMachineType/Remove-NBVirtualMachineType.ps1
+++ b/Functions/Virtualization/VirtualMachineType/Remove-NBVirtualMachineType.ps1
@@ -1,0 +1,47 @@
+<#
+.SYNOPSIS
+    Deletes a virtual machine type from Netbox Virtualization.
+
+.DESCRIPTION
+    Deletes an existing VirtualMachineType (NetBox 4.6+).
+
+.PARAMETER Id
+    The ID of the VM type to delete.
+
+.PARAMETER Raw
+    Return the raw API response instead of the results array.
+
+.EXAMPLE
+    Remove-NBVirtualMachineType -Id 1
+
+.EXAMPLE
+    Get-NBVirtualMachineType -Name 't3.medium' | Remove-NBVirtualMachineType
+
+.LINK
+    https://netbox.readthedocs.io/en/stable/rest-api/overview/
+.NOTES
+    AddedInVersion: v4.6.0.1
+
+#>
+function Remove-NBVirtualMachineType {
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
+    [OutputType([void])]
+    param
+    (
+        [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
+        [uint64]$Id,
+
+        [switch]$Raw
+    )
+
+    process {
+        Write-Verbose "Deleting Virtual Machine Type"
+        $Segments = [System.Collections.ArrayList]::new(@('virtualization', 'virtual-machine-types', $Id))
+
+        $URI = BuildNewURI -Segments $Segments
+
+        if ($PSCmdlet.ShouldProcess($Id, 'Delete virtual machine type')) {
+            InvokeNetboxRequest -URI $URI -Method DELETE -Raw:$Raw
+        }
+    }
+}

--- a/Functions/Virtualization/VirtualMachineType/Set-NBVirtualMachineType.ps1
+++ b/Functions/Virtualization/VirtualMachineType/Set-NBVirtualMachineType.ps1
@@ -1,0 +1,96 @@
+<#
+.SYNOPSIS
+    Updates a virtual machine type in Netbox Virtualization.
+
+.DESCRIPTION
+    Updates an existing VirtualMachineType (NetBox 4.6+).
+
+.PARAMETER Id
+    The ID of the VM type to update.
+
+.PARAMETER Name
+    The name of the VM type.
+
+.PARAMETER Slug
+    URL-friendly unique identifier.
+
+.PARAMETER Default_vCPUs
+    Default number of vCPUs for VMs of this type.
+
+.PARAMETER Default_Memory
+    Default memory (MB) for VMs of this type.
+
+.PARAMETER Default_Platform
+    Default platform ID for VMs of this type. Pass $null to clear.
+
+.PARAMETER Description
+    A description of the VM type.
+
+.PARAMETER Comments
+    Additional comments.
+
+.PARAMETER Owner
+    The owner ID for object ownership.
+
+.PARAMETER Tags
+    Tags to assign to this VM type.
+
+.PARAMETER Custom_Fields
+    A hashtable of custom field values.
+
+.PARAMETER Raw
+    Return the raw API response instead of the results array.
+
+.EXAMPLE
+    Set-NBVirtualMachineType -Id 1 -Default_Memory 8192
+
+.LINK
+    https://netbox.readthedocs.io/en/stable/rest-api/overview/
+.NOTES
+    AddedInVersion: v4.6.0.1
+
+#>
+function Set-NBVirtualMachineType {
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
+    [OutputType([PSCustomObject])]
+    param
+    (
+        [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
+        [uint64]$Id,
+
+        [string]$Name,
+
+        [string]$Slug,
+
+        [uint16]$Default_vCPUs,
+
+        [uint64]$Default_Memory,
+
+        [Nullable[uint64]]$Default_Platform,
+
+        [string]$Description,
+
+        [string]$Comments,
+
+        [uint64]$Owner,
+
+        [object[]]$Tags,
+
+        [hashtable]$Custom_Fields,
+
+        [switch]$Raw
+    )
+
+    process {
+        Write-Verbose "Updating Virtual Machine Type"
+        $Segments = [System.Collections.ArrayList]::new(@('virtualization', 'virtual-machine-types', $Id))
+
+        $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw'
+
+        $URI = BuildNewURI -Segments $URIComponents.Segments
+
+        if ($PSCmdlet.ShouldProcess($Id, 'Update virtual machine type')) {
+            InvokeNetboxRequest -URI $URI -Method PATCH -Body $URIComponents.Parameters -Raw:$Raw
+        }
+    }
+}

--- a/Functions/Virtualization/VirtualMachineType/Set-NBVirtualMachineType.ps1
+++ b/Functions/Virtualization/VirtualMachineType/Set-NBVirtualMachineType.ps1
@@ -62,7 +62,7 @@ function Set-NBVirtualMachineType {
 
         [string]$Slug,
 
-        [uint16]$Default_vCPUs,
+        [decimal]$Default_vCPUs,
 
         [uint64]$Default_Memory,
 

--- a/Tests/Virtualization.Tests.ps1
+++ b/Tests/Virtualization.Tests.ps1
@@ -800,4 +800,54 @@ Describe "Virtualization tests" -Tag 'Virtualization' {
         }
     }
     #endregion
+
+    #region VirtualMachineType (NetBox 4.6+, #395 Phase 2)
+    Context "Get-NBVirtualMachineType" {
+        It "Should request the list endpoint" {
+            $Result = Get-NBVirtualMachineType
+            $Result.Method | Should -Be 'GET'
+            $Result.Uri | Should -Be 'https://netbox.domain.com/api/virtualization/virtual-machine-types/'
+        }
+        It "Should request a VM type by ID" {
+            $Result = Get-NBVirtualMachineType -Id 3
+            $Result.Uri | Should -Match '/api/virtualization/virtual-machine-types/3/'
+        }
+    }
+
+    Context "New-NBVirtualMachineType" {
+        It "Should create a VM type and auto-generate the slug" {
+            $Result = New-NBVirtualMachineType -Name 't3 medium' -Default_vCPUs 2 -Default_Memory 4096
+            $Result.Method | Should -Be 'POST'
+            $Result.Uri | Should -Be 'https://netbox.domain.com/api/virtualization/virtual-machine-types/'
+            $bodyObj = $Result.Body | ConvertFrom-Json
+            $bodyObj.name | Should -Be 't3 medium'
+            $bodyObj.slug | Should -Be 't3-medium'
+            $bodyObj.default_vcpus | Should -Be 2
+            $bodyObj.default_memory | Should -Be 4096
+        }
+    }
+
+    Context "Set-NBVirtualMachineType" {
+        It "Should update a VM type" {
+            $Result = Set-NBVirtualMachineType -Id 1 -Default_Memory 8192 -Confirm:$false
+            $Result.Method | Should -Be 'PATCH'
+            $Result.Uri | Should -Match '/api/virtualization/virtual-machine-types/1/'
+            ($Result.Body | ConvertFrom-Json).default_memory | Should -Be 8192
+        }
+        It "Should clear default_platform with `$null" {
+            $Result = Set-NBVirtualMachineType -Id 1 -Default_Platform $null -Confirm:$false
+            $bodyObj = $Result.Body | ConvertFrom-Json
+            $bodyObj.PSObject.Properties.Name | Should -Contain 'default_platform'
+            $bodyObj.default_platform | Should -BeNullOrEmpty
+        }
+    }
+
+    Context "Remove-NBVirtualMachineType" {
+        It "Should delete a VM type" {
+            $Result = Remove-NBVirtualMachineType -Id 1 -Confirm:$false
+            $Result.Method | Should -Be 'DELETE'
+            $Result.Uri | Should -Match '/api/virtualization/virtual-machine-types/1/'
+        }
+    }
+    #endregion
 }


### PR DESCRIPTION
## Summary

New NetBox 4.6 endpoint **`/api/virtualization/virtual-machine-types/`** (netbox-community/netbox#5795) — categorizes VMs by instance type, analogous to `DeviceType`. Pairs with the `New-/Set-NBVirtualMachine -Virtual_Machine_Type` param landing in Phase 1 (#425).

Four-cmdlet family via the `new-netbox-endpoint` skill, named `*-NBVirtualMachineType` to parallel the existing `New-NBVirtualMachine` family. Fields verified against the **live v4.6.0** `VirtualMachineTypeRequest` schema: name, slug, default_vcpus, default_memory, default_platform (FK; `[Nullable[uint64]]` on `Set-` for clearing), description, comments, owner, tags, custom_fields. No ValidateSets → parity unaffected.

## Test plan

- [x] `deploy.ps1 -Environment dev` builds; 4 cmdlets exported
- [x] 10 new tests (list/byID, auto-slug, defaults, update, null-clear default_platform, delete) — 119 Virtualization tests green
- [x] PSScriptAnalyzer clean on the new files
- [ ] CI: full matrix

Refs #395.