### PR TITLE
feat: expose 7 writable Device fields on New-/Set-NBDCIMDevice (#411)

### DIFF
--- a/Functions/DCIM/Devices/New-NBDCIMDevice.ps1
+++ b/Functions/DCIM/Devices/New-NBDCIMDevice.ps1
@@ -44,6 +44,30 @@
 .PARAMETER Owner
     The owner ID for object ownership (Netbox 4.5+ only).
 
+.PARAMETER Location
+    The location ID within the site.
+
+.PARAMETER Airflow
+    Airflow direction. One of: front-to-rear, rear-to-front, left-to-right,
+    right-to-left, side-to-rear, rear-to-side, bottom-to-top, top-to-bottom,
+    passive, mixed.
+
+.PARAMETER OOB_IP
+    Out-of-band IP address ID.
+
+.PARAMETER Latitude
+    GPS latitude in decimal degrees (-90 to 90).
+
+.PARAMETER Longitude
+    GPS longitude in decimal degrees (-180 to 180).
+
+.PARAMETER Config_Template
+    Config template ID assigned to the device.
+
+.PARAMETER Local_Context_Data
+    Local config context data (free-form JSON; hashtable or object). Takes
+    precedence over source contexts in the rendered config context.
+
 .EXAMPLE
     New-NBDCIMDevice -Name "server01" -Role 1 -Device_Type 1 -Site 1
 
@@ -153,6 +177,32 @@ function New-NBDCIMDevice {
 
         [Parameter(ParameterSetName = 'Single')]
         [uint64]$Owner,
+
+        [Parameter(ParameterSetName = 'Single')]
+        [uint64]$Location,
+
+        [Parameter(ParameterSetName = 'Single')]
+        [ValidateSet('front-to-rear', 'rear-to-front', 'left-to-right', 'right-to-left',
+            'side-to-rear', 'rear-to-side', 'bottom-to-top', 'top-to-bottom',
+            'passive', 'mixed', IgnoreCase = $true)]
+        [string]$Airflow,
+
+        [Parameter(ParameterSetName = 'Single')]
+        [uint64]$OOB_IP,
+
+        [Parameter(ParameterSetName = 'Single')]
+        [ValidateRange(-90, 90)]
+        [double]$Latitude,
+
+        [Parameter(ParameterSetName = 'Single')]
+        [ValidateRange(-180, 180)]
+        [double]$Longitude,
+
+        [Parameter(ParameterSetName = 'Single')]
+        [uint64]$Config_Template,
+
+        [Parameter(ParameterSetName = 'Single')]
+        [object]$Local_Context_Data,
 
         # Bulk mode parameters
         [Parameter(ParameterSetName = 'Bulk', Mandatory = $true, ValueFromPipeline = $true)]

--- a/Functions/DCIM/Devices/Set-NBDCIMDevice.ps1
+++ b/Functions/DCIM/Devices/Set-NBDCIMDevice.ps1
@@ -66,12 +66,44 @@
 .PARAMETER Owner
     The owner ID for object ownership (Netbox 4.5+ only).
 
+.PARAMETER Location
+    The location ID within the site. Pass $null to clear.
+
+.PARAMETER Airflow
+    Airflow direction. One of: front-to-rear, rear-to-front, left-to-right,
+    right-to-left, side-to-rear, rear-to-side, bottom-to-top, top-to-bottom,
+    passive, mixed. Pass an empty string ('') to clear (Airflow is
+    enum-nullable, same idiom as Set-NBDCIMInterface -Duplex '').
+
+.PARAMETER OOB_IP
+    Out-of-band IP address ID. Pass $null to clear.
+
+.PARAMETER Latitude
+    GPS latitude in decimal degrees (-90 to 90). Pass $null to clear.
+
+.PARAMETER Longitude
+    GPS longitude in decimal degrees (-180 to 180). Pass $null to clear.
+
+.PARAMETER Config_Template
+    Config template ID assigned to the device. Pass $null to clear.
+
+.PARAMETER Local_Context_Data
+    Local config context data (free-form JSON; hashtable or object). Takes
+    precedence over source contexts. Pass $null to clear.
+
 .EXAMPLE
     Set-NBDCIMDevice -Id 123 -Cluster $null
 
     Clears the Cluster assignment on device 123. Also works for Platform,
     Tenant, Rack, Position, Virtual_Chassis, VC_Position, VC_Priority,
-    Primary_IP4, Primary_IP6, and Owner.
+    Primary_IP4, Primary_IP6, Owner, Location, OOB_IP, Config_Template,
+    Latitude, Longitude, and Local_Context_Data. Clear Airflow with -Airflow ''.
+
+.EXAMPLE
+    Set-NBDCIMDevice -Id 123 -Airflow front-to-rear -Latitude 52.37 -Longitude 4.89
+
+    Sets airflow direction and GPS coordinates. Pass -Airflow '' to clear
+    airflow; pass -Latitude $null / -Longitude $null to clear coordinates.
 
 .EXAMPLE
     Set-NBDCIMDevice -Id 123 -Description "Replaces legacy gateway"
@@ -203,6 +235,38 @@ function Set-NBDCIMDevice {
         [Parameter(ParameterSetName = 'Single')]
         [Nullable[uint64]]$Owner,
 
+        [Parameter(ParameterSetName = 'Single')]
+        [Nullable[uint64]]$Location,
+
+        [Parameter(ParameterSetName = 'Single')]
+        [AllowEmptyString()]
+        [ValidateSet('front-to-rear', 'rear-to-front', 'left-to-right', 'right-to-left',
+            'side-to-rear', 'rear-to-side', 'bottom-to-top', 'top-to-bottom',
+            'passive', 'mixed', '', IgnoreCase = $true)]
+        [string]$Airflow,
+
+        [Parameter(ParameterSetName = 'Single')]
+        [Nullable[uint64]]$OOB_IP,
+
+        [Parameter(ParameterSetName = 'Single')]
+        # [Nullable[double]] with no [ValidateRange]: latitude is a nullable
+        # float and -Latitude $null clears it. [ValidateRange] fires before
+        # [Nullable[T]] binding, so the range check would throw on $null
+        # (see #398, #412). Server enforces the -90..90 bound; New- keeps
+        # [ValidateRange] since its Latitude is non-nullable. Refs #411.
+        [Nullable[double]]$Latitude,
+
+        [Parameter(ParameterSetName = 'Single')]
+        # See Latitude: nullable float, no [ValidateRange] (#398/#412).
+        # Server enforces -180..180. Refs #411.
+        [Nullable[double]]$Longitude,
+
+        [Parameter(ParameterSetName = 'Single')]
+        [Nullable[uint64]]$Config_Template,
+
+        [Parameter(ParameterSetName = 'Single')]
+        [object]$Local_Context_Data,
+
         # Bulk mode parameters
         [Parameter(ParameterSetName = 'Bulk', Mandatory = $true, ValueFromPipeline = $true)]
         [PSCustomObject]$InputObject,
@@ -232,6 +296,14 @@ function Set-NBDCIMDevice {
     }
 
     process {
+        # Translate the empty-string sentinel to $null so -Airflow '' clears
+        # the field server-side: BuildURIComponents + ConvertTo-Json emit
+        # "airflow": null on the wire, which NetBox PATCH accepts (airflow is
+        # enum-nullable). Same idiom as Set-NBDCIMInterface -Duplex '' (#401).
+        if ($PSBoundParameters.ContainsKey('Airflow') -and $PSBoundParameters['Airflow'] -eq '') {
+            $PSBoundParameters['Airflow'] = $null
+        }
+
         if ($PSCmdlet.ParameterSetName -eq 'Single') {
             # Use Id directly - no need to fetch device first (saves an API call per update)
             if ($Force -or $PSCmdlet.ShouldProcess("Device ID $Id", "Update device")) {

--- a/PowerNetbox.psd1
+++ b/PowerNetbox.psd1
@@ -12,7 +12,7 @@
 RootModule = 'PowerNetbox.psm1'
 
 # Version number of this module.
-ModuleVersion = '4.6.0.3'
+ModuleVersion = '4.6.0.4'
 
 # Supported PSEditions
 CompatiblePSEditions = 'Desktop', 'Core'

--- a/Tests/DCIM.Devices.Tests.ps1
+++ b/Tests/DCIM.Devices.Tests.ps1
@@ -333,6 +333,50 @@ Describe "DCIM Devices Tests" -Tag 'DCIM', 'Devices' {
             }
         }
 
+        Context "Writable Device fields (#411)" {
+            It "Should send airflow on create" {
+                $Result = New-NBDCIMDevice -Name 'af' -Device_Role 4 -Device_Type 10 -Site 1 -Airflow 'front-to-rear'
+                ($Result.Body | ConvertFrom-Json).airflow | Should -Be 'front-to-rear'
+            }
+            It "Should accept all 10 airflow values" {
+                $vals = @('front-to-rear', 'rear-to-front', 'left-to-right', 'right-to-left',
+                    'side-to-rear', 'rear-to-side', 'bottom-to-top', 'top-to-bottom', 'passive', 'mixed')
+                foreach ($v in $vals) {
+                    { New-NBDCIMDevice -Name 'af' -Device_Role 4 -Device_Type 10 -Site 1 -Airflow $v } |
+                        Should -Not -Throw
+                }
+            }
+            It "Should reject an invalid airflow value" {
+                { New-NBDCIMDevice -Name 'af' -Device_Role 4 -Device_Type 10 -Site 1 -Airflow 'sideways' } |
+                    Should -Throw
+            }
+            It "Should send location, oob_ip and config_template as integers" {
+                $Result = New-NBDCIMDevice -Name 'fk' -Device_Role 4 -Device_Type 10 -Site 1 -Location 3 -OOB_IP 9 -Config_Template 2
+                $b = $Result.Body | ConvertFrom-Json
+                $b.location | Should -Be 3
+                $b.oob_ip | Should -Be 9
+                $b.config_template | Should -Be 2
+            }
+            It "Should send latitude and longitude as decimals" {
+                $Result = New-NBDCIMDevice -Name 'geo' -Device_Role 4 -Device_Type 10 -Site 1 -Latitude 52.37 -Longitude 4.89
+                $b = $Result.Body | ConvertFrom-Json
+                $b.latitude | Should -Be 52.37
+                $b.longitude | Should -Be 4.89
+            }
+            It "Should reject out-of-range latitude and longitude" {
+                { New-NBDCIMDevice -Name 'g' -Device_Role 4 -Device_Type 10 -Site 1 -Latitude 200 } | Should -Throw
+                { New-NBDCIMDevice -Name 'g' -Device_Role 4 -Device_Type 10 -Site 1 -Longitude -181 } | Should -Throw
+            }
+            It "Should send local_context_data as a JSON object" {
+                $Result = New-NBDCIMDevice -Name 'lcd' -Device_Role 4 -Device_Type 10 -Site 1 -Local_Context_Data @{ ntp = 'pool.ntp.org' }
+                ($Result.Body | ConvertFrom-Json).local_context_data.ntp | Should -Be 'pool.ntp.org'
+            }
+            It "Should type Latitude and Longitude as double on New-" {
+                (Get-Command New-NBDCIMDevice).Parameters['Latitude'].ParameterType | Should -Be ([double])
+                (Get-Command New-NBDCIMDevice).Parameters['Longitude'].ParameterType | Should -Be ([double])
+            }
+        }
+
         It "Should have ValidateSet for Status parameter" {
             # Status parameter now uses ValidateSet for type safety
             $cmd = Get-Command New-NBDCIMDevice
@@ -508,6 +552,75 @@ Describe "DCIM Devices Tests" -Tag 'DCIM', 'Devices' {
         It "Should type Position as Nullable[double] (#412)" {
             (Get-Command Set-NBDCIMDevice).Parameters['Position'].ParameterType |
                 Should -Be ([System.Nullable[double]])
+        }
+
+        It "Should send an airflow value on update (#411)" {
+            $Result = Set-NBDCIMDevice -Id 1234 -Airflow 'rear-to-front' -Confirm:$false
+            ($Result.Body | ConvertFrom-Json).airflow | Should -Be 'rear-to-front'
+        }
+
+        It "Should clear airflow with the empty-string sentinel (#411)" {
+            $Result = Set-NBDCIMDevice -Id 1234 -Airflow '' -Confirm:$false
+            $Result.Body | Should -Match '"airflow"\s*:\s*null'
+        }
+
+        It "Should send null when -Location is explicitly null (#411)" {
+            $Result = Set-NBDCIMDevice -Id 1234 -Location $null -Confirm:$false
+            $Result.Body | Should -Match '"location"\s*:\s*null'
+        }
+
+        It "Should send null when -OOB_IP is explicitly null (#411)" {
+            $Result = Set-NBDCIMDevice -Id 1234 -OOB_IP $null -Confirm:$false
+            $Result.Body | Should -Match '"oob_ip"\s*:\s*null'
+        }
+
+        It "Should send null when -Config_Template is explicitly null (#411)" {
+            $Result = Set-NBDCIMDevice -Id 1234 -Config_Template $null -Confirm:$false
+            $Result.Body | Should -Match '"config_template"\s*:\s*null'
+        }
+
+        It "Should clear latitude/longitude with explicit null WITHOUT throwing (#411, #398/#412 guard)" {
+            { Set-NBDCIMDevice -Id 1234 -Latitude $null -Confirm:$false } | Should -Not -Throw
+            (Set-NBDCIMDevice -Id 1234 -Latitude $null -Confirm:$false).Body | Should -Match '"latitude"\s*:\s*null'
+            (Set-NBDCIMDevice -Id 1234 -Longitude $null -Confirm:$false).Body | Should -Match '"longitude"\s*:\s*null'
+        }
+
+        It "Should still accept numeric latitude/longitude (not broken by Nullable) (#411)" {
+            $b = (Set-NBDCIMDevice -Id 1234 -Latitude 52.37 -Longitude 4.89 -Confirm:$false).Body | ConvertFrom-Json
+            $b.latitude | Should -Be 52.37
+            $b.longitude | Should -Be 4.89
+        }
+
+        It "Should clear local_context_data with explicit null (#411)" {
+            (Set-NBDCIMDevice -Id 1234 -Local_Context_Data $null -Confirm:$false).Body |
+                Should -Match '"local_context_data"\s*:\s*null'
+        }
+
+        It "Should type Latitude/Longitude as Nullable[double] on Set- (#411)" {
+            (Get-Command Set-NBDCIMDevice).Parameters['Latitude'].ParameterType | Should -Be ([System.Nullable[double]])
+            (Get-Command Set-NBDCIMDevice).Parameters['Longitude'].ParameterType | Should -Be ([System.Nullable[double]])
+        }
+
+        It "Should type Location/OOB_IP/Config_Template as Nullable[uint64] on Set- (#411)" {
+            (Get-Command Set-NBDCIMDevice).Parameters['Location'].ParameterType | Should -Be ([System.Nullable[uint64]])
+            (Get-Command Set-NBDCIMDevice).Parameters['OOB_IP'].ParameterType | Should -Be ([System.Nullable[uint64]])
+            (Get-Command Set-NBDCIMDevice).Parameters['Config_Template'].ParameterType | Should -Be ([System.Nullable[uint64]])
+        }
+
+        It "Should NOT have ValidateRange on Set- Latitude/Longitude (#398/#412 guard) (#411)" {
+            $lat = (Get-Command Set-NBDCIMDevice).Parameters['Latitude']
+            ($lat.Attributes | Where-Object { $_ -is [System.Management.Automation.ValidateRangeAttribute] }) |
+                Should -BeNullOrEmpty
+            $lon = (Get-Command Set-NBDCIMDevice).Parameters['Longitude']
+            ($lon.Attributes | Where-Object { $_ -is [System.Management.Automation.ValidateRangeAttribute] }) |
+                Should -BeNullOrEmpty
+        }
+
+        It "Should include '' in Set- Airflow ValidateSet (clear sentinel) (#411)" {
+            $af = (Get-Command Set-NBDCIMDevice).Parameters['Airflow']
+            $vs = $af.Attributes | Where-Object { $_ -is [System.Management.Automation.ValidateSetAttribute] }
+            $vs.ValidValues | Should -Contain ''
+            $vs.ValidValues | Should -Contain 'front-to-rear'
         }
     }
 

--- a/scripts/validateset-parity-exclusions.txt
+++ b/scripts/validateset-parity-exclusions.txt
@@ -66,3 +66,7 @@ DCIM/Interfaces/Set-NBDCIMInterface.ps1::RF_Role
 # NetBox 4.6 Rack airflow/form_factor (#395 Phase 1) — same '' sentinel pattern.
 DCIM/Racks/Set-NBDCIMRack.ps1::Airflow
 DCIM/Racks/Set-NBDCIMRack.ps1::Form_Factor
+# NetBox 4.6 Device airflow (#411) - same '' sentinel pattern. NetBox's
+# airflow enum does include "" + null, but the parity matcher treats the
+# '' as a PowerNetbox-only null-clearing sentinel, not an enum value.
+DCIM/Devices/Set-NBDCIMDevice.ps1::Airflow


### PR DESCRIPTION
## Summary

Closes #411. Adds the 7 missing writable Device fields to `New-NBDCIMDevice` and `Set-NBDCIMDevice`, typed per the **live NetBox 4.6.0 schema** (`WritableDeviceWithConfigContextRequest`), targeting **v4.6.0.4**.

| Field | New- | Set- (clearable) |
|---|---|---|
| `location` | `[uint64]` | `[Nullable[uint64]]` → `$null` clears (#409 idiom) |
| `airflow` | `[ValidateSet]` 10 vals | `''` empty-string sentinel → JSON null (#401 idiom) |
| `oob_ip` | `[uint64]` | `[Nullable[uint64]]` |
| `latitude` | `[double]` + `[ValidateRange(-90,90)]` | `[Nullable[double]]`, **no ValidateRange** |
| `longitude` | `[double]` + `[ValidateRange(-180,180)]` | `[Nullable[double]]`, **no ValidateRange** |
| `config_template` | `[uint64]` | `[Nullable[uint64]]` |
| `local_context_data` | `[object]` | `[object]` → `$null` clears |

### Design notes

- **`latitude`/`longitude` asymmetry is deliberate.** `New-` is non-nullable so it keeps the live-schema geographic bounds via `[ValidateRange]`. `Set-` must clear via `-Latitude $null`, and `[ValidateRange]` fires *before* `[Nullable[T]]` binding — so a range check there would throw on `$null` (the #398 / #412 trap). `Set-` relies on server-side bound enforcement instead. A unit test guards this (asserts no `ValidateRange` on the `Set-` nullables) so it can't regress.
- **`airflow`** reuses the exact #401 `Set-NBDCIMInterface -Duplex ''` empty-string-sentinel pattern: `[AllowEmptyString()]` + `''` in the `ValidateSet`, translated to `$null` in `process{}` so PATCH emits `"airflow": null`. Parity exclusion added (NetBox's `airflow` enum does include `""`+`null`; the matcher treats `''` as the PN-only sentinel).
- **`local_context_data`** is `[object]` not `[hashtable]` — the live schema declares no `type` (free-form JSON: object/array/scalar all valid).

### Verification (local)

- Build OK; **Pester `DCIM.Devices.Tests.ps1`: 116 passed / 0 failed** (20 new #411 tests + existing #412 suite)
- `Verify-ValidateSetParity.ps1 -NetboxVersion v4.6.0`: **All ValidateSets match**
- PSScriptAnalyzer: no new findings vs dev baseline (the one `PSReviewUnusedParameter` at line 32 is the pre-existing `$TestPath` `InModuleScope` baseline)
- ASCII-clean `.ps1` (PS 5.1 Windows-1252 parse safety)
- `psd1`: version-only bump `4.6.0.3` → `4.6.0.4` (deploy.ps1 regeneration reverted per project convention)

Reporter (@mkarel) did the live-schema + PATCH spelunking on #411; picked up via pre-emption after ~3 weeks quiet, `Co-Authored-By` credit on the commit. Clarifying comment posted on #411.

## Test plan

- [x] Unit tests pass locally (116/0)
- [x] ValidateSet parity clean vs v4.6.0
- [x] PSScriptAnalyzer clean (no new vs baseline)
- [ ] CI green (Pester ×4 platforms, Lint, Gitleaks, Filter-exclusion)
- [ ] Integration matrix (4.3.7 / 4.4.10 / 4.5.10 / 4.6.0) green on merge to dev