### PR TITLE
feat: CableBundle endpoint (Get/New/Set/Remove) — NetBox 4.6 (#395 Phase 2c)

### DIFF
--- a/Functions/DCIM/CableBundles/Get-NBDCIMCableBundle.ps1
+++ b/Functions/DCIM/CableBundles/Get-NBDCIMCableBundle.ps1
@@ -1,0 +1,95 @@
+<#
+.SYNOPSIS
+    Retrieve cable bundles from Netbox DCIM.
+
+.DESCRIPTION
+    Returns cable bundles (NetBox 4.6+). A CableBundle groups individual
+    cables that are managed as a single physical run (e.g. a bundle of
+    48 CAT6 cables between two patch panels). It is NOT for modeling
+    individual fiber strands within one cable.
+
+.PARAMETER Id
+    One or more cable bundle database IDs (detail endpoint).
+
+.PARAMETER Name
+    Filter by name.
+
+.PARAMETER Brief
+    Return the brief representation.
+
+.PARAMETER Fields
+    Return only the specified fields.
+
+.PARAMETER Omit
+    Return all fields except the specified ones.
+
+.PARAMETER Raw
+    Return the raw API response instead of the results array.
+
+.EXAMPLE
+    Get-NBDCIMCableBundle -Name 'PP1-PP2 trunk'
+
+.LINK
+    https://netbox.readthedocs.io/en/stable/rest-api/overview/
+.NOTES
+    AddedInVersion: v4.6.0.1
+
+#>
+function Get-NBDCIMCableBundle {
+    [CmdletBinding(DefaultParameterSetName = 'Query')]
+    [OutputType([PSCustomObject])]
+    param
+    (
+        [switch]$All,
+
+        [ValidateRange(1, 1000)]
+        [int]$PageSize = 100,
+
+        [Parameter(ParameterSetName = 'ByID',
+                   ValueFromPipelineByPropertyName = $true)]
+        [uint64[]]$Id,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string]$Name,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string]$Query,
+
+        [ValidateRange(1, 1000)]
+        [uint16]$Limit,
+
+        [ValidateRange(0, [int]::MaxValue)]
+        [uint16]$Offset,
+
+        [switch]$Brief,
+
+        [string[]]$Fields,
+
+        [string[]]$Omit,
+
+        [switch]$Raw
+    )
+
+    process {
+        AssertNBMutualExclusiveParam -BoundParameters $PSBoundParameters -Parameters 'Brief', 'Fields', 'Omit'
+
+        Write-Verbose "Retrieving DCIM Cable Bundle"
+        switch ($PSCmdlet.ParameterSetName) {
+            'ByID' {
+                foreach ($CableBundleId in $Id) {
+                    $Segments = [System.Collections.ArrayList]::new(@('dcim', 'cable-bundles', $CableBundleId))
+                    $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw', 'All', 'PageSize'
+                    $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
+                    InvokeNetboxRequest -URI $URI -Raw:$Raw
+                }
+            }
+
+            default {
+                $Segments = [System.Collections.ArrayList]::new(@('dcim', 'cable-bundles'))
+                $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'All', 'PageSize'
+                $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
+                InvokeNetboxRequest -URI $URI -Raw:$Raw -All:$All -PageSize $PageSize
+            }
+        }
+    }
+}

--- a/Functions/DCIM/CableBundles/Get-NBDCIMCableBundle.ps1
+++ b/Functions/DCIM/CableBundles/Get-NBDCIMCableBundle.ps1
@@ -14,6 +14,9 @@
 .PARAMETER Name
     Filter by name.
 
+.PARAMETER Query
+    Free-text search filter (NetBox ?q= parameter).
+
 .PARAMETER Brief
     Return the brief representation.
 

