### PR TITLE
Feature/contact groups

### DIFF
--- a/Functions/Tenancy/ContactGroups/Get-NBContactGroup.ps1
+++ b/Functions/Tenancy/ContactGroups/Get-NBContactGroup.ps1
@@ -5,8 +5,8 @@ function Get-NBContactGroup {
         Get one or more contact groups from Netbox
 
     .DESCRIPTION
-        Retrieves contact groups from Netbox. contact groups link contacts
-        to objects (devices, sites, circuits, etc.) with a specific role.
+        Retrieves contact groups from Netbox. Contact groups are hierarchical
+        organizational containers for grouping related contacts.
 
     .PARAMETER Id
         The database ID of the contact group.
@@ -14,8 +14,11 @@ function Get-NBContactGroup {
     .PARAMETER Name
         The specific name of the contact group.
 
-    .PARAMETER Contact_Id
-        Filter by contact database ID.
+    .PARAMETER Slug
+        Filter by the contact group's slug.
+
+    .PARAMETER Parent_Id
+        Filter by parent contact group database ID (returns its direct children).
 
     .PARAMETER Offset
         Start the search at this index in results
@@ -68,7 +71,10 @@ function Get-NBContactGroup {
         [string]$Name,
 
         [Parameter(ParameterSetName = 'Query')]
-        [uint64]$Contact_Id,
+        [string]$Slug,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64]$Parent_Id,
 
         [switch]$All,
 

--- a/Functions/Tenancy/ContactGroups/Get-NBContactGroup.ps1
+++ b/Functions/Tenancy/ContactGroups/Get-NBContactGroup.ps1
@@ -1,0 +1,123 @@
+
+function Get-NBContactGroup {
+<#
+    .SYNOPSIS
+        Get one or more contact groups from Netbox
+
+    .DESCRIPTION
+        Retrieves contact groups from Netbox. contact groups link contacts
+        to objects (devices, sites, circuits, etc.) with a specific role.
+
+    .PARAMETER Id
+        The database ID of the contact group.
+
+    .PARAMETER Name
+        The specific name of the contact group.
+
+    .PARAMETER Contact_Id
+        Filter by contact database ID.
+
+    .PARAMETER Offset
+        Start the search at this index in results
+
+    .PARAMETER Raw
+        Return the unparsed data from the HTTP request
+
+    .PARAMETER All
+        Automatically fetch all pages of results. Uses the API's pagination
+        to retrieve all items across multiple requests.
+
+    .PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+    .PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'site.name', 'device_type.model').
+
+    .PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+    .PARAMETER PageSize
+        Number of items per page when using -All. Default: 100.
+        Range: 1-1000.
+
+    .PARAMETER Limit
+        Limit the number of results to this number
+
+    .EXAMPLE
+        PS C:\> Get-NBContactGroup
+
+    .EXAMPLE
+        PS C:\> Get-NBContactGroup -Id 5
+
+    .NOTES
+        The -Brief, -Fields, and -Omit parameters are mutually exclusive.
+#>
+
+    [CmdletBinding(DefaultParameterSetName = 'Query')]
+    [OutputType([PSCustomObject])]
+    param
+    (
+        [Parameter(ParameterSetName = 'ByID', ValueFromPipelineByPropertyName = $true)]
+        [uint64[]]$Id,
+
+        [Parameter(ParameterSetName = 'Query',
+                   Position = 0)]
+        [string]$Name,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64]$Contact_Id,
+
+        [switch]$All,
+
+        [switch]$Brief,
+
+        [string[]]$Fields,
+
+        [string[]]$Omit,
+
+        [ValidateRange(1, 1000)]
+        [int]$PageSize = 100,
+
+        [ValidateRange(1, 1000)]
+        [uint16]$Limit,
+
+        [ValidateRange(0, [int]::MaxValue)]
+        [uint16]$Offset,
+
+        [switch]$Raw
+    )
+
+    process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
+        Write-Verbose "Retrieving Contact Group"
+        switch ($PSCmdlet.ParameterSetName) {
+        'ById' {
+            foreach ($ContactGroup_ID in $Id) {
+                $Segments = [System.Collections.ArrayList]::new(@('tenancy', 'contact-groups', $ContactGroup_ID))
+
+                $URIComponents = BuildURIComponents -URISegments $Segments -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw', 'All', 'PageSize'
+
+                $uri = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
+
+                InvokeNetboxRequest -URI $uri -Raw:$Raw -All:$All -PageSize $PageSize
+            }
+            return
+        }
+
+        default {
+            $Segments = [System.Collections.ArrayList]::new(@('tenancy', 'contact-groups'))
+
+            $URIComponents = BuildURIComponents -URISegments $Segments -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'All', 'PageSize'
+
+            $uri = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
+
+            InvokeNetboxRequest -URI $uri -Raw:$Raw -All:$All -PageSize $PageSize
+        }
+    }
+    }
+}

