### PR TITLE
fix: _ArgumentCompleters no longer triggers module auto-loader — closes #418 (v4.6.0.2)

### DIFF
--- a/Functions/Helpers/_ArgumentCompleters.ps1
+++ b/Functions/Helpers/_ArgumentCompleters.ps1
@@ -455,13 +455,32 @@ function Register-NBArgumentCompleters {
     [OutputType([void])]
     param()
 
-    # Get all PowerNetbox commands
-    $moduleCommands = Get-Command -Module PowerNetbox -ErrorAction SilentlyContinue |
-        Where-Object { $_.CommandType -eq 'Function' }
-
-    if (-not $moduleCommands) {
-        Write-Verbose "PowerNetbox module not loaded, skipping completer registration"
+    # Resolve exported function names from THIS module's manifest instead of
+    # `Get-Command -Module PowerNetbox`. That call triggers PowerShell's module
+    # auto-loader, which side-loads any PowerNetbox copy found on
+    # $env:PSModulePath. A fork developer who also has a PSGallery build
+    # installed then ends up with two PowerNetbox modules in one session,
+    # breaking Pester ("Multiple script or manifest modules named
+    # 'PowerNetbox'") — see #418. Reading FunctionsToExport from the manifest
+    # is auto-load-free, also works under $PSModuleAutoLoadingPreference='None',
+    # and mirrors whatever deploy.ps1 wrote (dev build = all functions,
+    # prod build = public only).
+    $manifestPath = Join-Path $PSScriptRoot 'PowerNetbox.psd1'
+    if (-not (Test-Path -LiteralPath $manifestPath)) {
+        Write-Verbose "PowerNetbox manifest not found at $manifestPath, skipping completer registration"
         return
+    }
+
+    $exportedNames = (Import-PowerShellDataFile -LiteralPath $manifestPath).FunctionsToExport
+    if (-not $exportedNames) {
+        Write-Verbose "PowerNetbox manifest exports no functions, skipping completer registration"
+        return
+    }
+
+    # Shape into objects with a .Name property so the rest of this function,
+    # which filters on $_.Name, is unchanged.
+    $moduleCommands = foreach ($exportedName in $exportedNames) {
+        [pscustomobject]@{ Name = $exportedName }
     }
 
     # Status completers - context-specific

--- a/Functions/Helpers/_ArgumentCompleters.ps1
+++ b/Functions/Helpers/_ArgumentCompleters.ps1
@@ -465,6 +465,14 @@ function Register-NBArgumentCompleters {
     # is auto-load-free, also works under $PSModuleAutoLoadingPreference='None',
     # and mirrors whatever deploy.ps1 wrote (dev build = all functions,
     # prod build = public only).
+    #
+    # NOTE on $PSScriptRoot: this source file is never imported on its own.
+    # deploy.ps1 concatenates every Functions/**/*.ps1 into the built
+    # PowerNetbox.psm1, and the module is always loaded from that psm1 (dev
+    # build dir or the PSGallery install dir). In both, PowerNetbox.psm1 and
+    # PowerNetbox.psd1 are siblings, so for a function defined in the psm1
+    # $PSScriptRoot is the module root and the manifest sits right next to it.
+    # (Verified: arg completers register correctly at real import.)
     $manifestPath = Join-Path $PSScriptRoot 'PowerNetbox.psd1'
     if (-not (Test-Path -LiteralPath $manifestPath)) {
         Write-Verbose "PowerNetbox manifest not found at $manifestPath, skipping completer registration"

--- a/PowerNetbox.psd1
+++ b/PowerNetbox.psd1
@@ -12,7 +12,7 @@
 RootModule = 'PowerNetbox.psm1'
 
 # Version number of this module.
-ModuleVersion = '4.6.0.1'
+ModuleVersion = '4.6.0.2'
 
 # Supported PSEditions
 CompatiblePSEditions = 'Desktop', 'Core'

--- a/Tests/Helpers.Tests.ps1
+++ b/Tests/Helpers.Tests.ps1
@@ -1079,4 +1079,23 @@ Describe "Helpers tests" -Tag 'Core', 'Helpers' {
             }
         }
     }
+
+    Context "Register-NBArgumentCompleters does not trigger the module auto-loader (#418)" {
+        It "Loads exactly one PowerNetbox module after import" {
+            # The regression: Get-Command -Module PowerNetbox inside
+            # Register-NBArgumentCompleters side-loaded a second copy.
+            (Get-Module PowerNetbox).Count | Should -Be 1
+        }
+
+        It "Resolves exported names from the manifest, never via Get-Command -Module" {
+            InModuleScope -ModuleName 'PowerNetbox' {
+                Mock Register-ArgumentCompleter -MockWith { }
+                Mock Get-Command -MockWith { throw 'Get-Command must not be used to enumerate the module (auto-load risk, #418)' }
+
+                { Register-NBArgumentCompleters } | Should -Not -Throw
+                Should -Not -Invoke Get-Command
+                Should -Invoke Register-ArgumentCompleter -Scope It
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Closes #418 (reported by @danubie with an exact root-cause diagnosis).

`Register-NBArgumentCompleters` enumerated the module via `Get-Command -Module PowerNetbox` during import. That triggers PowerShell's module auto-loader, side-loading any PowerNetbox copy on `$env:PSModulePath`. A fork developer who also has a PSGallery build installed then has **two** PowerNetbox modules in one session, and Pester aborts with *"Multiple script or manifest modules named 'PowerNetbox'"*.

**Fix:** resolve exported function names from this module's own manifest (`Import-PowerShellDataFile $PSScriptRoot/PowerNetbox.psd1` → `FunctionsToExport`) instead of `Get-Command`. Auto-load-free, also works under `$PSModuleAutoLoadingPreference='None'`, and mirrors whatever `deploy.ps1` wrote (dev build = all functions, prod = public only). Names are shaped into objects with a `.Name` property so the rest of the function is untouched (minimal diff).

## Test plan

- [x] Module count after `Import-Module` = **1** (was 2) — new regression test
- [x] `Register-NBArgumentCompleters` never calls `Get-Command` (mocked to throw) — new regression test
- [x] Helpers suite **84 passed / 0 failed**
- [x] PSScriptAnalyzer clean in the changed region
- [ ] CI: full matrix

Bumps to **v4.6.0.2**. Co-Authored-By @danubie.