### PR TITLE
Feature/enable arrays in query parameters

### DIFF
--- a/Functions/Extras/Tags/Get-NBTag.ps1
+++ b/Functions/Extras/Tags/Get-NBTag.ps1
@@ -57,10 +57,10 @@ function Get-NBTag {
         [uint64[]]$Id,
 
         [Parameter(ParameterSetName = 'Query')]
-        [string]$Name,
+        [string[]]$Name,
 
         [Parameter(ParameterSetName = 'Query')]
-        [string]$Slug,
+        [string[]]$Slug,
 
         [ValidateRange(1, 1000)]
         [uint16]$Limit,

--- a/Functions/Helpers/BuildNewURI.ps1
+++ b/Functions/Helpers/BuildNewURI.ps1
@@ -69,11 +69,14 @@ function BuildNewURI {
         $QueryParts = [System.Collections.Generic.List[string]]::new()
 
         foreach ($param in $Parameters.GetEnumerator()) {
-            Write-Verbose " Adding URI parameter $($param.Key):$($param.Value)"
-            # URL encode key and value using .NET Uri class (available everywhere)
-            $EncodedKey = [System.Uri]::EscapeDataString($param.Key)
-            $EncodedValue = [System.Uri]::EscapeDataString([string]$param.Value)
-            $QueryParts.Add("$EncodedKey=$EncodedValue")
+            # Handle array values by repeating the key for each value (e.g., ?key=value1&key=value2)
+            foreach ($thisValue in $param.Value) {
+                Write-Verbose " Adding URI parameter $($param.Key):$thisValue"
+                # URL encode key and value using .NET Uri class (available everywhere)
+                $EncodedKey = [System.Uri]::EscapeDataString($param.Key)
+                $EncodedValue = [System.Uri]::EscapeDataString([string]$thisValue)
+                $QueryParts.Add("$EncodedKey=$EncodedValue")
+            }
         }
 
         $uriBuilder.Query = $QueryParts -join '&'

--- a/Functions/Helpers/BuildNewURI.ps1
+++ b/Functions/Helpers/BuildNewURI.ps1
@@ -70,10 +70,10 @@ function BuildNewURI {
 
         foreach ($param in $Parameters.GetEnumerator()) {
             # Handle array values by repeating the key for each value (e.g., ?key=value1&key=value2)
+            $EncodedKey = [System.Uri]::EscapeDataString($param.Key)
             foreach ($thisValue in $param.Value) {
                 Write-Verbose " Adding URI parameter $($param.Key):$thisValue"
                 # URL encode key and value using .NET Uri class (available everywhere)
-                $EncodedKey = [System.Uri]::EscapeDataString($param.Key)
                 $EncodedValue = [System.Uri]::EscapeDataString([string]$thisValue)
                 $QueryParts.Add("$EncodedKey=$EncodedValue")
             }

--- a/Tests/Helpers.Tests.ps1
+++ b/Tests/Helpers.Tests.ps1
@@ -93,6 +93,21 @@ Describe "Helpers tests" -Tag 'Core', 'Helpers' {
                 $URIBuilder.URI.AbsoluteURI | Should -Match 'https://netbox.domain.com/api/seg1/seg2/\?param1=paramval1'
             }
         }
+
+        It "Should generate a URI with 2 parameters; 2nd is an array that gets joined" {
+            InModuleScope -ModuleName 'PowerNetbox' {
+                # Using ordered hashtable to ensure consistent parameter order in the generated URI for testing; not necessary in production code
+                $URIParameters = [ordered]@{
+                    'param1' = 'paramval1'
+                    'param2' = @('val1', 'val2', 'val3 having spaces')
+                }
+
+                $URIBuilder = BuildNewURI -Segments 'seg1', 'seg2' -Parameters $URIParameters -SkipConnectedCheck
+                $URIBuilder.Query | Should -Match 'param1=paramval1'
+                $URIBuilder.Query | Should -Match 'param2=val1&param2=val2&param2=val3%20having%20spaces'
+                $URIBuilder.URI.AbsoluteURI | Should -Match 'https://netbox.domain.com/api/seg1/seg2/\?param1=paramval1&param2=val1&param2=val2&param2=val3%20having%20spaces'
+            }
+        }
     }
 
     Context "Building URI components" {

--- a/Tests/Helpers.Tests.ps1
+++ b/Tests/Helpers.Tests.ps1
@@ -103,9 +103,8 @@ Describe "Helpers tests" -Tag 'Core', 'Helpers' {
                 }
 
                 $URIBuilder = BuildNewURI -Segments 'seg1', 'seg2' -Parameters $URIParameters -SkipConnectedCheck
-                $URIBuilder.Query | Should -Match 'param1=paramval1'
-                $URIBuilder.Query | Should -Match 'param2=val1&param2=val2&param2=val3%20having%20spaces'
-                $URIBuilder.URI.AbsoluteURI | Should -Match 'https://netbox.domain.com/api/seg1/seg2/\?param1=paramval1&param2=val1&param2=val2&param2=val3%20having%20spaces'
+                $URIBuilder.Query | Should -Match '(?=.*param2=val1)(?=.*param2=val2)(?=.*param2=val3%20having%20spaces)'
+                $URIBuilder.URI.AbsoluteURI | Should -Match 'https://netbox.domain.com/api/seg1/seg2/\?(?=.*param1=paramval1)(?=.*param2=val1)(?=.*param2=val2)(?=.*param2=val3%20having%20spaces)'
             }
         }
     }