--- a/Functions/Tenancy/ContactGroups/Get-NBContactGroup.ps1
+++ b/Functions/Tenancy/ContactGroups/Get-NBContactGroup.ps1
@@ -84,7 +84,7 @@ function Get-NBContactGroup {
         [ValidateRange(1, 1000)]
         [uint16]$Limit,
 
-        [ValidateRange(0, [int]::MaxValue)]
+        [ValidateRange(0, [uint16]::MaxValue)]
         [uint16]$Offset,
 
         [switch]$Raw

--- a/Functions/Tenancy/ContactGroups/New-NBContactGroup.ps1
+++ b/Functions/Tenancy/ContactGroups/New-NBContactGroup.ps1
@@ -14,7 +14,7 @@ function New-NBContactGroup {
         The contact group's slug, a URL-friendly unique identifier. Auto-generated from Name if not provided.
 
     .PARAMETER Description
-        Short description of the contact
+        Short description of the contact group
 
     .PARAMETER Comments
         Detailed comments. Markdown supported.
@@ -72,6 +72,13 @@ function New-NBContactGroup {
     process {
         Write-Verbose "Creating Contact Group"
         $Segments = [System.Collections.ArrayList]::new(@('tenancy', 'contact-groups'))
+
+        # Auto-generate slug from name if not provided. NetBox's REST API requires
+        # 'slug' on POST (it does not auto-slug server-side; only the web UI does),
+        # so derive it client-side to match New-NBTenantGroup and the documented examples.
+        if (-not $PSBoundParameters.ContainsKey('Slug')) {
+            $PSBoundParameters['Slug'] = ($Name -replace '\s+', '-').ToLower()
+        }
 
         $paramDict = $PSBoundParameters
         if ($PSBoundParameters.ContainsKey('Parent') -and $false -eq [System.UInt64]::TryParse($Parent, [ref]$null)) {

--- a/Functions/Tenancy/ContactGroups/New-NBContactGroup.ps1
+++ b/Functions/Tenancy/ContactGroups/New-NBContactGroup.ps1
@@ -76,7 +76,10 @@ function New-NBContactGroup {
         $paramDict = $PSBoundParameters
         if ($PSBoundParameters.ContainsKey('Parent') -and $false -eq [System.UInt64]::TryParse($Parent, [ref]$null)) {
             # if it isn't a int, we assume it's a name which needs to be presented differently in the body
-            $paramDict = $PSBoundParameters | ConvertTo-Json | ConvertFrom-Json -AsHashtable
+            $paramDict = @{}
+            foreach ($key in $PSBoundParameters.Keys) {
+                $paramDict[$key] = $PSBoundParameters[$key]
+            }
             $paramDict['parent'] = @{ 'name' = $Parent }
         }
 

--- a/Functions/Tenancy/ContactGroups/New-NBContactGroup.ps1
+++ b/Functions/Tenancy/ContactGroups/New-NBContactGroup.ps1
@@ -1,0 +1,95 @@
+
+function New-NBContactGroup {
+<#
+    .SYNOPSIS
+        Create a new contact group in Netbox
+
+    .DESCRIPTION
+        Creates a new contact group object in Netbox which can be linked to other objects
+
+    .PARAMETER Name
+        The contact group's full name, e.g "Organisation IT Support"
+
+    .PARAMETER Slug
+        The contact group's slug, a URL-friendly unique identifier. Auto-generated from Name if not provided.
+
+    .PARAMETER Description
+        Short description of the contact
+
+    .PARAMETER Comments
+        Detailed comments. Markdown supported.
+
+    .PARAMETER Parent
+        The parent contact group, specified by name or database ID. Establishes a hierarchy of contact groups.
+
+    .PARAMETER Custom_Fields
+        Hashtable of custom field values.
+
+    .PARAMETER Tags
+        Array of tag names or IDs to assign to the contact group.
+
+    .PARAMETER Raw
+        Return the raw API response instead of the created object.
+
+    .EXAMPLE
+        PS C:\> New-NBContactGroup -Name 'Admins'
+
+    .EXAMPLE
+        PS C:\> New-NBContactGroup -Name 'Network Admin' -Description 'Supporters of the network' -Parent 'Admins'
+        Creates a contact group named 'Network Admin' which is a child of the 'Admins' contact group.
+
+    .NOTES
+#>
+
+    [CmdletBinding(ConfirmImpact = 'Low',
+                   SupportsShouldProcess = $true)]
+    [OutputType([pscustomobject])]
+    param
+    (
+        [Parameter(Mandatory = $true,
+                   ValueFromPipelineByPropertyName = $true)]
+        [ValidateLength(1, 100)]
+        [string]$Name,
+
+        [ValidateLength(0, 100)]
+        [string]$Slug,
+
+        [ValidateLength(0, 200)]
+        [string]$Description,
+
+        [string]$Comments,
+
+        [ValidateLength(1, 100)]
+        [string]$Parent,
+
+        [hashtable]$Custom_Fields,
+
+        [object[]]$Tags,
+
+        [switch]$Raw
+    )
+
+    process {
+        Write-Verbose "Creating Contact Group"
+        $Segments = [System.Collections.ArrayList]::new(@('tenancy', 'contact-groups'))
+
+        $paramDict = $PSBoundParameters
+        if ($PSBoundParameters.ContainsKey('Parent') -and $false -eq [System.UInt64]::TryParse($Parent, [ref]$null)) {
+            # if it isn't a int, we assume it's a name which needs to be presented differently in the body
+            $paramDict = $PSBoundParameters | ConvertTo-Json | ConvertFrom-Json -AsHashtable
+            $paramDict['parent'] = @{ 'name' = $Parent }
+        }
+
+        $URIComponents = BuildURIComponents -URISegments $Segments -ParametersDictionary $paramDict -SkipParameterByName 'Raw'
+
+        $URI = BuildNewURI -Segments $URIComponents.Segments
+
+        if ($PSCmdlet.ShouldProcess($Name, 'Create new contactgroup')) {
+            InvokeNetboxRequest -URI $URI -Method POST -Body $URIComponents.Parameters -Raw:$Raw
+        }
+    }
+}
+
+
+
+

--- a/Functions/Tenancy/ContactGroups/Remove-NBContactGroup.ps1
+++ b/Functions/Tenancy/ContactGroups/Remove-NBContactGroup.ps1
@@ -1,0 +1,62 @@
+<#
+    .SYNOPSIS
+        Removes a contactgroup from Netbox.
+
+    .DESCRIPTION
+        Removes a contactgroup from the Netbox tenancy module.
+        Supports pipeline input from Get-NBContactGroup.
+
+    .PARAMETER Id
+        The database ID(s) of the contactgroup(s) to remove. Accepts pipeline input.
+
+    .PARAMETER Force
+        Skip confirmation prompts.
+
+    .PARAMETER Raw
+        Return the raw API response instead of the results array.
+
+    .EXAMPLE
+        Remove-NBContactGroup -Id 1
+        Removes contactgroup ID 1 (with confirmation prompt).
+
+    .EXAMPLE
+        Remove-NBContactGroup -Id 1 -Force
+        Removes contactgroup ID 1 without confirmation.
+
+    .EXAMPLE
+        Get-NBContactGroup -Id 5 | Remove-NBContactGroup -Force
+        Removes all contact groups in a specific group via pipeline.
+
+    .LINK
+        https://netbox.readthedocs.io/en/stable/models/tenancy/contactgroup/
+
+    .NOTES
+
+#>
+function Remove-NBContactGroup {
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'High')]
+    [OutputType([void])]
+    param
+    (
+        [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ValueFromPipeline = $true)]
+        [uint64[]]$Id,
+
+        [switch]$Force,
+
+        [switch]$Raw
+    )
+
+    process {
+        Write-Verbose "Removing Contact Group"
+        foreach ($ContactgroupId in $Id) {
+
+            $Segments = [System.Collections.ArrayList]::new(@('tenancy', 'contact-groups', $ContactgroupId))
+
+            $URI = BuildNewURI -Segments $Segments
+
+            if ($Force -or $PSCmdlet.ShouldProcess("ID $ContactgroupId", 'Delete contact group')) {
+                InvokeNetboxRequest -URI $URI -Method DELETE -Raw:$Raw
+            }
+        }
+    }
+}

--- a/Functions/Tenancy/ContactGroups/Remove-NBContactGroup.ps1
+++ b/Functions/Tenancy/ContactGroups/Remove-NBContactGroup.ps1
@@ -41,6 +41,8 @@ function Remove-NBContactGroup {
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ValueFromPipeline = $true)]
         [uint64[]]$Id,
 
+        [switch]$Force,
+
         [switch]$Raw
     )
 
@@ -52,7 +54,7 @@ function Remove-NBContactGroup {
 
             $URI = BuildNewURI -Segments $Segments
 
-            if ($PSCmdlet.ShouldProcess("ID $ContactgroupId", 'Delete contact group')) {
+            if ($Force -or $PSCmdlet.ShouldProcess("ID $ContactgroupId", 'Delete contact group')) {
                 InvokeNetboxRequest -URI $URI -Method DELETE -Raw:$Raw
             }
         }

--- a/Functions/Tenancy/ContactGroups/Remove-NBContactGroup.ps1
+++ b/Functions/Tenancy/ContactGroups/Remove-NBContactGroup.ps1
@@ -41,8 +41,6 @@ function Remove-NBContactGroup {
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true, ValueFromPipeline = $true)]
         [uint64[]]$Id,
 
-        [switch]$Force,
-
         [switch]$Raw
     )
 
