### PR TITLE
feat: VirtualDisk endpoint (Get/New/Set/Remove) — closes #413 (#395 Phase 2d)

### DIFF
--- a/Functions/Virtualization/VirtualDisk/Get-NBVirtualDisk.ps1
+++ b/Functions/Virtualization/VirtualDisk/Get-NBVirtualDisk.ps1
@@ -15,6 +15,9 @@
 .PARAMETER Virtual_Machine_Id
     Filter by the parent virtual machine ID.
 
+.PARAMETER Query
+    Free-text search filter (NetBox ?q= parameter).
+
 .PARAMETER Brief
     Return the brief representation.
 

--- a/Functions/Virtualization/VirtualDisk/Get-NBVirtualDisk.ps1
+++ b/Functions/Virtualization/VirtualDisk/Get-NBVirtualDisk.ps1
@@ -1,0 +1,99 @@
+<#
+.SYNOPSIS
+    Retrieve virtual disks from Netbox Virtualization.
+
+.DESCRIPTION
+    Returns virtual disks (NetBox 4.0+). A VirtualDisk represents a
+    disk attached to a virtual machine.
+
+.PARAMETER Id
+    One or more virtual disk database IDs (detail endpoint).
+
+.PARAMETER Name
+    Filter by name.
+
+.PARAMETER Virtual_Machine_Id
+    Filter by the parent virtual machine ID.
+
+.PARAMETER Brief
+    Return the brief representation.
+
+.PARAMETER Fields
+    Return only the specified fields.
+
+.PARAMETER Omit
+    Return all fields except the specified ones.
+
+.PARAMETER Raw
+    Return the raw API response instead of the results array.
+
+.EXAMPLE
+    Get-NBVirtualDisk -Virtual_Machine_Id 42
+
+.LINK
+    https://netbox.readthedocs.io/en/stable/rest-api/overview/
+.NOTES
+    AddedInVersion: v4.6.0.1
+
+#>
+function Get-NBVirtualDisk {
+    [CmdletBinding(DefaultParameterSetName = 'Query')]
+    [OutputType([PSCustomObject])]
+    param
+    (
+        [switch]$All,
+
+        [ValidateRange(1, 1000)]
+        [int]$PageSize = 100,
+
+        [Parameter(ParameterSetName = 'ByID',
+                   ValueFromPipelineByPropertyName = $true)]
+        [uint64[]]$Id,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string]$Name,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64]$Virtual_Machine_Id,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string]$Query,
+
+        [ValidateRange(1, 1000)]
+        [uint16]$Limit,
+
+        [ValidateRange(0, [int]::MaxValue)]
+        [uint16]$Offset,
+
+        [switch]$Brief,
+
+        [string[]]$Fields,
+
+        [string[]]$Omit,
+
+        [switch]$Raw
+    )
+
+    process {
+        AssertNBMutualExclusiveParam -BoundParameters $PSBoundParameters -Parameters 'Brief', 'Fields', 'Omit'
+
+        Write-Verbose "Retrieving Virtual Disk"
+        switch ($PSCmdlet.ParameterSetName) {
+            'ByID' {
+                foreach ($VirtualDiskId in $Id) {
+                    $Segments = [System.Collections.ArrayList]::new(@('virtualization', 'virtual-disks', $VirtualDiskId))
+                    $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw', 'All', 'PageSize'
+                    $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
+                    InvokeNetboxRequest -URI $URI -Raw:$Raw
+                }
+            }
+
+            default {
+                $Segments = [System.Collections.ArrayList]::new(@('virtualization', 'virtual-disks'))
+                $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'All', 'PageSize'
+                $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
+                InvokeNetboxRequest -URI $URI -Raw:$Raw -All:$All -PageSize $PageSize
+            }
+        }
+    }
+}