--- a/Tests/Integration.Tests.ps1
+++ b/Tests/Integration.Tests.ps1
@@ -1170,6 +1170,18 @@ Describe "Live Integration Tests" -Tag 'Integration', 'Live' -Skip:(-not $script
         BeforeAll {
             $script:TestTagName = "$($script:TestPrefix)-Tag"
             $script:TestTagSlug = $script:TestTagName.ToLower() -replace '[^a-z0-9-]', '-'
+
+            $script:TestTagName2 = "$($script:TestPrefix)-Tag2"
+            $script:TestTagSlug2 = $script:TestTagName2.ToLower() -replace '[^a-z0-9-]', '-'
+
+            $tag2 = New-NBTag -Name $script:TestTagName2 -Slug $script:TestTagSlug2 -Color 'ffff00'
+            $script:TestTag2Id = $tag2.id
+            [void]$script:CreatedResources.Tags.Add($tag2.id)
+        }
+        AfterAll {
+            { Remove-NBTag -Id $script:TestTag2Id -Confirm:$false } | Should -Not -Throw
+            $script:CreatedResources.Tags.Remove($script:TestTag2Id)
+            $script:TestTag2Id = $null
         }
 
         It "Should create a tag" {
@@ -1190,6 +1202,32 @@ Describe "Live Integration Tests" -Tag 'Integration', 'Live' -Skip:(-not $script
             $tag | Should -Not -BeNullOrEmpty
             $tag.id | Should -Be $script:TestTagId
             $tag.name | Should -Be $script:TestTagName
+        }
+
+        It "Should get tag by name" {
+            $tag = Get-NBTag -Name $script:TestTagName
+
+            $tag | Should -Not -BeNullOrEmpty
+            $tag.id | Should -Be $script:TestTagId
+            $tag.name | Should -Be $script:TestTagName
+        }
+
+        It "Should get two tags by two name" {
+            $tags = Get-NBTag -Name $script:TestTagName, $script:TestTagName2
+
+            $tags | Should -Not -BeNullOrEmpty
+            $tags.Count | Should -Be  2
+            $tags.id | Should -Contain $script:TestTagId
+            $tags.id | Should -Contain $script:TestTag2Id
+        }
+
+        It "Should get two tags by two slugs" {
+            $tags = Get-NBTag -Slug $script:TestTagSlug, $script:TestTagSlug2
+
+            $tags | Should -Not -BeNullOrEmpty
+            $tags.Count | Should -Be  2
+            $tags.id | Should -Contain $script:TestTagId
+            $tags.id | Should -Contain $script:TestTag2Id
         }
 
         It "Should update tag" {


### PR DESCRIPTION
## Description

Prepare for enable query parameters having array values. 
Implement change, add unit test.
As proof of concept: Enable arrays on Get-NBTag parameters (name, slug) and implement integration test.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] CI/CD or build changes

## Related Issues

Implements #446 

Fixes #

## Checklist

### Code Quality
- [X] Code follows the [PowerShell Practice and Style Guidelines](https://poshcode.gitbook.io/powershell-practice-and-style/)
- [X] Functions use `[CmdletBinding()]` attribute
- [X] State-changing functions use `SupportsShouldProcess`
- [X] No hardcoded paths or credentials
- [X] `Write-Verbose` used for debugging (not `Write-Host`)

### Testing
- [X] Existing tests pass (`Invoke-Pester ./Tests/`)
- [X] New tests added for new functionality
- [X] Tested manually against Netbox instance (if applicable)

### Documentation
- [X] Function has proper comment-based help (`.SYNOPSIS`, `.DESCRIPTION`, `.EXAMPLE`)
- [ ] README updated (if needed)
- [ ] Wiki updated (if needed)

## Testing Performed

Netbox version tested: 4.4.9 (Docker) and 4.6.0.2
PowerShell version: 7.6.1
Platform (Windows/Linux/macOS): Windows

## Screenshots (if applicable)

<!-- Add screenshots for UI-related changes -->

## Additional Notes

<!-- Any additional context or notes for reviewers -->