@@ -54,7 +52,7 @@ function Remove-NBContactGroup {
 
             $URI = BuildNewURI -Segments $Segments
 
-            if ($Force -or $PSCmdlet.ShouldProcess("ID $ContactgroupId", 'Delete contact group')) {
+            if ($PSCmdlet.ShouldProcess("ID $ContactgroupId", 'Delete contact group')) {
                 InvokeNetboxRequest -URI $URI -Method DELETE -Raw:$Raw
             }
         }

--- a/Functions/Tenancy/ContactGroups/Set-NBContactGroup.ps1
+++ b/Functions/Tenancy/ContactGroups/Set-NBContactGroup.ps1
@@ -1,0 +1,89 @@
+
+function Set-NBContactGroup {
+<#
+    .SYNOPSIS
+        Update a contact group in Netbox
+
+    .DESCRIPTION
+        Updates a contact group object in Netbox which can be linked to other objects
+
+    .PARAMETER Id
+        Database ID of the contact group to update.
+
+    .PARAMETER Name
+        The contact group's full name, e.g "Organisation IT Support"
+
+    .PARAMETER Description
+        Short description of the contact group
+
+    .PARAMETER Comments
+        Detailed comments. Markdown supported.
+
+    .PARAMETER Custom_Fields
+        Hashtable of custom field values.
+
+    .PARAMETER Tags
+        Array of tag names or IDs to assign to the contact group.
+
+    .PARAMETER Force
+        Skip confirmation prompts.
+
+    .PARAMETER Raw
+        Return the raw API response instead of the updated object.
+
+    .EXAMPLE
+        PS C:\> Set-NBContactGroup -Id 5 -Name 'New Name' -Description 'Updated description' -Force
+.NOTES
+
+#>
+
+    [CmdletBinding(ConfirmImpact = 'Medium',
+                   SupportsShouldProcess = $true)]
+    [OutputType([pscustomobject])]
+    param
+    (
+        [Parameter(Mandatory = $true,
+                   ValueFromPipelineByPropertyName = $true,
+                   ValueFromPipeline = $true)]
+        [uint64[]]$Id,
+
+        [ValidateLength(1, 100)]
+        [string]$Name,
+
+        [ValidateLength(0, 200)]
+        [string]$Description,
+
+        [string]$Comments,
+
+        [hashtable]$Custom_Fields,
+
+        [object[]]$Tags,
+
+        [switch]$Force,
+
+        [switch]$Raw
+    )
+
+    begin {
+        $Method = 'PATCH'
+    }
+
+    process {
+        Write-Verbose "Updating Contact Group"
+        foreach ($ContactGroupId in $Id) {
+            $Segments = [System.Collections.ArrayList]::new(@('tenancy', 'contact-groups', $ContactGroupId))
+
+            $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw', 'Force'
+
+            $URI = BuildNewURI -Segments $URIComponents.Segments
+
+            if ($Force -or $PSCmdlet.ShouldProcess("ID $ContactGroupId", 'Update contact group')) {
+                InvokeNetboxRequest -URI $URI -Method $Method -Body $URIComponents.Parameters -Raw:$Raw
+            }
+        }
+    }
+}
+
+
+
+

--- a/Functions/Tenancy/ContactGroups/Set-NBContactGroup.ps1
+++ b/Functions/Tenancy/ContactGroups/Set-NBContactGroup.ps1
@@ -59,8 +59,6 @@ function Set-NBContactGroup {
 
         [object[]]$Tags,
 
-        [switch]$Force,
-
         [switch]$Raw
     )
 
@@ -77,7 +75,7 @@ function Set-NBContactGroup {
 
             $URI = BuildNewURI -Segments $URIComponents.Segments
 
-            if ($Force -or $PSCmdlet.ShouldProcess("ID $ContactGroupId", 'Update contact group')) {
+            if ($PSCmdlet.ShouldProcess("ID $ContactGroupId", 'Update contact group')) {
                 InvokeNetboxRequest -URI $URI -Method $Method -Body $URIComponents.Parameters -Raw:$Raw
             }
         }

--- a/Functions/Tenancy/ContactGroups/Set-NBContactGroup.ps1
+++ b/Functions/Tenancy/ContactGroups/Set-NBContactGroup.ps1
@@ -59,6 +59,8 @@ function Set-NBContactGroup {
 
         [object[]]$Tags,
 
+        [switch]$Force,
+
         [switch]$Raw
     )
 
@@ -75,7 +77,7 @@ function Set-NBContactGroup {
 
             $URI = BuildNewURI -Segments $URIComponents.Segments
 
-            if ($PSCmdlet.ShouldProcess("ID $ContactGroupId", 'Update contact group')) {
+            if ($Force -or $PSCmdlet.ShouldProcess("ID $ContactGroupId", 'Update contact group')) {
                 InvokeNetboxRequest -URI $URI -Method $Method -Body $URIComponents.Parameters -Raw:$Raw
             }
         }

--- a/Functions/Tenancy/Contacts/Get-NBContact.ps1
+++ b/Functions/Tenancy/Contacts/Get-NBContact.ps1
@@ -31,8 +31,8 @@ function Get-NBContact {
     .PARAMETER Group
         The specific group as defined in Netbox.
 
-    .PARAMETER GroupID
-        The database ID of the group in Netbox
+    .PARAMETER Group_ID
+        A database ID of the group in Netbox which contacts should be filtered by. Alias: -GroupId for backwards compatibility.
 
     .PARAMETER Limit
         Limit the number of results to this number
@@ -109,10 +109,12 @@ function Get-NBContact {
         [string]$Address,
 
         [Parameter(ParameterSetName = 'Query')]
+        [Alias('Groups','GroupNames')]
         [string]$Group,
 
         [Parameter(ParameterSetName = 'Query')]
-        [uint64]$GroupID,
+        [Alias('GroupId')]
+        [uint64]$Group_Id,
 
         [ValidateRange(1, 1000)]
         [uint16]$Limit,
@@ -127,30 +129,31 @@ function Get-NBContact {
         AssertNBMutualExclusiveParam `
             -BoundParameters $PSBoundParameters `
             -Parameters 'Brief', 'Fields', 'Omit'
+
         Write-Verbose "Retrieving Contact"
         switch ($PSCmdlet.ParameterSetName) {
-        'ById' {
-            foreach ($Contact_ID in $Id) {
-                $Segments = [System.Collections.ArrayList]::new(@('tenancy', 'contacts', $Contact_ID))
+            'ById' {
+                foreach ($Contact_ID in $Id) {
+                    $Segments = [System.Collections.ArrayList]::new(@('tenancy', 'contacts', $Contact_ID))
 
-                $URIComponents = BuildURIComponents -URISegments $Segments -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw', 'All', 'PageSize'
+                    $URIComponents = BuildURIComponents -URISegments $Segments -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw', 'All', 'PageSize'
+
+                    $uri = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
+
+                    InvokeNetboxRequest -URI $uri -Raw:$Raw -All:$All -PageSize $PageSize
+                }
+                return
+            }
+
+            default {
+                $Segments = [System.Collections.ArrayList]::new(@('tenancy', 'contacts'))
+
+                $URIComponents = BuildURIComponents -URISegments $Segments -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'All', 'PageSize'
 
                 $uri = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
 
                 InvokeNetboxRequest -URI $uri -Raw:$Raw -All:$All -PageSize $PageSize
             }
-            return
         }
-
-        default {
-            $Segments = [System.Collections.ArrayList]::new(@('tenancy', 'contacts'))
-
-            $URIComponents = BuildURIComponents -URISegments $Segments -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'All', 'PageSize'
-
-            $uri = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
-
-            InvokeNetboxRequest -URI $uri -Raw:$Raw -All:$All -PageSize $PageSize
-        }
-    }
     }
 }

--- a/Functions/Tenancy/Contacts/New-NBContact.ps1
+++ b/Functions/Tenancy/Contacts/New-NBContact.ps1
@@ -34,6 +34,12 @@ function New-NBContact {
     .PARAMETER Custom_Fields
         Hashtable of custom field values.
 
+    .PARAMETER Tags
+        Array of tag names or IDs to assign to the contact.
+
+    .PARAMETER Group_Id
+        Array of contact group IDs to associate with the contact.
+
     .PARAMETER Raw
         Return the raw API response instead of the created object.
 
@@ -76,13 +82,19 @@ function New-NBContact {
 
         [hashtable]$Custom_Fields,
 
-
         [object[]]$Tags,
+
+        [uint64[]]$Group_Id,
 
         [switch]$Raw
     )
 
     process {
+        # For parametername consistency group_id -> groups: PUT api expects "groups": [1,2,3]
+        if ($PSBoundParameters.ContainsKey('Group_Id')) {
+            $PSBoundParameters.Groups = $PSBoundParameters.Group_Id
+            $PSBoundParameters.Remove('Group_Id') | Out-Null
+        }
         Write-Verbose "Creating Contact"
         $Segments = [System.Collections.ArrayList]::new(@('tenancy', 'contacts'))
 

--- a/Functions/Tenancy/Contacts/New-NBContact.ps1
+++ b/Functions/Tenancy/Contacts/New-NBContact.ps1
@@ -84,6 +84,7 @@ function New-NBContact {
 
         [object[]]$Tags,
 
+        [Alias('Group')]
         [uint64[]]$Group_Id,
 
         [switch]$Raw

--- a/Functions/Tenancy/Contacts/Remove-NBContact.ps1
+++ b/Functions/Tenancy/Contacts/Remove-NBContact.ps1
@@ -42,7 +42,7 @@ function Remove-NBContact {
     param
     (
         [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
-        [uint64]$Id,
+        [uint64[]]$Id,
 
         [switch]$Force,
 

--- a/Functions/Tenancy/Contacts/Set-NBContact.ps1
+++ b/Functions/Tenancy/Contacts/Set-NBContact.ps1
@@ -16,8 +16,8 @@ function Set-NBContact {
     .PARAMETER Email
         Email address of the contact
 
-    .PARAMETER Group
-        Database ID of assigned group
+    .PARAMETER Group_Id
+        Database ID of assigned group. Alias: Groups for backwards compatibility.
 
     .PARAMETER Title
         Job title or other title related to the contact
@@ -61,15 +61,13 @@ function Set-NBContact {
     (
         [Parameter(Mandatory = $true,
                    ValueFromPipelineByPropertyName = $true)]
-        [uint64]$Id,
+        [uint64[]]$Id,
 
         [ValidateLength(1, 100)]
         [string]$Name,
 
         [ValidateLength(0, 254)]
         [string]$Email,
-
-        [uint64]$Group,
 
         [ValidateLength(0, 100)]
         [string]$Title,
@@ -90,10 +88,12 @@ function Set-NBContact {
 
         [hashtable]$Custom_Fields,
 
-        [switch]$Force,
-
-
         [object[]]$Tags,
+
+        [Alias('Group')]
+        [uint64[]]$Group_Id,
+
+        [switch]$Force,
 
         [switch]$Raw
     )
@@ -103,6 +103,10 @@ function Set-NBContact {
     }
 
     process {
+        if ($PSBoundParameters.ContainsKey('Group_Id')) {
+            $PSBoundParameters['Groups'] = [System.Collections.ArrayList]::new(@($PSBoundParameters['Group_Id']))
+            $PSBoundParameters.Remove('Group_Id') | Out-Null
+        }
         Write-Verbose "Updating Contact"
         foreach ($ContactId in $Id) {
             $Segments = [System.Collections.ArrayList]::new(@('tenancy', 'contacts', $ContactId))

--- a/Functions/Tenancy/Contacts/Set-NBContact.ps1
+++ b/Functions/Tenancy/Contacts/Set-NBContact.ps1
@@ -17,7 +17,7 @@ function Set-NBContact {
         Email address of the contact
 
     .PARAMETER Group_Id
-        Database ID of assigned group. Alias: Groups for backwards compatibility.
+        Database ID(s) of assigned contact group(s). Alias: -Group (the previous parameter name) for backwards compatibility.
 
     .PARAMETER Title
         Job title or other title related to the contact

--- a/Tests/Integration.Tests.ps1
+++ b/Tests/Integration.Tests.ps1
@@ -1209,6 +1209,78 @@ Describe "Live Integration Tests" -Tag 'Integration', 'Live' -Skip:(-not $script
         }
     }
 
+    Context "Contact Group CRUD" {
+        BeforeAll {
+            # This group will be used for tests of adding/removeing contacts as well, so it's not removed at the end
+            $script:TestContactGroupId = @(-1, -1, -1)      # paremt group, chil1, child2
+            $script:TestContactGroupName = @("$($script:TestPrefix)-ContactGroup", "$($script:TestPrefix)-ContactGroup-Child", "$($script:TestPrefix)-ContactGroup-Child2")
+            $script:TestContactGroupSlug = $script:TestContactGroupName.ToLower() -replace '[^a-z0-9-]', '-'
+
+            $group = New-NBContactGroup -Name $script:TestContactGroupName[0] -Slug $script:TestContactGroupSlug[0]
+            $group | Should -Not -BeNullOrEmpty
+            $script:TestContactGroupId[0] = $group.id
+            [void]$script:CreatedResources.ContactGroups.Add($group.id)
+        }
+
+        It "Should create a contact group as child group" {
+            $childGroup = New-NBContactGroup -Name $script:TestContactGroupName[1] -Slug $script:TestContactGroupSlug[1] -Parent $script:TestContactGroupId[0]
+            $script:TestContactGroupId[1] = $childGroup.id
+            [void]$script:CreatedResources.ContactGroups.Add($childGroup.id)
+
+            $childGroup.parent.id | Should -Be $script:TestContactGroupId[0]
+        }
+
+        It "Should create child group (search parent by name)" {
+            $childGroup = New-NBContactGroup -Name $script:TestContactGroupName[2] -Slug $script:TestContactGroupSlug[2] -Parent $script:TestContactGroupName[0]
+            $script:TestContactGroupId[2] = $childGroup.id
+            [void]$script:CreatedResources.ContactGroups.Add($childGroup.id)
+
+            $childGroup.parent.id | Should -Be $script:TestContactGroupId[0]
+        }
+        It "Should get contact group by ID" {
+            $group = Get-NBContactGroup -Id $script:TestContactGroupId[0]
+
+            $group | Should -Not -BeNullOrEmpty
+            $group.id | Should -Be $script:TestContactGroupId[0]
+            $group.name | Should -Be $script:TestContactGroupName[0]
+        }
+
+        It "Should get multiple contact groups by id" {
+            $groups = Get-NBContactGroup -Id ($script:TestContactGroupId[0], $script:TestContactGroupId[1])
+
+            $groups | Should -Not -BeNullOrEmpty
+            $groups | Should -HaveCount 2
+            $groups[0].id | Should -Be $script:TestContactGroupId[0]
+            $groups[1].id | Should -Be $script:TestContactGroupId[1]
+        }
+
+        It "Should update contact group" {
+            $group = Set-NBContactGroup -Id $script:TestContactGroupId[0] -Description "$script:TestPrefix - Updated Contact Group"
+
+            $group.description | Should -BeLike "*Updated*"
+        }
+
+        It "Should update (rename) a contact group by pipeline Id" {
+            $Result = Get-NBContactGroup -Id $script:TestContactGroupId[0] | Set-NBContactGroup -Name "$($script:TestContactGroupName[0]) - Updated" -Confirm:$false
+
+            $Result.name | Should -Be "$($script:TestContactGroupName[0]) - Updated"   # renamed the group
+            $Result.slug | Should -Be $script:TestContactGroupSlug[0]  # slug should remain unchanged
+        }
+
+        It "Should delete child contact groups by Id" {
+            # Remove the child group first, otherwise the parent group deletion would do a cascading delete
+            { Remove-NBContactGroup -Id $script:TestContactGroupId[1] -Confirm:$false } | Should -Not -Throw
+            $script:CreatedResources.ContactGroups.Remove($script:TestContactGroupId[1])
+            $script:TestContactGroupId[1] = $null
+        }
+
+        It "Should delete contact group 2 by pipeline" {
+            { Get-NBContactGroup -Id $script:TestContactGroupId[2] | Remove-NBContactGroup -Confirm:$false } | Should -Not -Throw
+            $script:CreatedResources.ContactGroups.Remove($script:TestContactGroupId[2])
+            $script:TestContactGroupId[2] = $null
+        }
+    }
+
     Context "Contact Role CRUD" {
         BeforeAll {
             $script:TestContactRoleName = "$($script:TestPrefix)-ContactRole"
@@ -1363,89 +1435,6 @@ Describe "Live Integration Tests" -Tag 'Integration', 'Live' -Skip:(-not $script
             { Remove-NBContactAssignment -Id $script:TestContactAssignmentId -Confirm:$false } | Should -Not -Throw
 
             $script:CreatedResources.ContactAssignments.Remove($script:TestContactAssignmentId)
-        }
-    }
-
-    Context "Contact Group CRUD" {
-        BeforeAll {
-            $script:TestContactGroupId = @(-1, -1, -1)      # paremt group, chil1, child2
-            $script:TestContactGroupName = @("$($script:TestPrefix)-ContactGroup", "$($script:TestPrefix)-ContactGroup-Child", "$($script:TestPrefix)-ContactGroup-Child2")
-            $script:TestContactGroupSlug = $script:TestContactGroupName.ToLower() -replace '[^a-z0-9-]', '-'
-        }
-
-        It "Should create a contact group" {
-            $group = New-NBContactGroup -Name $script:TestContactGroupName[0] -Slug $script:TestContactGroupSlug[0]
-
-            $group | Should -Not -BeNullOrEmpty
-            $group.name | Should -Be $script:TestContactGroupName[0]
-
-            $script:TestContactGroupId[0] = $group.id
-            [void]$script:CreatedResources.ContactGroups.Add($group.id)
-
-            Write-Host "  Created contact group: $($group.name) (ID: $($group.id))" -ForegroundColor Green
-        }
-
-        It "Should create a contact group as child group" {
-            $childGroup = New-NBContactGroup -Name $script:TestContactGroupName[1] -Slug $script:TestContactGroupSlug[1] -Parent $script:TestContactGroupId[0]
-            $script:TestContactGroupId[1] = $childGroup.id
-            [void]$script:CreatedResources.ContactGroups.Add($childGroup.id)
-
-            $childGroup.parent.id | Should -Be $script:TestContactGroupId[0]
-        }
-
-        It "Should create child group (search parent by name)" {
-            $childGroup = New-NBContactGroup -Name $script:TestContactGroupName[2] -Slug $script:TestContactGroupSlug[2] -Parent $script:TestContactGroupName[0]
-            $script:TestContactGroupId[2] = $childGroup.id
-            [void]$script:CreatedResources.ContactGroups.Add($childGroup.id)
-
-            $childGroup.parent.id | Should -Be $script:TestContactGroupId[0]
-        }
-
-        It "Should get contact group by ID" {
-            $group = Get-NBContactGroup -Id $script:TestContactGroupId[0]
-
-            $group | Should -Not -BeNullOrEmpty
-            $group.id | Should -Be $script:TestContactGroupId[0]
-            $group.name | Should -Be $script:TestContactGroupName[0]
-        }
-
-        It "Should get multiple contact groups by id" {
-            $groups = Get-NBContactGroup -Id ($script:TestContactGroupId[0], $script:TestContactGroupId[1])
-
-            $groups | Should -Not -BeNullOrEmpty
-            $groups | Should -HaveCount 2
-            $groups[0].id | Should -Be $script:TestContactGroupId[0]
-            $groups[1].id | Should -Be $script:TestContactGroupId[1]
-        }
-
-        It "Should update contact group" {
-            $group = Set-NBContactGroup -Id $script:TestContactGroupId[0] -Description "$script:TestPrefix - Updated Contact Group"
-
-            $group.description | Should -BeLike "*Updated*"
-        }
-
-        It "Should update (rename) a contact group by pipeline Id" {
-            $Result = Get-NBContactGroup -Id $script:TestContactGroupId[0] | Set-NBContactGroup -Name 'Updated Group by pipeline' -Confirm:$false
-
-            $Result.name | Should -Be 'Updated Group by pipeline'   # renamed the group
-            $Result.slug | Should -Be $script:TestContactGroupSlug[0]  # slug should remain unchanged
-        }
-
-        It "Should delete child contact groups by Id" {
-            # Remove the child group first, otherwise the parent group deletion would do a cascading delete
-            { Remove-NBContactGroup -Id $script:TestContactGroupId[1] -Confirm:$false } | Should -Not -Throw
-            $script:CreatedResources.ContactGroups.Remove($script:TestContactGroupId[1])
-            $script:TestContactGroupId[1] = $null
-
-            { Remove-NBContactGroup -Id $script:TestContactGroupId[2] -Confirm:$false } | Should -Not -Throw
-            $script:CreatedResources.ContactGroups.Remove($script:TestContactGroupId[2])
-            $script:TestContactGroupId[2] = $null
-        }
-
-        It "Should delete contact group by pipeline" {
-            { Get-NBContactGroup -Id $script:TestContactGroupId[0] | Remove-NBContactGroup -Confirm:$false } | Should -Not -Throw
-            $script:CreatedResources.ContactGroups.Remove($script:TestContactGroupId[0])
-            $script:TestContactGroupId[0] = $null
         }
     }
 

--- a/Tests/Integration.Tests.ps1
+++ b/Tests/Integration.Tests.ps1
@@ -410,6 +410,7 @@ Describe "Live Integration Tests" -Tag 'Integration', 'Live' -Skip:(-not $script
             Tags                = [System.Collections.ArrayList]::new()
             Contacts            = [System.Collections.ArrayList]::new()
             ContactRoles        = [System.Collections.ArrayList]::new()
+            ContactGroups       = [System.Collections.ArrayList]::new()
         }
 
         Write-Host "Test Run ID: $script:TestRunId" -ForegroundColor Cyan
@@ -491,6 +492,9 @@ Describe "Live Integration Tests" -Tag 'Integration', 'Live' -Skip:(-not $script
         }
         foreach ($id in $script:CreatedResources.ContactRoles) {
             Remove-TestResource -ResourceType 'ContactRole' -Id $id -RemoveCommand { param($Id, $Confirm, $ErrorAction) Remove-NBContactRole -Id $Id -Confirm:$Confirm -ErrorAction $ErrorAction }
+        }
+        foreach ($id in $script:CreatedResources.ContactGroups) {
+             Remove-TestResource -ResourceType 'ContactGroup' -Id $id -RemoveCommand { param($Id, $Confirm, $ErrorAction) Remove-NBContactGroup -Id $Id -Confirm:$Confirm -ErrorAction $ErrorAction }
         }
 
         # Report any cleanup errors
@@ -1359,6 +1363,89 @@ Describe "Live Integration Tests" -Tag 'Integration', 'Live' -Skip:(-not $script
             { Remove-NBContactAssignment -Id $script:TestContactAssignmentId -Confirm:$false } | Should -Not -Throw
 
             $script:CreatedResources.ContactAssignments.Remove($script:TestContactAssignmentId)
+        }
+    }
+
+    Context "Contact Group CRUD" {
+        BeforeAll {
+            $script:TestContactGroupId = @(-1, -1, -1)      # paremt group, chil1, child2
+            $script:TestContactGroupName = @("$($script:TestPrefix)-ContactGroup", "$($script:TestPrefix)-ContactGroup-Child", "$($script:TestPrefix)-ContactGroup-Child2")
+            $script:TestContactGroupSlug = $script:TestContactGroupName.ToLower() -replace '[^a-z0-9-]', '-'
+        }
+
+        It "Should create a contact group" {
+            $group = New-NBContactGroup -Name $script:TestContactGroupName[0] -Slug $script:TestContactGroupSlug[0]
+
+            $group | Should -Not -BeNullOrEmpty
+            $group.name | Should -Be $script:TestContactGroupName[0]
+
+            $script:TestContactGroupId[0] = $group.id
+            [void]$script:CreatedResources.ContactGroups.Add($group.id)
+
+            Write-Host "  Created contact group: $($group.name) (ID: $($group.id))" -ForegroundColor Green
+        }
+
+        It "Should create a contact group as child group" {
+            $childGroup = New-NBContactGroup -Name $script:TestContactGroupName[1] -Slug $script:TestContactGroupSlug[1] -Parent $script:TestContactGroupId[0]
+            $script:TestContactGroupId[1] = $childGroup.id
+            [void]$script:CreatedResources.ContactGroups.Add($childGroup.id)
+
+            $childGroup.parent.id | Should -Be $script:TestContactGroupId[0]
+        }
+
+        It "Should create child group (search parent by name)" {
+            $childGroup = New-NBContactGroup -Name $script:TestContactGroupName[2] -Slug $script:TestContactGroupSlug[2] -Parent $script:TestContactGroupName[0]
+            $script:TestContactGroupId[2] = $childGroup.id
+            [void]$script:CreatedResources.ContactGroups.Add($childGroup.id)
+
+            $childGroup.parent.id | Should -Be $script:TestContactGroupId[0]
+        }
+
+        It "Should get contact group by ID" {
+            $group = Get-NBContactGroup -Id $script:TestContactGroupId[0]
+
+            $group | Should -Not -BeNullOrEmpty
+            $group.id | Should -Be $script:TestContactGroupId[0]
+            $group.name | Should -Be $script:TestContactGroupName[0]
+        }
+
+        It "Should get multiple contact groups by id" {
+            $groups = Get-NBContactGroup -Id ($script:TestContactGroupId[0], $script:TestContactGroupId[1])
+
+            $groups | Should -Not -BeNullOrEmpty
+            $groups | Should -HaveCount 2
+            $groups[0].id | Should -Be $script:TestContactGroupId[0]
+            $groups[1].id | Should -Be $script:TestContactGroupId[1]
+        }
+
+        It "Should update contact group" {
+            $group = Set-NBContactGroup -Id $script:TestContactGroupId[0] -Description "$script:TestPrefix - Updated Contact Group"
+
+            $group.description | Should -BeLike "*Updated*"
+        }
+
+        It "Should update (rename) a contact group by pipeline Id" {
+            $Result = Get-NBContactGroup -Id $script:TestContactGroupId[0] | Set-NBContactGroup -Name 'Updated Group by pipeline' -Confirm:$false
+
+            $Result.name | Should -Be 'Updated Group by pipeline'   # renamed the group
+            $Result.slug | Should -Be $script:TestContactGroupSlug[0]  # slug should remain unchanged
+        }
+
+        It "Should delete child contact groups by Id" {
+            # Remove the child group first, otherwise the parent group deletion would do a cascading delete
+            { Remove-NBContactGroup -Id $script:TestContactGroupId[1] -Confirm:$false } | Should -Not -Throw
+            $script:CreatedResources.ContactGroups.Remove($script:TestContactGroupId[1])
+            $script:TestContactGroupId[1] = $null
+
+            { Remove-NBContactGroup -Id $script:TestContactGroupId[2] -Confirm:$false } | Should -Not -Throw
+            $script:CreatedResources.ContactGroups.Remove($script:TestContactGroupId[2])
+            $script:TestContactGroupId[2] = $null
+        }
+
+        It "Should delete contact group by pipeline" {
+            { Get-NBContactGroup -Id $script:TestContactGroupId[0] | Remove-NBContactGroup -Confirm:$false } | Should -Not -Throw
+            $script:CreatedResources.ContactGroups.Remove($script:TestContactGroupId[0])
+            $script:TestContactGroupId[0] = $null
         }
     }
 

--- a/Tests/Integration.Tests.ps1
+++ b/Tests/Integration.Tests.ps1
@@ -1318,13 +1318,29 @@ Describe "Live Integration Tests" -Tag 'Integration', 'Live' -Skip:(-not $script
         BeforeAll {
             $script:TestContactName = "$($script:TestPrefix)-Contact"
             $script:TestContactSlug = $script:TestContactName.ToLower() -replace '[^a-z0-9-]', '-'
+
+            # Create an additional contact group to make context test independent from the "Contact Group CRUD"
+            $Script:TestContactGroup2Name = "$($script:TestPrefix)-ContactGroup2"
+            $Script:TestContactGroup2Slug = $Script:TestContactGroup2Name.ToLower() -replace '[^a-z0-9-]', '-'
+            $group2 = New-NBContactGroup -Name $Script:TestContactGroup2Name -Slug $Script:TestContactGroup2Slug
+            $Script:TestContactGroup2Id = $group2.id
+            [void]$script:CreatedResources.ContactGroups.Add($group2.id)
+        }
+        AfterAll {
+            # Cleanup the additional contact group created in BeforeAll
+            if ($Script:TestContactGroup2Id) {
+                { Remove-NBContactGroup -Id $Script:TestContactGroup2Id -Confirm:$false } | Should -Not -Throw
+                $script:CreatedResources.ContactGroups.Remove($Script:TestContactGroup2Id)
+                $Script:TestContactGroup2Id = $null
+            }
         }
 
         It "Should create a contact" {
-            $contact = New-NBContact -Name $script:TestContactName
+            $contact = New-NBContact -Name $script:TestContactName -Group_Id $Script:TestContactGroup2Id
 
             $contact | Should -Not -BeNullOrEmpty
             $contact.name | Should -Be $script:TestContactName
+            $contact.groups.Id | Should -Contain $Script:TestContactGroup2Id
 
             $script:TestContactId = $contact.id
             [void]$script:CreatedResources.Contacts.Add($contact.id)
@@ -1344,6 +1360,48 @@ Describe "Live Integration Tests" -Tag 'Integration', 'Live' -Skip:(-not $script
             $contact = Set-NBContact -Id $script:TestContactId -Description "$script:TestPrefix - Updated Contact"
 
             $contact.description | Should -BeLike "*Updated*"
+        }
+
+        It "Should add contact to contact group" {
+            # create contact
+            $contact = New-NBContact -Name "$($script:TestPrefix)-GroupContact"
+            [void]$script:CreatedResources.Contacts.Add($contact.id)
+
+            $Result = Set-NBContact -Id $contact.id -Group_Id $Script:TestContactGroup2Id -Confirm:$false
+
+            $Result | Should -Not -BeNullOrEmpty
+            $Result.id | Should -Be $contact.id
+            $Result.groups.Id | Should -Contain $Script:TestContactGroup2Id
+
+            $group = Get-NBContactGroup -Id $Script:TestContactGroup2Id
+            $group.contact_count | Should -Be 2
+
+            # Cleanup: remove contact from group, then delete contact
+            # additionally, prove, that renaming parameter -Group to -Groups is not a breaking change
+            $contact = Set-NBContact -Id $contact.id -Group_Id @() -Confirm:$false
+            $contact.groups | Should -HaveCount 0
+            { Remove-NBContact -Id $contact.id -Confirm:$false  } | Should -Not -Throw
+            $script:CreatedResources.Contacts.Remove($contact.id)
+        }
+
+        It "Should find two contacts in the same group" {
+            # create contact
+            $contact2 = New-NBContact -Name "$($script:TestPrefix)-GroupContact2" -Group_Id $Script:TestContactGroup2Id
+            [void]$script:CreatedResources.Contacts.Add($contact2.id)
+
+            $group = Get-NBContactGroup -Id $Script:TestContactGroup2Id
+
+            $group.contact_count | Should -Be 2
+
+            # now search for contacts by group Id
+            $contacts = Get-NBContact -Group_Id $Script:TestContactGroup2Id
+
+            $contacts | Should -Not -BeNullOrEmpty
+            $contacts | Should -HaveCount 2
+
+            #Cleanup: delete contact
+            { Remove-NBContact -Id $contact2.id -Confirm:$false  } | Should -Not -Throw
+            $script:CreatedResources.Contacts.Remove($contact2.id)
         }
     }
 

--- a/Tests/Tenancy.Tests.ps1
+++ b/Tests/Tenancy.Tests.ps1
@@ -325,6 +325,64 @@ Describe "Tenancy Module Tests" -Tag 'Tenancy' {
     }
     #endregion
 
+    #region ContactGroup Tests
+    Context "Get-NBContactGroup" {
+        It "Should request contact groups" {
+            $Result = Get-NBContactGroup
+            $Result.Method | Should -Be 'GET'
+            $Result.Uri | Should -Be 'https://netbox.domain.com/api/tenancy/contact-groups/'
+        }
+        It "Should request a contact group by ID" {
+            $Result = Get-NBContactGroup -Id 6
+            $Result.Uri | Should -Be 'https://netbox.domain.com/api/tenancy/contact-groups/6/'
+        }
+        It "Should request contact groups filtered by name" {
+            $Result = Get-NBContactGroup -Name 'Support Team'
+            $Result.Uri | Should -Be 'https://netbox.domain.com/api/tenancy/contact-groups/?name=Support%20Team'
+        }
+    }
+    Context "New-NBContactGroup" {
+        It "Should create a contact group" {
+            $Result = New-NBContactGroup -Name 'Support Team'
+            $Result.Method | Should -Be 'POST'
+            $Result.Uri | Should -Be 'https://netbox.domain.com/api/tenancy/contact-groups/'
+            $bodyObj = $Result.Body | ConvertFrom-Json
+            $bodyObj.name | Should -Be 'Support Team'
+        }
+        It "Should create a contact group with description and parent" {
+            $Result = New-NBContactGroup -Name 'Support Team' -Description 'Handles support requests' -Parent 2
+            $bodyObj = $Result.Body | ConvertFrom-Json
+            $bodyObj.description | Should -Be 'Handles support requests'
+            $bodyObj.parent | Should -Be 2
+        }
+    }
+    Context "Set-NBContactGroup" {
+        It "Should update a contact group" {
+            $Result = Set-NBContactGroup -Id 4 -Name 'Updated Group' -Confirm:$false
+            $Result.Method | Should -Be 'PATCH'
+            $Result.URI | Should -Be 'https://netbox.domain.com/api/tenancy/contact-groups/4/'
+            $Result.Body | ConvertFrom-Json | Select-Object -ExpandProperty name | Should -Be 'Updated Group'
+        }
+
+    }
+    Context "Remove-NBContactGroup" {
+        BeforeAll {
+            Mock -CommandName "Get-NBContactGroup" -MockWith {
+                return [pscustomobject]@{ 'Id' = $Id; 'Name' = 'TestGroup' }
+            }
+        }
+        It "Should remove a contact group" {
+            $Result = Remove-NBContactGroup -Id 4 -Confirm:$false
+            $Result.Method | Should -Be 'DELETE'
+            $Result.URI | Should -Be 'https://netbox.domain.com/api/tenancy/contact-groups/4/'
+        }
+        It "Should remove a contact group by pipeline input" {
+            $Result = Get-NBContactGroup -Id 5 | Remove-NBContactGroup -Confirm:$false
+            $Result.URI | Should -Be 'https://netbox.domain.com/api/tenancy/contact-groups/5/'
+        }
+    }
+    #endregion
+
     #region ContactAssignment Tests
     Context "Get-NBContactAssignment" {
         It "Should request contact assignments" {

--- a/Tests/Tenancy.Tests.ps1
+++ b/Tests/Tenancy.Tests.ps1
@@ -216,6 +216,11 @@ Describe "Tenancy Module Tests" -Tag 'Tenancy' {
             $Result = Get-NBContact -Name 'John Doe'
             $Result.Uri | Should -Be 'https://netbox.domain.com/api/tenancy/contacts/?name=John%20Doe'
         }
+
+        It "Should filter contacts by group ID" {
+            $Result = Get-NBContact -Group_Id 5
+            $Result.Uri | Should -Be 'https://netbox.domain.com/api/tenancy/contacts/?group_id=5'
+        }
     }
 
     Context "New-NBContact" {
@@ -233,6 +238,20 @@ Describe "Tenancy Module Tests" -Tag 'Tenancy' {
             $bodyObj = $Result.Body | ConvertFrom-Json
             $bodyObj.phone | Should -Be '+1-555-1234'
         }
+
+        It "Should map -Group_Id to the 'groups' body array" {
+            $Result = New-NBContact -Name 'Jane Doe' -Group_Id 1, 2
+            $bodyObj = $Result.Body | ConvertFrom-Json
+            $bodyObj.groups.Count | Should -Be 2
+            $bodyObj.groups | Should -Contain 1
+            $bodyObj.groups | Should -Contain 2
+        }
+
+        It "Should accept the -Group back-compat alias and map it to 'groups'" {
+            $Result = New-NBContact -Name 'Jane Doe' -Group 5
+            $bodyObj = $Result.Body | ConvertFrom-Json
+            $bodyObj.groups | Should -Contain 5
+        }
     }
 
     Context "Set-NBContact" {
@@ -246,6 +265,18 @@ Describe "Tenancy Module Tests" -Tag 'Tenancy' {
             $Result = Set-NBContact -Id 1 -Email 'new@example.com' -Confirm:$false
             $bodyObj = $Result.Body | ConvertFrom-Json
             $bodyObj.email | Should -Be 'new@example.com'
+        }
+
+        It "Should map -Group_Id to the 'groups' body array" {
+            $Result = Set-NBContact -Id 1 -Group_Id 3 -Confirm:$false
+            $bodyObj = $Result.Body | ConvertFrom-Json
+            $bodyObj.groups | Should -Contain 3
+        }
+
+        It "Should accept the -Group back-compat alias" {
+            $Result = Set-NBContact -Id 1 -Group 4 -Confirm:$false
+            $bodyObj = $Result.Body | ConvertFrom-Json
+            $bodyObj.groups | Should -Contain 4
         }
     }
 
@@ -355,6 +386,16 @@ Describe "Tenancy Module Tests" -Tag 'Tenancy' {
             $bodyObj.description | Should -Be 'Handles support requests'
             $bodyObj.parent | Should -Be 2
         }
+        It "Should auto-generate a slug from the name when -Slug is omitted" {
+            $Result = New-NBContactGroup -Name 'Support Team'
+            $bodyObj = $Result.Body | ConvertFrom-Json
+            $bodyObj.slug | Should -Be 'support-team'
+        }
+        It "Should resolve a non-numeric -Parent to a name object in the body" {
+            $Result = New-NBContactGroup -Name 'Child' -Parent 'Admins'
+            $bodyObj = $Result.Body | ConvertFrom-Json
+            $bodyObj.parent.name | Should -Be 'Admins'
+        }
     }
     Context "Set-NBContactGroup" {
         It "Should update a contact group" {
@@ -457,6 +498,9 @@ Describe "Tenancy Module Tests" -Tag 'Tenancy' {
             @{ Command = 'Remove-NBContactRole'; Parameters = @{ Id = 1 } }
             @{ Command = 'Remove-NBTenant'; Parameters = @{ Id = 1 } }
             @{ Command = 'Remove-NBTenantGroup'; Parameters = @{ Id = 1 } }
+            @{ Command = 'New-NBContactGroup'; Parameters = @{ Name = 'whatif-test' } }
+            @{ Command = 'Set-NBContactGroup'; Parameters = @{ Id = 1 } }
+            @{ Command = 'Remove-NBContactGroup'; Parameters = @{ Id = 1 } }
         )
 
         It 'Should support -WhatIf for <Command>' -TestCases $whatIfTestCases {


### PR DESCRIPTION
## Description

Implement new functions to handle contact groups and adopt contact functions to work with these groups

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] CI/CD or build changes

## Related Issues

Implements #442 
Implement (and fixes) #444 

## Checklist

### Code Quality
- [x] Code follows the [PowerShell Practice and Style Guidelines](https://poshcode.gitbook.io/powershell-practice-and-style/)
- [x] Functions use `[CmdletBinding()]` attribute
- [x] State-changing functions use `SupportsShouldProcess`
- [x] No hardcoded paths or credentials
- [x] `Write-Verbose` used for debugging (not `Write-Host`)

### Testing
- [x] Existing tests pass (`Invoke-Pester ./Tests/`)
- [x] New tests added for new functionality
- [x] Tested manually against Netbox instance (if applicable)

### Documentation
- [x] Function has proper comment-based help (`.SYNOPSIS`, `.DESCRIPTION`, `.EXAMPLE`)
- [ ] README updated (if needed)
- [ ] Wiki updated (if needed)

## Testing Performed

- Netbox version tested: Docker 4.4.9
- PowerShell version: Powershell 7.6.2
- Platform (Windows/Linux/macOS): Windows

## Additional Notes

The parameter naming tries to give a consistent Powershell style while maintaining backward compatibility. And it should  hide slightly different nameing in the NB-API.

