### PR TITLE
docs: remove 7 orphan .PARAMETER entries (parity baseline -> 0)

### DIFF
--- a/Functions/Circuits/Circuits/Get-NBCircuit.ps1
+++ b/Functions/Circuits/Circuits/Get-NBCircuit.ps1
@@ -28,16 +28,10 @@ function Get-NBCircuit {
         - String: Searches by provider name (e.g., 'Comcast')
         - Integer: Searches by database ID (e.g., 1)
 
-    .PARAMETER ProviderId
-        Alias for Provider. Database ID of the provider (uint64).
-
     .PARAMETER Type
         The name or database ID of the circuit type.
         - String: Searches by type name (e.g., 'Internet')
         - Integer: Searches by database ID (e.g., 1)
-
-    .PARAMETER TypeId
-        Alias for Type. Database ID of the circuit type (uint64).
 
     .PARAMETER Site
         Location/site of circuit. Provide either [string] or [uint64]. String will search site names, integer will search database IDs
@@ -53,9 +47,6 @@ function Get-NBCircuit {
 
     .PARAMETER Raw
         Return the raw API response instead of extracting the results array.
-
-    .PARAMETER ID__IN
-        Multiple unique DB IDs to retrieve
 
     .PARAMETER All
         Automatically fetch all pages of results. Uses the API's pagination

--- a/Functions/IPAM/Address/Get-NBIPAMAvailableIP.ps1
+++ b/Functions/IPAM/Address/Get-NBIPAMAvailableIP.ps1
@@ -17,9 +17,6 @@ function Get-NBIPAMAvailableIP {
     .PARAMETER Raw
         Return the raw API response.
 
-    .PARAMETER NumberOfIPs
-        Number of available IPs to return (alias for Limit).
-
     .EXAMPLE
         Get-NBIPAMAvailableIP -Prefix_ID (Get-NBIPAMPrefix -Prefix 192.0.2.0/24).id
 

--- a/Functions/Setup/Support/Get-NBAPIDefinition.ps1
+++ b/Functions/Setup/Support/Get-NBAPIDefinition.ps1
@@ -5,9 +5,6 @@
 .DESCRIPTION
     Retrieves Support objects from Netbox Setup module.
 
-.PARAMETER Raw
-    Return the raw API response instead of the results array.
-
 .PARAMETER Format
     Filter by format.
 

--- a/Functions/VPN/IKEPolicy/New-NBVPNIKEPolicy.ps1
+++ b/Functions/VPN/IKEPolicy/New-NBVPNIKEPolicy.ps1
@@ -26,9 +26,6 @@
 .PARAMETER Comments
     Additional comments.
 
-.PARAMETER CustomFields
-    Hashtable of custom field values.
-
 .PARAMETER Raw
     Return the raw API response instead of the results array.
 

--- a/Functions/VPN/TunnelGroup/New-NBVPNTunnelGroup.ps1
+++ b/Functions/VPN/TunnelGroup/New-NBVPNTunnelGroup.ps1
@@ -14,9 +14,6 @@
 .PARAMETER Description
     Description of the tunnel group.
 
-.PARAMETER CustomFields
-    Hashtable of custom field values.
-
 .PARAMETER Raw
     Return the raw API response instead of the results array.
 

--- a/Tests/Update-ParamHelpParityBaseline.ps1
+++ b/Tests/Update-ParamHelpParityBaseline.ps1
@@ -34,20 +34,15 @@ $header = @'
 #   Orphan  = a .PARAMETER help entry names a parameter that does not exist
 # Lines starting with # and blank lines are ignored. Matching is case-insensitive.
 #
-# This file is a BASELINE of pre-existing gaps, snapshotted so the CI gate in
-# CodeQuality.Tests.ps1 (Context "Comment-based help parameter parity") only
-# fails on NEW gaps. It is NOT a target to grow -- chip it down over time.
+# This file is the allow-list of KNOWN parity gaps. The CI gate in
+# CodeQuality.Tests.ps1 (Context "Comment-based help parameter parity") fails on
+# any gap NOT listed here. It is currently EMPTY -- every public function
+# parameter has matching .PARAMETER help -- so the gate is fully enforced.
 #
-# DO NOT add a NEW entry here to silence the gate. The correct fix for a new
-# finding is to add the .PARAMETER help (or fix the param name), then DELETE the
-# matching line below.
-#
-# Regenerate (only after reducing the backlog):
+# Keep it empty: the fix for a new finding is to add the .PARAMETER help (or fix
+# the param name), NOT to add a line here. Only regenerate after a deliberate,
+# reviewed change to the known set:
 #   pwsh -NoProfile -File ./Tests/Update-ParamHelpParityBaseline.ps1
-#
-# Quick win: ~90 entries are functions missing only ".PARAMETER Tags" (the
-# [object[]]$Tags rollout in #371) -- a single bulk doc PR clears those. Most of
-# the remainder are Get-* filter params whose text can come from the OpenAPI schema.
 # ---------------------------------------------------------------------------
 '@
 

--- a/Tests/param-help-parity-baseline.txt
+++ b/Tests/param-help-parity-baseline.txt
@@ -5,25 +5,14 @@
 #   Orphan  = a .PARAMETER help entry names a parameter that does not exist
 # Lines starting with # and blank lines are ignored. Matching is case-insensitive.
 #
-# This file is a BASELINE of pre-existing gaps, snapshotted so the CI gate in
-# CodeQuality.Tests.ps1 (Context "Comment-based help parameter parity") only
-# fails on NEW gaps. It is NOT a target to grow -- chip it down over time.
+# This file is the allow-list of KNOWN parity gaps. The CI gate in
+# CodeQuality.Tests.ps1 (Context "Comment-based help parameter parity") fails on
+# any gap NOT listed here. It is currently EMPTY -- every public function
+# parameter has matching .PARAMETER help -- so the gate is fully enforced.
 #
-# DO NOT add a NEW entry here to silence the gate. The correct fix for a new
-# finding is to add the .PARAMETER help (or fix the param name), then DELETE the
-# matching line below.
-#
-# Regenerate (only after reducing the backlog):
+# Keep it empty: the fix for a new finding is to add the .PARAMETER help (or fix
+# the param name), NOT to add a line here. Only regenerate after a deliberate,
+# reviewed change to the known set:
 #   pwsh -NoProfile -File ./Tests/Update-ParamHelpParityBaseline.ps1
-#
-# Quick win: ~90 entries are functions missing only ".PARAMETER Tags" (the
-# [object[]]$Tags rollout in #371) -- a single bulk doc PR clears those. Most of
-# the remainder are Get-* filter params whose text can come from the OpenAPI schema.
 # ---------------------------------------------------------------------------
-Get-NBAPIDefinition::RAW::Orphan
-Get-NBCircuit::ID__IN::Orphan
-Get-NBCircuit::PROVIDERID::Orphan
-Get-NBCircuit::TYPEID::Orphan
-Get-NBIPAMAvailableIP::NUMBEROFIPS::Orphan
-New-NBVPNIKEPolicy::CUSTOMFIELDS::Orphan
-New-NBVPNTunnelGroup::CUSTOMFIELDS::Orphan
+


### PR DESCRIPTION
## Description

Final cleanup of the param/`.PARAMETER` parity backlog opened in #457. Removes the 7 remaining **orphan** entries — `.PARAMETER` help that documents a parameter name which doesn't exist — taking the baseline from **7 → 0**. The CI gate is now **fully enforced**: any public-function parameter without matching `.PARAMETER` help fails.

## The 7 removed entries (all redundant or stale)
| Function | Removed | Why it's safe |
|---|---|---|
| `Get-NBCircuit` | `ProviderId`, `TypeId` | `[Alias()]` of `Provider`/`Type`, whose own help already says "name or database ID" |
| `Get-NBCircuit` | `Id__in` | stale; the real `Id` param is documented |
| `Get-NBIPAMAvailableIP` | `NumberOfIPs` | `[Alias()]` of the documented `Limit` |
| `Get-NBAPIDefinition` | `Raw` | no such param (the function takes `-Format` only) |
| `New-NBVPNIKEPolicy` | `CustomFields` | duplicate of the documented `Custom_Fields` |
| `New-NBVPNTunnelGroup` | `CustomFields` | duplicate of the documented `Custom_Fields` |

Aliases (`ProviderId`, `TypeId`, `NumberOfIPs`) stay declared in `param()` and remain fully usable — `Get-Help` lists them automatically under the real parameter, so no information is lost.

## Verification
- Parity oracle: **Missing 0 / Orphan 0** (was 7 orphans); baseline regenerated to **0 data lines**.
- `Invoke-Pester ./Tests/CodeQuality.Tests.ps1` → 7/7 green; ASCII-only; build clean.
- Baseline header updated to describe the empty, fully-enforced state.

## Type of Change
- [x] Documentation update

## Related
Closes out the parity backlog from #457 (after #458 + #459).