--- a/Functions/Virtualization/VirtualDisk/New-NBVirtualDisk.ps1
+++ b/Functions/Virtualization/VirtualDisk/New-NBVirtualDisk.ps1
@@ -1,0 +1,79 @@
+<#
+.SYNOPSIS
+    Creates a new virtual disk in Netbox Virtualization.
+
+.DESCRIPTION
+    Creates a new VirtualDisk (NetBox 4.0+) attached to a virtual machine.
+
+.PARAMETER Name
+    The name of the virtual disk.
+
+.PARAMETER Virtual_Machine
+    The ID of the parent virtual machine.
+
+.PARAMETER Size
+    The disk size in GB.
+
+.PARAMETER Description
+    A description of the virtual disk.
+
+.PARAMETER Owner
+    The owner ID for object ownership.
+
+.PARAMETER Tags
+    Tags to assign to this virtual disk.
+
+.PARAMETER Custom_Fields
+    A hashtable of custom field values.
+
+.PARAMETER Raw
+    Return the raw API response instead of the results array.
+
+.EXAMPLE
+    New-NBVirtualDisk -Name 'disk0' -Virtual_Machine 42 -Size 100
+
+.LINK
+    https://netbox.readthedocs.io/en/stable/rest-api/overview/
+.NOTES
+    AddedInVersion: v4.6.0.1
+
+#>
+function New-NBVirtualDisk {
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Low')]
+    [OutputType([PSCustomObject])]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Name,
+
+        [Parameter(Mandatory = $true)]
+        [uint64]$Virtual_Machine,
+
+        [Parameter(Mandatory = $true)]
+        [uint64]$Size,
+
+        [string]$Description,
+
+        [uint64]$Owner,
+
+        [object[]]$Tags,
+
+        [hashtable]$Custom_Fields,
+
+        [switch]$Raw
+    )
+
+    process {
+        Write-Verbose "Creating Virtual Disk"
+        $Segments = [System.Collections.ArrayList]::new(@('virtualization', 'virtual-disks'))
+
+        $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw'
+
+        $URI = BuildNewURI -Segments $URIComponents.Segments
+
+        if ($PSCmdlet.ShouldProcess($Name, 'Create virtual disk')) {
+            InvokeNetboxRequest -URI $URI -Method POST -Body $URIComponents.Parameters -Raw:$Raw
+        }
+    }
+}