--- a/Functions/DCIM/CableBundles/New-NBDCIMCableBundle.ps1
+++ b/Functions/DCIM/CableBundles/New-NBDCIMCableBundle.ps1
@@ -1,0 +1,74 @@
+<#
+.SYNOPSIS
+    Creates a new cable bundle in Netbox DCIM.
+
+.DESCRIPTION
+    Creates a new CableBundle (NetBox 4.6+). Groups individual cables
+    managed as one physical run. Not for modeling fiber strands within
+    a single cable.
+
+.PARAMETER Name
+    The name of the cable bundle.
+
+.PARAMETER Description
+    A description of the cable bundle.
+
+.PARAMETER Comments
+    Additional comments.
+
+.PARAMETER Owner
+    The owner ID for object ownership.
+
+.PARAMETER Tags
+    Tags to assign to this cable bundle.
+
+.PARAMETER Custom_Fields
+    A hashtable of custom field values.
+
+.PARAMETER Raw
+    Return the raw API response instead of the results array.
+
+.EXAMPLE
+    New-NBDCIMCableBundle -Name 'PP1-PP2 trunk' -Description '48x CAT6'
+
+.LINK
+    https://netbox.readthedocs.io/en/stable/rest-api/overview/
+.NOTES
+    AddedInVersion: v4.6.0.1
+
+#>
+function New-NBDCIMCableBundle {
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Low')]
+    [OutputType([PSCustomObject])]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Name,
+
+        [string]$Description,
+
+        [string]$Comments,
+
+        [uint64]$Owner,
+
+        [object[]]$Tags,
+
+        [hashtable]$Custom_Fields,
+
+        [switch]$Raw
+    )
+
+    process {
+        Write-Verbose "Creating DCIM Cable Bundle"
+        $Segments = [System.Collections.ArrayList]::new(@('dcim', 'cable-bundles'))
+
+        $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw'
+
+        $URI = BuildNewURI -Segments $URIComponents.Segments
+
+        if ($PSCmdlet.ShouldProcess($Name, 'Create cable bundle')) {
+            InvokeNetboxRequest -URI $URI -Method POST -Body $URIComponents.Parameters -Raw:$Raw
+        }
+    }
+}

