### PR TITLE
fix: Device.position is a float not [uint16] — closes #412 (v4.6.0.3)

### DIFF
--- a/Functions/DCIM/Devices/Get-NBDCIMDevice.ps1
+++ b/Functions/DCIM/Devices/Get-NBDCIMDevice.ps1
@@ -183,7 +183,8 @@ function Get-NBDCIMDevice {
         [uint64]$Virtual_Chassis_Id,
 
         [Parameter(ParameterSetName = 'Query')]
-        [uint16]$Position,
+        [ValidateRange(0.5, 999.99)]
+        [double]$Position,
 
         [Parameter(ParameterSetName = 'Query')]
         [string]$Serial,

--- a/Functions/DCIM/Devices/New-NBDCIMDevice.ps1
+++ b/Functions/DCIM/Devices/New-NBDCIMDevice.ps1
@@ -114,7 +114,8 @@ function New-NBDCIMDevice {
         [uint64]$Rack,
 
         [Parameter(ParameterSetName = 'Single')]
-        [uint16]$Position,
+        [ValidateRange(0.5, 999.99)]
+        [double]$Position,
 
         [Parameter(ParameterSetName = 'Single')]
         [ValidateSet('front', 'rear', IgnoreCase = $true)]

--- a/Functions/DCIM/Devices/Set-NBDCIMDevice.ps1
+++ b/Functions/DCIM/Devices/Set-NBDCIMDevice.ps1
@@ -41,7 +41,8 @@
     The rack ID.
 
 .PARAMETER Position
-    Position in the rack.
+    Rack-unit position (U). Accepts fractional values for half-U devices
+    (e.g. 1.5, 2.5). Pass $null to clear (unrack the device).
 
 .PARAMETER Face
     Face of the device in the rack.
@@ -158,7 +159,12 @@ function Set-NBDCIMDevice {
         [Nullable[uint64]]$Rack,
 
         [Parameter(ParameterSetName = 'Single')]
-        [Nullable[uint16]]$Position,
+        # [double] not [uint16]: NetBox rack position is a float (half-U
+        # devices at 1.5/2.5/...). No [ValidateRange] here -- it fires before
+        # [Nullable[T]] binding, so -Position $null (clear) would throw
+        # ValidationMetadataException (see #398). Server-side validation
+        # handles the 0.5..<1000 bound. Refs #412.
+        [Nullable[double]]$Position,
 
         [Parameter(ParameterSetName = 'Single')]
         [ValidateSet('front', 'rear', IgnoreCase = $true)]

--- a/PowerNetbox.psd1
+++ b/PowerNetbox.psd1
@@ -12,7 +12,7 @@
 RootModule = 'PowerNetbox.psm1'
 
 # Version number of this module.
-ModuleVersion = '4.6.0.2'
+ModuleVersion = '4.6.0.3'
 
 # Supported PSEditions
 CompatiblePSEditions = 'Desktop', 'Core'

--- a/Tests/DCIM.Devices.Tests.ps1
+++ b/Tests/DCIM.Devices.Tests.ps1
@@ -314,6 +314,25 @@ Describe "DCIM Devices Tests" -Tag 'DCIM', 'Devices' {
             $bodyObj.face | Should -Be 'front'
         }
 
+        Context "Fractional rack position (#412)" {
+            It "Should preserve a half-U position (1.5, not rounded to 2)" {
+                $Result = New-NBDCIMDevice -Name 'half-u' -Device_Role 4 -Device_Type 10 -Site 1 -Position 1.5
+                ($Result.Body | ConvertFrom-Json).position | Should -Be 1.5
+            }
+            It "Should accept a whole-number position as a double" {
+                $Result = New-NBDCIMDevice -Name 'whole-u' -Device_Role 4 -Device_Type 10 -Site 1 -Position 42
+                ($Result.Body | ConvertFrom-Json).position | Should -Be 42
+            }
+            It "Should reject a position below the 0.5 U floor" {
+                { New-NBDCIMDevice -Name 'bad' -Device_Role 4 -Device_Type 10 -Site 1 -Position 0.25 } |
+                    Should -Throw
+            }
+            It "Should type Position as double, not uint16" {
+                (Get-Command New-NBDCIMDevice).Parameters['Position'].ParameterType |
+                    Should -Be ([double])
+            }
+        }
+
         It "Should have ValidateSet for Status parameter" {
             # Status parameter now uses ValidateSet for type safety
             $cmd = Get-Command New-NBDCIMDevice
@@ -479,6 +498,16 @@ Describe "DCIM Devices Tests" -Tag 'DCIM', 'Devices' {
         It "Should still accept a numeric Position value (not broken by Nullable)" {
             $Result = Set-NBDCIMDevice -Id 1234 -Position 7 -Confirm:$false
             ($Result.Body | ConvertFrom-Json).position | Should -Be 7
+        }
+
+        It "Should preserve a fractional Position (2.5, not rounded) (#412)" {
+            $Result = Set-NBDCIMDevice -Id 1234 -Position 2.5 -Confirm:$false
+            ($Result.Body | ConvertFrom-Json).position | Should -Be 2.5
+        }
+
+        It "Should type Position as Nullable[double] (#412)" {
+            (Get-Command Set-NBDCIMDevice).Parameters['Position'].ParameterType |
+                Should -Be ([System.Nullable[double]])
         }
     }
 


### PR DESCRIPTION
## Summary

Closes #412. NetBox's API schema types `Device.position` as `number/double` (`0.5 ≤ position < 1000`) with explicit support for fractional **half-U** placements (1.5, 2.5, …). PowerNetbox typed it `[uint16]`, so `-Position 1.5` silently coerced to `2` — placing the device at the wrong rack unit. Reported independently by @mkarel (via Gemini) and by live-schema verification during #409.

| File | Before | After |
|---|---|---|
| `New-NBDCIMDevice` | `[uint16]$Position` | `[ValidateRange(0.5,999.99)][double]$Position` |
| `Get-NBDCIMDevice` | `[uint16]$Position` | `[ValidateRange(0.5,999.99)][double]$Position` |
| `Set-NBDCIMDevice` | `[Nullable[uint16]]$Position` | `[Nullable[double]]$Position`, **no** `[ValidateRange]` (fires before Nullable binding → would break `-Position $null` unrack; see #398) |

**Out of scope** (verified against the live schema): `VC_Position` (integer), `ModuleBay.position` (string label), DeviceBay (no position param).

## Test plan

- [x] Fractional position preserved (`1.5` not rounded to `2`) — New & Set
- [x] Whole-number position accepted as double
- [x] Position `< 0.5` rejected (New)
- [x] Parameter-type assertions (`[double]` / `[System.Nullable[double]]`)
- [x] Existing `Set -Position $null` clear still passes (proves `[Nullable[double]]` clears)
- [x] 96 DCIM.Devices tests green; PSScriptAnalyzer clean; ASCII-only
- [ ] CI: full matrix

Bumps to **v4.6.0.3**. Co-Authored-By @mkarel.