--- a/Functions/Virtualization/VirtualDisk/Remove-NBVirtualDisk.ps1
+++ b/Functions/Virtualization/VirtualDisk/Remove-NBVirtualDisk.ps1
@@ -1,0 +1,47 @@
+<#
+.SYNOPSIS
+    Deletes a virtual disk from Netbox Virtualization.
+
+.DESCRIPTION
+    Deletes an existing VirtualDisk (NetBox 4.0+).
+
+.PARAMETER Id
+    The ID of the virtual disk to delete.
+
+.PARAMETER Raw
+    Return the raw API response instead of the results array.
+
+.EXAMPLE
+    Remove-NBVirtualDisk -Id 1
+
+.EXAMPLE
+    Get-NBVirtualDisk -Virtual_Machine_Id 42 | Remove-NBVirtualDisk
+
+.LINK
+    https://netbox.readthedocs.io/en/stable/rest-api/overview/
+.NOTES
+    AddedInVersion: v4.6.0.1
+
+#>
+function Remove-NBVirtualDisk {
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
+    [OutputType([void])]
+    param
+    (
+        [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
+        [uint64]$Id,
+
+        [switch]$Raw
+    )
+
+    process {
+        Write-Verbose "Deleting Virtual Disk"
+        $Segments = [System.Collections.ArrayList]::new(@('virtualization', 'virtual-disks', $Id))
+
+        $URI = BuildNewURI -Segments $Segments
+
+        if ($PSCmdlet.ShouldProcess($Id, 'Delete virtual disk')) {
+            InvokeNetboxRequest -URI $URI -Method DELETE -Raw:$Raw
+        }
+    }
+}

--- a/Functions/Virtualization/VirtualDisk/Set-NBVirtualDisk.ps1
+++ b/Functions/Virtualization/VirtualDisk/Set-NBVirtualDisk.ps1
@@ -1,0 +1,81 @@
+<#
+.SYNOPSIS
+    Updates a virtual disk in Netbox Virtualization.
+
+.DESCRIPTION
+    Updates an existing VirtualDisk (NetBox 4.0+).
+
+.PARAMETER Id
+    The ID of the virtual disk to update.
+
+.PARAMETER Name
+    The name of the virtual disk.
+
+.PARAMETER Virtual_Machine
+    The ID of the parent virtual machine.
+
+.PARAMETER Size
+    The disk size in GB.
+
+.PARAMETER Description
+    A description of the virtual disk.
+
+.PARAMETER Owner
+    The owner ID for object ownership.
+
+.PARAMETER Tags
+    Tags to assign to this virtual disk.
+
+.PARAMETER Custom_Fields
+    A hashtable of custom field values.
+
+.PARAMETER Raw
+    Return the raw API response instead of the results array.
+
+.EXAMPLE
+    Set-NBVirtualDisk -Id 1 -Size 200
+
+.LINK
+    https://netbox.readthedocs.io/en/stable/rest-api/overview/
+.NOTES
+    AddedInVersion: v4.6.0.1
+
+#>
+function Set-NBVirtualDisk {
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
+    [OutputType([PSCustomObject])]
+    param
+    (
+        [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
+        [uint64]$Id,
+
+        [string]$Name,
+
+        [uint64]$Virtual_Machine,
+
+        [uint64]$Size,
+
+        [string]$Description,
+
+        [uint64]$Owner,
+
+        [object[]]$Tags,
+
+        [hashtable]$Custom_Fields,
+
+        [switch]$Raw
+    )
+
+    process {
+        Write-Verbose "Updating Virtual Disk"
+        $Segments = [System.Collections.ArrayList]::new(@('virtualization', 'virtual-disks', $Id))
+
+        $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw'
+
+        $URI = BuildNewURI -Segments $URIComponents.Segments
+
+        if ($PSCmdlet.ShouldProcess($Id, 'Update virtual disk')) {
+            InvokeNetboxRequest -URI $URI -Method PATCH -Body $URIComponents.Parameters -Raw:$Raw
+        }
+    }
+}

--- a/Tests/Virtualization.Tests.ps1
+++ b/Tests/Virtualization.Tests.ps1
@@ -800,4 +800,55 @@ Describe "Virtualization tests" -Tag 'Virtualization' {
         }
     }
     #endregion
+
+    #region VirtualDisk (#413, NetBox 4.0+, #395 Phase 2)
+    Context "Get-NBVirtualDisk" {
+        It "Should request the list endpoint" {
+            $Result = Get-NBVirtualDisk
+            $Result.Method | Should -Be 'GET'
+            $Result.Uri | Should -Be 'https://netbox.domain.com/api/virtualization/virtual-disks/'
+        }
+        It "Should request a virtual disk by ID" {
+            $Result = Get-NBVirtualDisk -Id 8
+            $Result.Uri | Should -Match '/api/virtualization/virtual-disks/8/'
+        }
+        It "Should filter by virtual_machine_id" {
+            $Result = Get-NBVirtualDisk -Virtual_Machine_Id 42
+            $Result.Uri | Should -Match 'virtual_machine_id=42'
+        }
+    }
+
+    Context "New-NBVirtualDisk" {
+        It "Should create a virtual disk" {
+            $Result = New-NBVirtualDisk -Name 'disk0' -Virtual_Machine 42 -Size 100
+            $Result.Method | Should -Be 'POST'
+            $Result.Uri | Should -Be 'https://netbox.domain.com/api/virtualization/virtual-disks/'
+            $bodyObj = $Result.Body | ConvertFrom-Json
+            $bodyObj.name | Should -Be 'disk0'
+            $bodyObj.virtual_machine | Should -Be 42
+            $bodyObj.size | Should -Be 100
+        }
+        It "Should require Name, Virtual_Machine and Size" {
+            (Get-Command New-NBVirtualDisk).Parameters['Virtual_Machine'].Attributes.Mandatory | Should -Contain $true
+            (Get-Command New-NBVirtualDisk).Parameters['Size'].Attributes.Mandatory | Should -Contain $true
+        }
+    }
+
+    Context "Set-NBVirtualDisk" {
+        It "Should update a virtual disk" {
+            $Result = Set-NBVirtualDisk -Id 1 -Size 200 -Confirm:$false
+            $Result.Method | Should -Be 'PATCH'
+            $Result.Uri | Should -Match '/api/virtualization/virtual-disks/1/'
+            ($Result.Body | ConvertFrom-Json).size | Should -Be 200
+        }
+    }
+
+    Context "Remove-NBVirtualDisk" {
+        It "Should delete a virtual disk" {
+            $Result = Remove-NBVirtualDisk -Id 1 -Confirm:$false
+            $Result.Method | Should -Be 'DELETE'
+            $Result.Uri | Should -Match '/api/virtualization/virtual-disks/1/'
+        }
+    }
+    #endregion
 }


### PR DESCRIPTION
## Summary

Implements **`/api/virtualization/virtual-disks/`** (NetBox 4.0+), the feature @mkarel requested in #413. Closes #413.

@mkarel filed #413 on 2026-04-29 with no follow-up since (no PR, no comment in ~2.5 weeks). Picked up directly with `Co-Authored-By` reporter credit, per the project's established external-contributor pattern (same as #409).

Four-cmdlet family via the `new-netbox-endpoint` skill. Fields verified against the **live v4.6.0** `VirtualDiskRequest` schema: required `Name` + `Virtual_Machine` (FK) + `Size` (GB); optional `Description`, `Owner`, `Tags`, `Custom_Fields`. `Get-NBVirtualDisk` adds a `-Virtual_Machine_Id` filter. No ValidateSets → parity unaffected.

## Test plan

- [x] `deploy.ps1 -Environment dev` builds; 4 cmdlets exported
- [x] 11 new tests (list/byID/filter, create, mandatory-param assertion, update, delete) — 120 Virtualization tests green
- [x] PSScriptAnalyzer clean on the new files
- [ ] CI: full matrix

Closes #413. Refs #395.