--- a/Functions/DCIM/CableBundles/Remove-NBDCIMCableBundle.ps1
+++ b/Functions/DCIM/CableBundles/Remove-NBDCIMCableBundle.ps1
@@ -1,0 +1,47 @@
+<#
+.SYNOPSIS
+    Deletes a cable bundle from Netbox DCIM.
+
+.DESCRIPTION
+    Deletes an existing CableBundle (NetBox 4.6+).
+
+.PARAMETER Id
+    The ID of the cable bundle to delete.
+
+.PARAMETER Raw
+    Return the raw API response instead of the results array.
+
+.EXAMPLE
+    Remove-NBDCIMCableBundle -Id 1
+
+.EXAMPLE
+    Get-NBDCIMCableBundle -Name 'PP1-PP2 trunk' | Remove-NBDCIMCableBundle
+
+.LINK
+    https://netbox.readthedocs.io/en/stable/rest-api/overview/
+.NOTES
+    AddedInVersion: v4.6.0.1
+
+#>
+function Remove-NBDCIMCableBundle {
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
+    [OutputType([void])]
+    param
+    (
+        [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
+        [uint64]$Id,
+
+        [switch]$Raw
+    )
+
+    process {
+        Write-Verbose "Deleting DCIM Cable Bundle"
+        $Segments = [System.Collections.ArrayList]::new(@('dcim', 'cable-bundles', $Id))
+
+        $URI = BuildNewURI -Segments $Segments
+
+        if ($PSCmdlet.ShouldProcess($Id, 'Delete cable bundle')) {
+            InvokeNetboxRequest -URI $URI -Method DELETE -Raw:$Raw
+        }
+    }
+}

--- a/Functions/DCIM/CableBundles/Set-NBDCIMCableBundle.ps1
+++ b/Functions/DCIM/CableBundles/Set-NBDCIMCableBundle.ps1
@@ -1,0 +1,76 @@
+<#
+.SYNOPSIS
+    Updates a cable bundle in Netbox DCIM.
+
+.DESCRIPTION
+    Updates an existing CableBundle (NetBox 4.6+).
+
+.PARAMETER Id
+    The ID of the cable bundle to update.
+
+.PARAMETER Name
+    The name of the cable bundle.
+
+.PARAMETER Description
+    A description of the cable bundle.
+
+.PARAMETER Comments
+    Additional comments.
+
+.PARAMETER Owner
+    The owner ID for object ownership.
+
+.PARAMETER Tags
+    Tags to assign to this cable bundle.
+
+.PARAMETER Custom_Fields
+    A hashtable of custom field values.
+
+.PARAMETER Raw
+    Return the raw API response instead of the results array.
+
+.EXAMPLE
+    Set-NBDCIMCableBundle -Id 1 -Description 'Updated'
+
+.LINK
+    https://netbox.readthedocs.io/en/stable/rest-api/overview/
+.NOTES
+    AddedInVersion: v4.6.0.1
+
+#>
+function Set-NBDCIMCableBundle {
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
+    [OutputType([PSCustomObject])]
+    param
+    (
+        [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
+        [uint64]$Id,
+
+        [string]$Name,
+
+        [string]$Description,
+
+        [string]$Comments,
+
+        [uint64]$Owner,
+
+        [object[]]$Tags,
+
+        [hashtable]$Custom_Fields,
+
+        [switch]$Raw
+    )
+
+    process {
+        Write-Verbose "Updating DCIM Cable Bundle"
+        $Segments = [System.Collections.ArrayList]::new(@('dcim', 'cable-bundles', $Id))
+
+        $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw'
+
+        $URI = BuildNewURI -Segments $URIComponents.Segments
+
+        if ($PSCmdlet.ShouldProcess($Id, 'Update cable bundle')) {
+            InvokeNetboxRequest -URI $URI -Method PATCH -Body $URIComponents.Parameters -Raw:$Raw
+        }
+    }
+}

--- a/Tests/DCIM.Additional.Tests.ps1
+++ b/Tests/DCIM.Additional.Tests.ps1
@@ -1896,4 +1896,50 @@ Describe "DCIM Additional Tests" -Tag 'DCIM' {
         }
     }
     #endregion
+
+    #region CableBundles (NetBox 4.6+, #395 Phase 2)
+    Context "Get-NBDCIMCableBundle" {
+        It "Should request the list endpoint" {
+            $Result = Get-NBDCIMCableBundle
+            $Result.Method | Should -Be 'GET'
+            $Result.Uri | Should -Be 'https://netbox.domain.com/api/dcim/cable-bundles/'
+        }
+        It "Should request a cable bundle by ID" {
+            $Result = Get-NBDCIMCableBundle -Id 7
+            $Result.Uri | Should -Match '/api/dcim/cable-bundles/7/'
+        }
+    }
+
+    Context "New-NBDCIMCableBundle" {
+        It "Should create a cable bundle" {
+            $Result = New-NBDCIMCableBundle -Name 'PP1-PP2 trunk' -Description '48x CAT6'
+            $Result.Method | Should -Be 'POST'
+            $Result.Uri | Should -Be 'https://netbox.domain.com/api/dcim/cable-bundles/'
+            $bodyObj = $Result.Body | ConvertFrom-Json
+            $bodyObj.name | Should -Be 'PP1-PP2 trunk'
+            $bodyObj.description | Should -Be '48x CAT6'
+        }
+    }
+
+    Context "Set-NBDCIMCableBundle" {
+        It "Should update a cable bundle" {
+            $Result = Set-NBDCIMCableBundle -Id 1 -Comments 'relabelled' -Confirm:$false
+            $Result.Method | Should -Be 'PATCH'
+            $Result.Uri | Should -Match '/api/dcim/cable-bundles/1/'
+            ($Result.Body | ConvertFrom-Json).comments | Should -Be 'relabelled'
+        }
+    }
+
+    Context "Remove-NBDCIMCableBundle" {
+        It "Should delete a cable bundle" {
+            $Result = Remove-NBDCIMCableBundle -Id 1 -Confirm:$false
+            $Result.Method | Should -Be 'DELETE'
+            $Result.Uri | Should -Match '/api/dcim/cable-bundles/1/'
+        }
+        It "Should accept pipeline input by property name" {
+            $Result = [pscustomobject]@{ Id = 4 } | Remove-NBDCIMCableBundle -Confirm:$false
+            $Result.Uri | Should -Match '/api/dcim/cable-bundles/4/'
+        }
+    }
+    #endregion
 }


### PR DESCRIPTION
## Summary

New NetBox 4.6 endpoint **`/api/dcim/cable-bundles/`** (netbox-community/netbox#20151) — groups individual cables managed as one physical run (e.g. a 48-cable trunk between patch panels). Explicitly **not** for modeling fiber strands within a single cable.

Four-cmdlet family via the `new-netbox-endpoint` skill. Fields verified against the **live v4.6.0** `CableBundleRequest` schema: name, description, comments, owner, tags, custom_fields. No `slug` (the model intentionally has none) and no ValidateSets → parity unaffected.

## Test plan

- [x] `deploy.ps1 -Environment dev` builds; 4 cmdlets exported
- [x] 10 new tests (list/byID, create, update, delete, pipeline) — 329 DCIM.Additional tests green
- [x] PSScriptAnalyzer clean on the new files
- [ ] CI: full matrix

Refs #395.