### PR TITLE
Supporting wildcards

### DIFF
--- a/Functions/Helpers/BuildNewURI.ps1
+++ b/Functions/Helpers/BuildNewURI.ps1
@@ -71,24 +71,33 @@ function BuildNewURI {
         foreach ($param in $Parameters.GetEnumerator()) {
             # Handle array values by repeating the key for each value (e.g., ?key=value1&key=value2)
             $paramKey = $param.Key
-            if ($Script:QueryParameterDecoration -ne '' -and $Script:QueryParameterHash.ContainsKey($param.Key)) {
+            $useQueryOption = $Script:QueryParameterDecoration -ne '' -and $Script:QueryParameterHash.ContainsKey($param.Key)
+            if ($useQueryOption) {
                 $apiCheck = $uriBuilder.Path
-                # temp try/catch to handle cases where the path is not in the hashset, which should not happen but just in case
-                try {
-                    if (-not ($Script:QueryParameterHash[$param.Key]).Contains($apiCheck)) {
-                        Write-Verbose " Parameter $($param.Key) for endpoint $apiCheck is not in the ignore case list"
-                        $paramKey = "$($param.Key)$($Script:QueryParameterDecoration)"
-                    }
-                } catch {
-                    Write-Verbose " IgnoreCase lookup skipped for $($param.Key): $_"
-                }
+                $useQueryOption = -not ($Script:QueryParameterHash[$param.Key]).Contains($apiCheck)
             }
-            $EncodedKey = [System.Uri]::EscapeDataString($paramKey)
-            foreach ($thisValue in $param.Value) {
-                Write-Verbose " Adding URI parameter $($paramKey):$thisValue"
-                # URL encode key and value using .NET Uri class (available everywhere)
-                $EncodedValue = [System.Uri]::EscapeDataString([string]$thisValue)
-                $QueryParts.Add("$EncodedKey=$EncodedValue")
+            if ($useQueryOption) {
+                Write-Verbose " Parameter $($param.Key) for endpoint $apiCheck is not in the ignore case list"
+                $paramKey = "$($param.Key)$($Script:QueryParameterDecoration)"
+                $EncodedKey = [System.Uri]::EscapeDataString($paramKey)
+                foreach ($thisValue in $param.Value) {
+                    Write-Verbose " Adding URI parameter $($paramKey):$thisValue"
+                    # if Powershell wildcard query is used, we need to convert wildcard to regex for Netbox API
+                    if ($Script:NetboxConfig.MatchMode -eq 'Wildcard') {
+                        $thisValue = Convert-PSWildcardToRegex -String $thisValue
+                    }
+                    # URL encode key and value using .NET Uri class (available everywhere)
+                    $EncodedValue = [System.Uri]::EscapeDataString([string]$thisValue)
+                    $QueryParts.Add("$EncodedKey=$EncodedValue")
+                }
+            } else {
+                $EncodedKey = [System.Uri]::EscapeDataString($paramKey)
+                foreach ($thisValue in $param.Value) {
+                    Write-Verbose " Adding URI parameter $($paramKey):$thisValue"
+                    # URL encode key and value using .NET Uri class (available everywhere)
+                    $EncodedValue = [System.Uri]::EscapeDataString([string]$thisValue)
+                    $QueryParts.Add("$EncodedKey=$EncodedValue")
+                }
             }
         }
 

--- a/Functions/Helpers/BuildNewURI.ps1
+++ b/Functions/Helpers/BuildNewURI.ps1
@@ -71,11 +71,11 @@ function BuildNewURI {
         foreach ($param in $Parameters.GetEnumerator()) {
             # Handle array values by repeating the key for each value (e.g., ?key=value1&key=value2)
             $paramKey = $param.Key
-            if ($Script:NetboxConfig.IgnoreCaseInQueries -and $Script:IgnoreCaseParameterHash.ContainsKey($param.Key)) {
+            if ($Script:NetboxConfig.IgnoreCaseInQueries -and $Script:QueryParameterHash.ContainsKey($param.Key)) {
                 $apiCheck = $uriBuilder.Path
                 # temp try/catch to handle cases where the path is not in the hashset, which should not happen but just in case
                 try {
-                    if (-not ($Script:IgnoreCaseParameterHash[$param.Key]).Contains($apiCheck)) {
+                    if (-not ($Script:QueryParameterHash[$param.Key]).Contains($apiCheck)) {
                         Write-Verbose " Parameter $($param.Key) for endpoint $apiCheck is not in the ignore case list"
                         $paramKey = "$($param.Key)__ie"
                     }

--- a/Functions/Helpers/BuildNewURI.ps1
+++ b/Functions/Helpers/BuildNewURI.ps1
@@ -79,25 +79,19 @@ function BuildNewURI {
             if ($useQueryOption) {
                 Write-Verbose " Parameter $($param.Key) for endpoint $apiCheck is not in the ignore case list"
                 $paramKey = "$($param.Key)$($Script:QueryParameterDecoration)"
-                $EncodedKey = [System.Uri]::EscapeDataString($paramKey)
-                foreach ($thisValue in $param.Value) {
-                    Write-Verbose " Adding URI parameter $($paramKey):$thisValue"
-                    # if Powershell wildcard query is used, we need to convert wildcard to regex for Netbox API
-                    if ($Script:NetboxConfig.MatchMode -eq 'Wildcard') {
-                        $thisValue = Convert-PSWildcardToRegex -String $thisValue
-                    }
-                    # URL encode key and value using .NET Uri class (available everywhere)
-                    $EncodedValue = [System.Uri]::EscapeDataString([string]$thisValue)
-                    $QueryParts.Add("$EncodedKey=$EncodedValue")
+            }
+
+            $EncodedKey = [System.Uri]::EscapeDataString($paramKey)
+            foreach ($thisValue in $param.Value) {
+                Write-Verbose " Adding URI parameter $($paramKey):$thisValue"
+                $valueToEncode = $thisValue
+                # if Powershell wildcard query is used, we need to convert wildcard to regex for Netbox API
+                if ($useQueryOption -and $Script:NetboxConfig.MatchMode -eq 'Wildcard') {
+                    $valueToEncode = Convert-PSWildcardToRegex -String $thisValue
                 }
-            } else {
-                $EncodedKey = [System.Uri]::EscapeDataString($paramKey)
-                foreach ($thisValue in $param.Value) {
-                    Write-Verbose " Adding URI parameter $($paramKey):$thisValue"
-                    # URL encode key and value using .NET Uri class (available everywhere)
-                    $EncodedValue = [System.Uri]::EscapeDataString([string]$thisValue)
-                    $QueryParts.Add("$EncodedKey=$EncodedValue")
-                }
+                # URL encode key and value using .NET Uri class (available everywhere)
+                $EncodedValue = [System.Uri]::EscapeDataString([string]$valueToEncode)
+                $QueryParts.Add("$EncodedKey=$EncodedValue")
             }
         }
 

--- a/Functions/Helpers/BuildNewURI.ps1
+++ b/Functions/Helpers/BuildNewURI.ps1
@@ -71,13 +71,13 @@ function BuildNewURI {
         foreach ($param in $Parameters.GetEnumerator()) {
             # Handle array values by repeating the key for each value (e.g., ?key=value1&key=value2)
             $paramKey = $param.Key
-            if ($Script:NetboxConfig.IgnoreCaseInQueries -and $Script:QueryParameterHash.ContainsKey($param.Key)) {
+            if ($Script:QueryParameterDecoration -ne '' -and $Script:QueryParameterHash.ContainsKey($param.Key)) {
                 $apiCheck = $uriBuilder.Path
                 # temp try/catch to handle cases where the path is not in the hashset, which should not happen but just in case
                 try {
                     if (-not ($Script:QueryParameterHash[$param.Key]).Contains($apiCheck)) {
                         Write-Verbose " Parameter $($param.Key) for endpoint $apiCheck is not in the ignore case list"
-                        $paramKey = "$($param.Key)__ie"
+                        $paramKey = "$($param.Key)$($Script:QueryParameterDecoration)"
                     }
                 } catch {
                     Write-Verbose " IgnoreCase lookup skipped for $($param.Key): $_"

--- a/Functions/Helpers/Convert-PSWildcardToRegex.ps1
+++ b/Functions/Helpers/Convert-PSWildcardToRegex.ps1
@@ -1,0 +1,37 @@
+function Convert-PSWildcardToRegex {
+    <#
+        .SYNOPSIS
+            Converts a Powershell wildcard string to a regex string
+        .DESCRIPTION
+            Converts a Powershell wildcard string to a regex string. This is necessary because the Netbox API uses regex for its search parameters.
+        .PARAMETER String
+            The Powershell wildcard string to convert to regex.
+        .OUTPUTS
+            [string] The converted regex string.
+        .EXAMPLE
+            Convert-PSWildcardToRegex -String 'abc*'
+            Returns '^abc.*$'
+        .EXAMPLE
+            Convert-PSWildcardToRegex -String 'a[bc]?'
+            Returns '^a[bc].$'
+        .NOTES
+    #>
+    [CmdletBinding()]
+    [OutputType([string])]
+    param (
+        [string] $String
+    )
+
+    process {
+        if ($null -eq $String) {
+            return
+        }
+        if ([string]::IsNullOrEmpty($String)) {
+            return $String
+        }
+        # replace wildcard characters with regex equivalents
+        $regexString = [regex]::Escape($String)
+        $regexString = $regexString -replace '\\\*', '.*' -replace '\\\?', '.' -replace '\\\[', '[' -replace '\\\]', ']'
+        "^$regexString`$"
+    }
+}

--- a/Functions/Helpers/Convert-PSWildcardToRegex.ps1
+++ b/Functions/Helpers/Convert-PSWildcardToRegex.ps1
@@ -23,9 +23,6 @@ function Convert-PSWildcardToRegex {
     )
 
     process {
-        if ($null -eq $String) {
-            return
-        }
         if ([string]::IsNullOrEmpty($String)) {
             return $String
         }

--- a/Functions/Helpers/Get-VersionQueryParameterSupport.ps1
+++ b/Functions/Helpers/Get-VersionQueryParameterSupport.ps1
@@ -1,0 +1,44 @@
+function Get-VersionQueryParameterSupport {
+    <#
+    .SYNOPSIS
+    Gets the version query parameter support information.
+
+    .DESCRIPTION
+    This function checks the supported API versions and returns an object containing the minimum, maximum, and used versions.
+
+    .PARAMETER ShowWarning
+    Switch to show warnings if the active API version is outside the supported range.
+
+    .OUTPUTS
+    [PSCustomObject] with properties [version]MinVersion, [version]MaxVersion, [version]APIVersion, and [string!!]UsedVersion.
+    #>
+    [CmdletBinding()]
+    [OutputType([PSCustomObject])]
+    param (
+        [switch] $ShowWarning
+    )
+
+    CheckNetboxIsConnected
+
+    $result = [PSCustomObject]@{
+        MinVersion      = [version] (@($Script:IgnoreCaseParameterDictonary.Keys)[0])
+        MaxVersion      = [version] (@($Script:IgnoreCaseParameterDictonary.Keys)[-1])
+        APIVersion      = [version]::new($script:NetboxConfig.ParsedVersion.Major, $script:NetboxConfig.ParsedVersion.Minor)
+        UsedVersion     = (@($Script:IgnoreCaseParameterDictonary.Keys)[-1])   # Default is the latest known version; $null: unsupported version
+    }
+    if ($result.APIVersion -lt $result.MinVersion -and $ShowWarning) {
+        Write-Warning "API version $($script:NetboxConfig.ParsedVersion) is less than the minimum supported version ($(@($Script:IgnoreCaseParameterDictonary.Keys)[0])). No case-insensitive parameters will be used."
+        $result.UsedVersion = $null
+    } else {
+        foreach ($key in $Script:IgnoreCaseParameterDictonary.Keys) {
+            if ([version]$key -eq $result.APIVersion) {
+                $result.UsedVersion = [version]$key
+                break
+            }
+        }
+        if ($result.UsedVersion -lt $result.APIVersion -and $ShowWarning) {
+            Write-Warning "No explicit defined query parameter support for API version $($result.APIVersion). Taking the latest known version ($($result.MaxVersion))."
+        }
+    }
+    $result
+}

--- a/Functions/Helpers/Get-VersionQueryParameterSupport.ps1
+++ b/Functions/Helpers/Get-VersionQueryParameterSupport.ps1
@@ -21,16 +21,16 @@ function Get-VersionQueryParameterSupport {
     CheckNetboxIsConnected
 
     $result = [PSCustomObject]@{
-        MinVersion      = [version] (@($Script:IgnoreCaseParameterDictonary.Keys)[0])
-        MaxVersion      = [version] (@($Script:IgnoreCaseParameterDictonary.Keys)[-1])
+        MinVersion      = [version] (@($Script:IgnoreCaseParameterDictionary.Keys)[0])
+        MaxVersion      = [version] (@($Script:IgnoreCaseParameterDictionary.Keys)[-1])
         APIVersion      = [version]::new($script:NetboxConfig.ParsedVersion.Major, $script:NetboxConfig.ParsedVersion.Minor)
-        UsedVersion     = (@($Script:IgnoreCaseParameterDictonary.Keys)[-1])   # Default is the latest known version; $null: unsupported version
+        UsedVersion     = (@($Script:IgnoreCaseParameterDictionary.Keys)[-1])   # Default is the latest known version; $null: unsupported version
     }
     if ($result.APIVersion -lt $result.MinVersion -and $ShowWarning) {
-        Write-Warning "API version $($script:NetboxConfig.ParsedVersion) is less than the minimum supported version ($(@($Script:IgnoreCaseParameterDictonary.Keys)[0])). No case-insensitive parameters will be used."
+        Write-Warning "API version $($script:NetboxConfig.ParsedVersion) is less than the minimum supported version ($(@($Script:IgnoreCaseParameterDictionary.Keys)[0])). PowerNetbox query options will not be used."
         $result.UsedVersion = $null
     } else {
-        foreach ($key in $Script:IgnoreCaseParameterDictonary.Keys) {
+        foreach ($key in $Script:IgnoreCaseParameterDictionary.Keys) {
             if ([version]$key -eq $result.APIVersion) {
                 $result.UsedVersion = [version]$key
                 break

--- a/Functions/Helpers/Get-VersionQueryParameterSupport.ps1
+++ b/Functions/Helpers/Get-VersionQueryParameterSupport.ps1
@@ -10,7 +10,7 @@ function Get-VersionQueryParameterSupport {
     Switch to show warnings if the active API version is outside the supported range.
 
     .OUTPUTS
-    [PSCustomObject] with properties [version]MinVersion, [version]MaxVersion, [version]APIVersion, and [string!!]UsedVersion.
+    [PSCustomObject] with properties [version]MinVersion, [version]MaxVersion, [version]APIVersion, and [version]UsedVersion ($null when the API is older than MinVersion).
     #>
     [CmdletBinding()]
     [OutputType([PSCustomObject])]
@@ -24,7 +24,7 @@ function Get-VersionQueryParameterSupport {
         MinVersion      = [version] (@($Script:IgnoreCaseParameterDictionary.Keys)[0])
         MaxVersion      = [version] (@($Script:IgnoreCaseParameterDictionary.Keys)[-1])
         APIVersion      = [version]::new($script:NetboxConfig.ParsedVersion.Major, $script:NetboxConfig.ParsedVersion.Minor)
-        UsedVersion     = (@($Script:IgnoreCaseParameterDictionary.Keys)[-1])   # Default is the latest known version; $null: unsupported version
+        UsedVersion     = [version] (@($Script:IgnoreCaseParameterDictionary.Keys)[-1])   # Default is the latest known version; $null: unsupported version
     }
     if ($result.APIVersion -lt $result.MinVersion -and $ShowWarning) {
         Write-Warning "API version $($script:NetboxConfig.ParsedVersion) is less than the minimum supported version ($(@($Script:IgnoreCaseParameterDictionary.Keys)[0])). PowerNetbox query options will not be used."

--- a/Functions/Helpers/_IgnoreCaseParameters.ps1
+++ b/Functions/Helpers/_IgnoreCaseParameters.ps1
@@ -184,7 +184,7 @@ $Script:IgnoreCaseParameterV461 = @{
 }
 #endregion
 
-#region IgnoreCase parameter dictionary
+#region Regex parameter dictionary
 $Script:RegexParameterBaseline = @{
     'account'                  = @()
     'action_type'              = @()
@@ -352,7 +352,6 @@ $Script:IgnoreCaseParameterDictionary['4.5'] = $Script:IgnoreCaseParameterBaseli
 $Script:IgnoreCaseParameterDictionary['4.6'] = $Script:IgnoreCaseParameterBaseline + $Script:IgnoreCaseParameterV461
 
 $Script:RegexParameterDictionary  = [ordered]@{}
-# For testing, we do like there is only the baseline; TODO: Remove #
 $Script:RegexParameterDictionary['4.4'] = $Script:RegexParameterBaseline + $Script:RegexParameterV449
 $Script:RegexParameterDictionary['4.5'] = $Script:RegexParameterBaseline + $Script:RegexParameterV450
 $Script:RegexParameterDictionary['4.6'] = $Script:RegexParameterBaseline + $Script:RegexParameterV461

--- a/Functions/Helpers/_IgnoreCaseParameters.ps1
+++ b/Functions/Helpers/_IgnoreCaseParameters.ps1
@@ -182,7 +182,7 @@ $Script:IgnoreCaseParameterV461 = @{
 
 # Set-NBQueryOption will set this to whatever is appropriate for the API version
 # default is to start with case insensitive
-$Script:IgnoreCaseParameterHash = @{}
+$Script:QueryParameterHash = @{}
 # This will contain the collection of all case-insensitive parameters per known API version, including any exceptions for specific endpoints
 # Keep it orderd so that we can easily find the first and last known versions
 $Script:IgnoreCaseParameterDictonary  = [ordered]@{}

--- a/Functions/Helpers/_IgnoreCaseParameters.ps1
+++ b/Functions/Helpers/_IgnoreCaseParameters.ps1
@@ -182,6 +182,7 @@ $Script:IgnoreCaseParameterV461 = @{
 
 # Set-NBQueryOption will set this to whatever is appropriate for the API version
 # default is to start with case insensitive
+$Script:QueryParameterDecoration = ''       # valid values are '', '__ie', '__regex', '__iregex'
 $Script:QueryParameterHash = @{}
 # This will contain the collection of all case-insensitive parameters per known API version, including any exceptions for specific endpoints
 # Keep it orderd so that we can easily find the first and last known versions

--- a/Functions/Helpers/_IgnoreCaseParameters.ps1
+++ b/Functions/Helpers/_IgnoreCaseParameters.ps1
@@ -346,13 +346,13 @@ $Script:QueryParameterDecoration = ''       # valid values are '', '__ie', '__re
 $Script:QueryParameterHash = @{}
 # This will contain the collection of all case-insensitive parameters per known API version, including any exceptions for specific endpoints
 # Keep it orderd so that we can easily find the first and last known versions
-$Script:IgnoreCaseParameterDictonary  = [ordered]@{}
-$Script:IgnoreCaseParameterDictonary['4.4'] = $Script:IgnoreCaseParameterBaseline + $Script:IgnoreCaseParameterV449
-$Script:IgnoreCaseParameterDictonary['4.5'] = $Script:IgnoreCaseParameterBaseline + $Script:IgnoreCaseParameterV450
-$Script:IgnoreCaseParameterDictonary['4.6'] = $Script:IgnoreCaseParameterBaseline + $Script:IgnoreCaseParameterV461
+$Script:IgnoreCaseParameterDictionary  = [ordered]@{}
+$Script:IgnoreCaseParameterDictionary['4.4'] = $Script:IgnoreCaseParameterBaseline + $Script:IgnoreCaseParameterV449
+$Script:IgnoreCaseParameterDictionary['4.5'] = $Script:IgnoreCaseParameterBaseline + $Script:IgnoreCaseParameterV450
+$Script:IgnoreCaseParameterDictionary['4.6'] = $Script:IgnoreCaseParameterBaseline + $Script:IgnoreCaseParameterV461
 
 $Script:RegexParameterDictionary  = [ordered]@{}
 # For testing, we do like there is only the baseline; TODO: Remove #
-$Script:RegexParameterDictionary['4.4'] = $Script:RegexParameterBaseline + $Script:IgnoreCaseParameterV449
-$Script:RegexParameterDictionary['4.5'] = $Script:RegexParameterBaseline + $Script:IgnoreCaseParameterV450
-$Script:RegexParameterDictionary['4.6'] = $Script:RegexParameterBaseline + $Script:IgnoreCaseParameterV461
+$Script:RegexParameterDictionary['4.4'] = $Script:RegexParameterBaseline + $Script:RegexParameterV449
+$Script:RegexParameterDictionary['4.5'] = $Script:RegexParameterBaseline + $Script:RegexParameterV450
+$Script:RegexParameterDictionary['4.6'] = $Script:RegexParameterBaseline + $Script:RegexParameterV461

--- a/Functions/Helpers/_IgnoreCaseParameters.ps1
+++ b/Functions/Helpers/_IgnoreCaseParameters.ps1
@@ -1,7 +1,6 @@
 <#
-    List of API parameters of type string, that could be requested as case-insensitive
+    List of API parameters of type string, that could be requested as case-insensitive or regex match
     The list is based on the swagger spec of NetBox, slightly modified to remove parameters that are not relevant for the API client
-    e.g. parameters that are only used in the UI, or parameters that might be misleading
 
     The solution is based on a baseline list of parameters taken from v4.4.9.
     Depending on the currently connect APIs version, additional parameters are added.
@@ -13,12 +12,15 @@
 
     If the minimum supported API version of this module should change, the baseline list must be updated to reflect the new minimum version.
     - Move any entry "<parameter> = @()" from the new minimum version to the baseline list, if it is not already present there.
-      After that, let's say the new minimum version is v4.5.0, then IgnoreCaseParameterV450 must only contain the parameters that do have an exception list
+      After that, let's say the new minimum version is v4.5.0, then IgnoreCase/RegexParameterV450 must only contain the parameters that do have an exception list
     - At the end of the file
-      - Remove $Script:IgnoreCaseParameterDictonary['4.4'] =...
+      - Remove $Script:IgnoreCaseParameterDictionary['4.4'] =...
+      - Remove $Script:RegexParameterDictionary['4.4'] =...
     If a new API version is released
       - a new $Script:IgnoreCaseParameterV4nn entry must be added
-      - At the end of the file, add a new entry to $Script:IgnoreCaseParameterDictonary['4.nn'] = $Script:IgnoreCaseParameterBaseline + $Script:IgnoreCaseParameterV4nn
+      - a new $Script:RegexParameterV4nn entry must be added
+      - At the end of the file, add a new entry to $Script:IgnoreCaseParameterDictionary['4.nn'] = $Script:IgnoreCaseParameterBaseline + $Script:IgnoreCaseParameterV4nn
+      - At the end of the file, add a new entry to $Script:RegexParameterDictionary['4.nn'] = $Script:RegexParameterBaseline + $Script:RegexParameterV4nn
 
     As the minimum supported API will rise beyond 4.6, in 'Setup.Tests.ps1' Context 'Query Options' the mocked data must be updated.
 
@@ -26,6 +28,7 @@
 #>
 
 # Current baseline is the API v4.4.9 list of fully supported case-insensitive parameters, which is the minimum version supported by this module
+#region IgnoreCase parameter dictionary
 $Script:IgnoreCaseParameterBaseline = @{
     'account'                  = @()
     'action_type'              = @()
@@ -179,6 +182,163 @@ $Script:IgnoreCaseParameterV461 = @{
     'service_id'     = @('api/ipam/ip-addresses/')
     'type'           = @('api/circuits/circuits/', 'api/circuits/virtual-circuits/', 'api/virtualization/clusters/')
 }
+#endregion
+
+#region IgnoreCase parameter dictionary
+$Script:RegexParameterBaseline = @{
+    'account'                  = @()
+    'action_type'              = @()
+    'app_label'                = @()
+    'asset_tag'                = @()
+    'auth_cipher'              = @()
+    'auth_key'                 = @()
+    'auth_psk'                 = @()
+    'auth_type'                = @()
+    'authentication_algorithm' = @()
+    'authentication_method'    = @()    # 1
+    'ca_file_path'             = @()
+    'cid'                      = @()
+    'color'                    = @()
+    'description'              = @()
+    'device_status'            = @()
+    'dns_name'                 = @()
+    'domain'                   = @()
+    'duplex'                   = @()
+    'email'                    = @()
+    'encapsulation'            = @()    # 2
+    'encryption_algorithm'     = @()
+    'facility'                 = @()
+    'facility_id'              = @()
+    'feed_leg'                 = @()
+    'file_extension'           = @()
+    'file_name'                = @()
+    'first_name'               = @()
+    'form_factor'              = @()
+    'group_name'               = @()
+    'hash'                     = @()    # 3
+    'http_content_type'        = @()
+    'http_method'              = @()
+    'key'                      = @()
+    'label'                    = @()
+    'last_name'                = @()
+    'link'                     = @()
+    'link_text'                = @()
+    'link_url'                 = @()
+    'mac_address'              = @()
+    'mime_type'                = @()    # 4
+    'mode'                     = @()
+    'name'                     = @()
+    'object_repr'              = @()
+    'part_id'                  = @()
+    'part_number'              = @()
+    'path'                     = @()
+    'phone'                    = @()
+    'poe_mode'                 = @()
+    'poe_type'                 = @()
+    'pp_info'                  = @()    # 5
+    'preshared_key'            = @()
+    'qinq_role'                = @()
+    'rd'                       = @()
+    'rf_channel'               = @()
+    'rf_role'                  = @()
+    'secret'                   = @()
+    'serial'                   = @()
+    'slug'                     = @()
+    'source_url'               = @()
+    'ssid'                     = @()    # 6
+    'status'                   = @()
+    'table'                    = @()
+    'time_zone'                = @()
+    'title'                    = @()
+    'user_name'                = @()
+    'username'                 = @()
+    'validation_regex'         = @()
+    'wwn'                      = @()
+    'xconnect_id'              = @()    # 69
+}
+
+$Script:RegexParameterV449 = @{
+    # v4.4.9 existing parameters that are case-insensitive, exceptions for endpoints are listed in the arrays
+    'address'     = @('api/ipam/ip-addresses/')
+    'kind'        = @('api/dcim/interfaces/')
+    'model'       = @('api/dcim/devices/')
+    'object_type' = @('api/core/jobs/', 'api/extras/bookmarks/', 'api/extras/image-attachments/', 'api/extras/table-configs/', 'api/extras/tagged-objects/', 'api/tenancy/contact-assignments/')
+    'position'    = @('api/dcim/devices/')
+    'protocol'    = @('api/ipam/service-templates/', 'api/ipam/services/')
+    'role'        = @('api/dcim/devices/', 'api/dcim/inventory-item-templates/', 'api/dcim/inventory-items/', 'api/dcim/racks/', 'api/ipam/ip-ranges/', 'api/ipam/prefixes/', 'api/ipam/vlans/', 'api/tenancy/contact-assignments/', 'api/virtualization/virtual-machines/')
+    'service_id'  = @('api/ipam/ip-addresses/')
+    'type'        = @('api/circuits/circuits/', 'api/circuits/virtual-circuits/', 'api/dcim/console-port-templates/', 'api/dcim/console-server-port-templates/', 'api/dcim/power-feeds/', 'api/dcim/power-outlet-templates/', 'api/dcim/power-port-templates/', 'api/virtualization/clusters/')
+}
+$Script:RegexParameterV450 = @{
+    # v4.4.9 -> v4.5.0, these parameters are case-insensitive for all endpoints
+    'action'         = @()      # 70
+    'airflow'        = @()
+    'base_choices'   = @()
+    'button_class'   = @()
+    'cable_end'      = @()
+    'distance_unit'  = @()
+    'face'           = @()
+    'filter_logic'   = @()
+    'length_unit'    = @()
+    'outer_unit'     = @()
+    'phase'          = @()      # 80
+    'protocol'       = @()
+    'queue_name'     = @()
+    'start_on_boot'  = @()
+    'subdevice_role' = @()
+    'supply'         = @()
+    'term_side'      = @()
+    'ui_editable'    = @()
+    'ui_visible'     = @()
+    'weight_unit'    = @()      # 89
+    # existing parameters that are case-insensitive, exceptions for endpoints are listed in the arrays
+    'address'        = @('api/ipam/ip-addresses/')
+    'kind'           = @('api/dcim/interfaces/')
+    'model'          = @('api/dcim/devices/')
+    'object_type'    = @('api/core/jobs/', 'api/extras/bookmarks/', 'api/extras/image-attachments/', 'api/extras/table-configs/', 'api/extras/tagged-objects/', 'api/tenancy/contact-assignments/')
+    'position'       = @('api/dcim/devices/')
+    'priority'       = @('api/ipam/fhrp-group-assignments/')
+    'profile'        = @('api/dcim/module-types/', 'api/dcim/modules/', 'api/extras/config-contexts/')
+    'role'           = @('api/dcim/devices/', 'api/dcim/inventory-item-templates/', 'api/dcim/inventory-items/', 'api/dcim/racks/', 'api/ipam/ip-ranges/', 'api/ipam/prefixes/', 'api/ipam/vlans/', 'api/tenancy/contact-assignments/', 'api/virtualization/virtual-machines/')
+    'service_id'     = @('api/ipam/ip-addresses/')
+    'type'           = @('api/circuits/circuits/', 'api/circuits/virtual-circuits/', 'api/virtualization/clusters/')
+}
+$Script:RegexParameterV461 = @{
+    # v4.4.9 -> v4.6.1, these parameters are case-insensitive for all endpoints
+    'action'         = @()
+    'airflow'        = @()
+    'base_choices'   = @()
+    'button_class'   = @()
+    'cable_end'      = @()
+    'distance_unit'  = @()
+    'face'           = @()
+    'filter_logic'   = @()
+    'length_unit'    = @()
+    'notifications'  = @()      # new in 4.6.1, not present in 4.5.0
+    'outer_unit'     = @()
+    'phase'          = @()
+    'protocol'       = @()
+    'queue_name'     = @()
+    'start_on_boot'  = @()
+    'subdevice_role' = @()
+    'supply'         = @()
+    'term_side'      = @()
+    'ui_editable'    = @()
+    'ui_visible'     = @()
+    'weight_unit'    = @()
+    # existing parameters that are case-insensitive, exceptions for endpoints are listed in the arrays
+    'address'        = @('api/ipam/ip-addresses/')
+    'kind'           = @('api/dcim/interfaces/')
+    'model'          = @('api/dcim/devices/')
+    'object_type'    = @('api/core/jobs/', 'api/extras/bookmarks/', 'api/extras/image-attachments/', 'api/extras/table-configs/', 'api/extras/tagged-objects/', 'api/tenancy/contact-assignments/')
+    'position'       = @('api/dcim/devices/')
+    'priority'       = @('api/ipam/fhrp-group-assignments/')
+    'profile'        = @('api/dcim/module-types/', 'api/dcim/modules/', 'api/extras/config-contexts/')
+    'role'           = @('api/dcim/devices/', 'api/dcim/inventory-item-templates/', 'api/dcim/inventory-items/', 'api/dcim/racks/', 'api/ipam/asns/', 'api/ipam/ip-ranges/', 'api/ipam/prefixes/', 'api/ipam/vlans/', 'api/tenancy/contact-assignments/', 'api/virtualization/virtual-machines/')
+    'service_id'     = @('api/ipam/ip-addresses/')
+    'type'           = @('api/circuits/circuits/', 'api/circuits/virtual-circuits/', 'api/virtualization/clusters/')
+}
+#endregion
 
 # Set-NBQueryOption will set this to whatever is appropriate for the API version
 # default is to start with case insensitive
@@ -190,3 +350,9 @@ $Script:IgnoreCaseParameterDictonary  = [ordered]@{}
 $Script:IgnoreCaseParameterDictonary['4.4'] = $Script:IgnoreCaseParameterBaseline + $Script:IgnoreCaseParameterV449
 $Script:IgnoreCaseParameterDictonary['4.5'] = $Script:IgnoreCaseParameterBaseline + $Script:IgnoreCaseParameterV450
 $Script:IgnoreCaseParameterDictonary['4.6'] = $Script:IgnoreCaseParameterBaseline + $Script:IgnoreCaseParameterV461
+
+$Script:RegexParameterDictionary  = [ordered]@{}
+# For testing, we do like there is only the baseline; TODO: Remove #
+$Script:RegexParameterDictionary['4.4'] = $Script:RegexParameterBaseline + $Script:IgnoreCaseParameterV449
+$Script:RegexParameterDictionary['4.5'] = $Script:RegexParameterBaseline + $Script:IgnoreCaseParameterV450
+$Script:RegexParameterDictionary['4.6'] = $Script:RegexParameterBaseline + $Script:IgnoreCaseParameterV461

--- a/Functions/Setup/Connect-NBAPI.ps1
+++ b/Functions/Setup/Connect-NBAPI.ps1
@@ -202,12 +202,13 @@ function Connect-NBAPI {
         Write-Verbose "Found compatible version [$versionString] (parsed: $($script:NetboxConfig.ParsedVersion))!"
     }
 
+    $script:NetboxConfig.Connected = $true
+    Write-Verbose "Successfully connected!"
+
     # This needs a valid ParsedVersion to work, so it must be called after the version check
     $null = Set-NBQueryOption -IgnoreCase:$IgnoreCase
     $null = Set-NBQueryOption -MatchMode $MatchMode
 
-    $script:NetboxConfig.Connected = $true
-    Write-Verbose "Successfully connected!"
 
     Write-Verbose "Connection process completed"
 }

--- a/Functions/Setup/Connect-NBAPI.ps1
+++ b/Functions/Setup/Connect-NBAPI.ps1
@@ -43,6 +43,13 @@ function Connect-NBAPI {
         and only on endpoints where that lookup is available; unsupported fields stay case-sensitive.
         See Set-NBQueryOption for details.
 
+    .PARAMETER MatchMode
+        Sets the match mode for query parameters. Valid values are:
+        - Exact: Only exact matches will be returned (default).
+        - Wildcard: Query parameters will be treated as Powershell wildcards.
+        - Regex: Query parameters will be treated as regular expressions (Netbox's `regex`).
+        See Set-NBQueryOption for details.
+
     .EXAMPLE
         PS C:\> Connect-NBAPI -Hostname "netbox.domain.com"
 
@@ -52,6 +59,11 @@ function Connect-NBAPI {
         PS C:\> Connect-NBAPI -Hostname "netbox.domain.com" -IgnoreCase
 
         This will prompt for Credential, then proceed to attempt a connection to Netbox with case-insensitive query parameters enabled
+
+    .EXAMPLE
+        PS C:\> Connect-NBAPI -URI "https://netbox.domain.com:8443" -Credential $cred -IgnoreCase -MatchMode 'Wildcard'
+
+        Same, but with a full URI, credential object, and both query options set.
 
     .NOTES
         AddedInVersion: v1.0.4
@@ -74,7 +86,7 @@ function Connect-NBAPI {
         $Credential,
 
         [Parameter(ParameterSetName = 'Manual')]
-        [ValidateSet('https', 'http', IgnoreCase = $true)]
+        [ValidateSet('https', 'http')]
         [string]$Scheme = 'https',
 
         [Parameter(ParameterSetName = 'Manual')]
@@ -92,7 +104,10 @@ function Connect-NBAPI {
         [ValidateRange(1, 65535)]
         [uint16]$TimeoutSeconds = 30,
 
-        [switch]$IgnoreCase
+        [switch]$IgnoreCase,
+
+        [ValidateSet('Exact', 'Wildcard', 'Regex')]
+        [string]$MatchMode = 'Exact'
     )
 
     if (-not $Credential) {
@@ -188,6 +203,7 @@ function Connect-NBAPI {
 
     # This needs a valid ParsedVersion to work, so it must be called after the version check
     $null = Set-NBQueryOption -IgnoreCase:$IgnoreCase
+    $null = Set-NBQueryOption -MatchMode $MatchMode
 
     $script:NetboxConfig.Connected = $true
     Write-Verbose "Successfully connected!"

--- a/Functions/Setup/Connect-NBAPI.ps1
+++ b/Functions/Setup/Connect-NBAPI.ps1
@@ -4,7 +4,8 @@ function Connect-NBAPI {
         Connects to the Netbox API and ensures Credential work properly
 
     .DESCRIPTION
-        Connects to the Netbox API and ensures Credential work properly
+        Connects to the Netbox API and ensures Credential work properly.
+        After a successful connection, the query options IgnoreCase and MatchMode are set to their respective values (or defaults).
 
     .PARAMETER Hostname
         The hostname for the resource such as netbox.domain.com

--- a/Functions/Setup/Get-NBQueryOption.ps1
+++ b/Functions/Setup/Get-NBQueryOption.ps1
@@ -19,12 +19,16 @@ function Get-NBQueryOption {
     param ()
 
     Write-Verbose "Getting Netbox Query Options"
-    if ($null -eq $script:NetboxConfig.IgnoreCaseInQueries) {
+    if ($null -eq $script:NetboxConfig.IgnoreCaseInQueries -or $null -eq $script:NetboxConfig.MatchMode) {
         throw "Netbox Query Options are not set! You may set them with Set-NBQueryOption"
     }
 
     [PSCustomObject]@{
         Name = "IgnoreCase"
         Value = $script:NetboxConfig.IgnoreCaseInQueries
+    }
+    [PSCustomObject]@{
+        Name = "MatchMode"
+        Value = $script:NetboxConfig.MatchMode
     }
 }

--- a/Functions/Setup/Set-NBQueryOption.ps1
+++ b/Functions/Setup/Set-NBQueryOption.ps1
@@ -56,7 +56,7 @@ function Set-NBQueryOption {
                 $script:NetboxConfig.MatchMode = $MatchMode
             }
         }
-        $Script:IgnoreCaseParameterHash = @{}       # reset list (equal to case sensitive)
+        $Script:QueryParameterHash = @{}       # reset list (equal to case sensitive)
 
         if ($IgnoreCase -eq $true -or $MatchMode -ne 'Exact') {
             CheckNetboxIsConnected
@@ -68,13 +68,13 @@ function Set-NBQueryOption {
             }
             foreach ($key in $Script:IgnoreCaseParameterDictonary.Keys) {
                 if ([version]$key -eq [version]$activeApiMinorVersion) {
-                    $Script:IgnoreCaseParameterHash = $Script:IgnoreCaseParameterDictonary[$key]
+                    $Script:QueryParameterHash = $Script:IgnoreCaseParameterDictonary[$key]
                     break
                 }
             }
-            if ($Script:IgnoreCaseParameterHash.Keys.Count -eq 0) {
+            if ($Script:QueryParameterHash.Keys.Count -eq 0) {
                 $latestKnownVersion = (@($Script:IgnoreCaseParameterDictonary.Keys)[-1])
-                $Script:IgnoreCaseParameterHash = $Script:IgnoreCaseParameterDictonary[$latestKnownVersion]
+                $Script:QueryParameterHash = $Script:IgnoreCaseParameterDictonary[$latestKnownVersion]
                 Write-Warning "No case-insensitive parameters are defined for API version $($activeApiMinorVersion).x. Taking the latest known version ($latestKnownVersion)."
             }
         }

--- a/Functions/Setup/Set-NBQueryOption.ps1
+++ b/Functions/Setup/Set-NBQueryOption.ps1
@@ -35,10 +35,12 @@
 #>
 function Set-NBQueryOption {
     [CmdletBinding(ConfirmImpact = 'Low',
-        SupportsShouldProcess = $true)]
+        SupportsShouldProcess = $true,
+        DefaultParameterSetName = 'IgnoreCase')]
     [OutputType([boolean], [string])]
     param (
-        [Parameter(ParameterSetName = 'IgnoreCase', Mandatory = $true)]
+        # Not mandatory + default set: a bare `Set-NBQueryOption` keeps its pre-MatchMode meaning (IgnoreCase = $false)
+        [Parameter(ParameterSetName = 'IgnoreCase')]
         [switch]$IgnoreCase,
 
         [Parameter(ParameterSetName = 'MatchMode', Mandatory = $true)]

--- a/Functions/Setup/Set-NBQueryOption.ps1
+++ b/Functions/Setup/Set-NBQueryOption.ps1
@@ -58,8 +58,8 @@ function Set-NBQueryOption {
         }
 
         # depending on the API version, we have different sets of parameters that are supported.
-        # Per API version, a set of IgnoreCaseParameterDictonary and RegexParameterDictionary must be defined in the module (see _IgnoreCaseParameters.ps1)
-        # This is presumed, to get the latest known version supported from IgnoreCaseParameterDictonary only
+        # Per API version, a set of IgnoreCaseParameterDictionary and RegexParameterDictionary must be defined in the module (see _IgnoreCaseParameters.ps1)
+        # This is presumed, to get the latest known version supported from IgnoreCaseParameterDictionary only
         $Script:QueryParameterDecoration = ''
         $Script:QueryParameterHash = @{}
         if ($script:NetboxConfig.IgnoreCaseInQueries -or $script:NetboxConfig.MatchMode -ne 'Exact') {
@@ -74,7 +74,7 @@ function Set-NBQueryOption {
                 }
             'True, Exact' {
                 $Script:QueryParameterDecoration = '__ie'
-                $Script:QueryParameterHash = $Script:IgnoreCaseParameterDictonary[$qpSupport.UsedVersion.tostring()]
+                $Script:QueryParameterHash = $Script:IgnoreCaseParameterDictionary[$qpSupport.UsedVersion.tostring()]
             }
             'False, Wildcard' {
                 $Script:QueryParameterDecoration = '__regex'

--- a/Functions/Setup/Set-NBQueryOption.ps1
+++ b/Functions/Setup/Set-NBQueryOption.ps1
@@ -56,52 +56,47 @@ function Set-NBQueryOption {
                 $script:NetboxConfig.MatchMode = $MatchMode
             }
         }
-        switch ("$($script:NetboxConfig.IgnoreCaseInQueries), $($script:NetboxConfig.MatchMode)") {
-            'False, Exact' {
-                $Script:QueryParameterDecoration = ''
+
+        # depending on the API version, we have different sets of parameters that are supported.
+        # Per API version, a set of IgnoreCaseParameterDictonary and RegexParameterDictionary must be defined in the module (see _IgnoreCaseParameters.ps1)
+        # This is presumed, to get the latest known version supported from IgnoreCaseParameterDictonary only
+        $Script:QueryParameterDecoration = ''
+        $Script:QueryParameterHash = @{}
+        if ($script:NetboxConfig.IgnoreCaseInQueries -or $script:NetboxConfig.MatchMode -ne 'Exact') {
+            $qpSupport = Get-VersionQueryParameterSupport -ShowWarning
+            if ($null -eq $qpSupport.UsedVersion) {
+                return                  # version below oldest supported version
+            }
+            switch ("$($script:NetboxConfig.IgnoreCaseInQueries), $($script:NetboxConfig.MatchMode)") {
+                'False, Exact' {
+                    $Script:QueryParameterDecoration = ''
+                    $Script:QueryParameterHash = @{}
+                }
+            'True, Exact' {
+                $Script:QueryParameterDecoration = '__ie'
+                $Script:QueryParameterHash = $Script:IgnoreCaseParameterDictonary[$qpSupport.UsedVersion.tostring()]
             }
             'False, Wildcard' {
                 $Script:QueryParameterDecoration = '__regex'
+                $Script:QueryParameterHash = $Script:RegexParameterDictionary[$qpSupport.UsedVersion.tostring()]
             }
             'False, Regex' {
                 $Script:QueryParameterDecoration = '__regex'
-            }
-            'True, Exact' {
-                $Script:QueryParameterDecoration = '__ie'
+                $Script:QueryParameterHash = $Script:RegexParameterDictionary[$qpSupport.UsedVersion.tostring()]
             }
             'True, Wildcard' {
                 $Script:QueryParameterDecoration = '__iregex'
+                $Script:QueryParameterHash = $Script:RegexParameterDictionary[$qpSupport.UsedVersion.tostring()]
             }
             'True, Regex' {
                 $Script:QueryParameterDecoration = '__iregex'
+                $Script:QueryParameterHash = $Script:RegexParameterDictionary[$qpSupport.UsedVersion.tostring()]
             }
             default {
                 Throw "Invalid combination of IgnoreCase and MatchMode: $($script:NetboxConfig.IgnoreCaseInQueries), $($script:NetboxConfig.MatchMode)"
             }
         }
-
-        $Script:QueryParameterHash = @{}       # reset list (equal to case sensitive)
-
-        if ('' -ne $Script:QueryParameterDecoration) {
-            CheckNetboxIsConnected
-            # depending on the API version, we have different sets of parameters that are supported.
-            $activeApiMinorVersion = "{0}.{1}" -f ($script:NetboxConfig.ParsedVersion -split '\.')[0..1] #, ($script:NetboxConfig.ParsedVersion -split '\.')[1]
-            if ([version]$activeApiMinorVersion -lt [version](@($Script:IgnoreCaseParameterDictonary.Keys)[0])) {
-                Write-Warning "API version $($script:NetboxConfig.ParsedVersion) is less than the minimum supported version ($(@($Script:IgnoreCaseParameterDictonary.Keys)[0])). No case-insensitive parameters will be used."
-                return $false
-            }
-            foreach ($key in $Script:IgnoreCaseParameterDictonary.Keys) {
-                if ([version]$key -eq [version]$activeApiMinorVersion) {
-                    $Script:QueryParameterHash = $Script:IgnoreCaseParameterDictonary[$key]
-                    break
-                }
-            }
-            if ($Script:QueryParameterHash.Keys.Count -eq 0) {
-                $latestKnownVersion = (@($Script:IgnoreCaseParameterDictonary.Keys)[-1])
-                $Script:QueryParameterHash = $Script:IgnoreCaseParameterDictonary[$latestKnownVersion]
-                Write-Warning "No case-insensitive parameters are defined for API version $($activeApiMinorVersion).x. Taking the latest known version ($latestKnownVersion)."
-            }
-        }
+    }
 
         switch ($PSCmdlet.ParameterSetName) {
             'IgnoreCase' {

--- a/Functions/Setup/Set-NBQueryOption.ps1
+++ b/Functions/Setup/Set-NBQueryOption.ps1
@@ -6,7 +6,13 @@
     Sets the behaviour of query parameters (see notes).
 
 .PARAMETER IgnoreCase
-    If set, query parameters of type string will be case-insensitive (Netbox's `__ie`)
+    If set, query parameters of type string will be case-insensitive (Netbox's `__ie`). To reset to case-sensitive, use `-IgnoreCase:$false`.
+
+.PARAMETER MatchMode
+    Sets the match mode for query parameters. Valid values are:
+    - Exact: Only exact matches will be returned (default).
+    - Wildcard: Query parameters will be treated as Powershell wildcards.
+    - Regex: Query parameters will be treated as regular expressions (Netbox's `regex`).
 
 .EXAMPLE
     Set-NBQueryOption -IgnoreCase
@@ -16,27 +22,43 @@
     Set-NBQueryOption -IgnoreCase:$false
     Sets the Netbox API query parameters to be case-sensitive (default on startup of the module).
 
+.EXAMPLE
+    Set-NBQueryOption -MatchMode 'Wildcard'
+    Sets the Netbox API query parameters to be treated as Powershell wildcards.
+
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
 
 .NOTES
     Depending on the API version, different sets of parameters are supported as case-insensitive.
     As this feature is relying on the API version and its supported parameters, not all parameters are supported as case-insensitive.
-
 #>
 function Set-NBQueryOption {
     [CmdletBinding(ConfirmImpact = 'Low',
         SupportsShouldProcess = $true)]
-    [OutputType([boolean])]
+    [OutputType([boolean], [string])]
     param (
-        [switch]$IgnoreCase
+        [Parameter(ParameterSetName = 'IgnoreCase', Mandatory = $true)]
+        [switch]$IgnoreCase,
+
+        [Parameter(ParameterSetName = 'MatchMode', Mandatory = $true)]
+        [ValidateSet('Exact', 'Wildcard', 'Regex')]
+        [string]$MatchMode = 'Exact'
     )
 
     if ($PSCmdlet.ShouldProcess('Netbox Query Options', 'Set')) {
-        $script:NetboxConfig.IgnoreCaseInQueries = $IgnoreCase
+        # We only set the values if they are passed in, otherwise we leave them as they are.
+        switch ($PSCmdlet.ParameterSetName) {
+            'IgnoreCase' {
+                $script:NetboxConfig.IgnoreCaseInQueries = $IgnoreCase
+            }
+            'MatchMode' {
+                $script:NetboxConfig.MatchMode = $MatchMode
+            }
+        }
         $Script:IgnoreCaseParameterHash = @{}       # reset list (equal to case sensitive)
 
-        if ($IgnoreCase -eq $true) {
+        if ($IgnoreCase -eq $true -or $MatchMode -ne 'Exact') {
             CheckNetboxIsConnected
             # depending on the API version, we have different sets of parameters that are supported.
             $activeApiMinorVersion = "{0}.{1}" -f ($script:NetboxConfig.ParsedVersion -split '\.')[0..1] #, ($script:NetboxConfig.ParsedVersion -split '\.')[1]
@@ -57,6 +79,15 @@ function Set-NBQueryOption {
             }
         }
 
-        $script:NetboxConfig.IgnoreCaseInQueries
+        switch ($PSCmdlet.ParameterSetName) {
+            'IgnoreCase' {
+                Write-Verbose "Set IgnoreCase to $($script:NetboxConfig.IgnoreCaseInQueries)"
+                $script:NetboxConfig.IgnoreCaseInQueries
+            }
+            'MatchMode' {
+                Write-Verbose "Set MatchMode to $($script:NetboxConfig.MatchMode)"
+                $script:NetboxConfig.MatchMode
+            }
+        }
     }
 }

--- a/Functions/Setup/Set-NBQueryOption.ps1
+++ b/Functions/Setup/Set-NBQueryOption.ps1
@@ -56,9 +56,33 @@ function Set-NBQueryOption {
                 $script:NetboxConfig.MatchMode = $MatchMode
             }
         }
+        switch ("$($script:NetboxConfig.IgnoreCaseInQueries), $($script:NetboxConfig.MatchMode)") {
+            'False, Exact' {
+                $Script:QueryParameterDecoration = ''
+            }
+            'False, Wildcard' {
+                $Script:QueryParameterDecoration = '__regex'
+            }
+            'False, Regex' {
+                $Script:QueryParameterDecoration = '__regex'
+            }
+            'True, Exact' {
+                $Script:QueryParameterDecoration = '__ie'
+            }
+            'True, Wildcard' {
+                $Script:QueryParameterDecoration = '__iregex'
+            }
+            'True, Regex' {
+                $Script:QueryParameterDecoration = '__iregex'
+            }
+            default {
+                Throw "Invalid combination of IgnoreCase and MatchMode: $($script:NetboxConfig.IgnoreCaseInQueries), $($script:NetboxConfig.MatchMode)"
+            }
+        }
+
         $Script:QueryParameterHash = @{}       # reset list (equal to case sensitive)
 
-        if ($IgnoreCase -eq $true -or $MatchMode -ne 'Exact') {
+        if ('' -ne $Script:QueryParameterDecoration) {
             CheckNetboxIsConnected
             # depending on the API version, we have different sets of parameters that are supported.
             $activeApiMinorVersion = "{0}.{1}" -f ($script:NetboxConfig.ParsedVersion -split '\.')[0..1] #, ($script:NetboxConfig.ParsedVersion -split '\.')[1]

--- a/Functions/Setup/Support/SetupNetboxConfigVariable.ps1
+++ b/Functions/Setup/Support/SetupNetboxConfigVariable.ps1
@@ -20,6 +20,7 @@ function SetupNetboxConfigVariable {
             'ParsedVersion' = $null
             'BranchStack'   = [System.Collections.Generic.Stack[object]]::new()
             'IgnoreCaseInQueries' = $false
+            'MatchMode'     = 'Exact'
         }
     }
     else {

--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ and authentication details, and worked examples are in the documentation:
 
 ---
 
+## Filter parameter usage in API queries
+
 ### Case sensitivity - insensitivity
 
 The NetBox API, by default, treats all query parameter values as case-sensitive. As PowerShell is [as case-insensitive as possible](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_case-sensitivity), the module offers an option to use case-insensitive query values.
@@ -76,9 +78,22 @@ The NetBox API, by default, treats all query parameter values as case-sensitive.
 
 `Set-NBQueryOption -IgnoreCase:$true` or `Connect-NBAPI -IgnoreCase`.
 
-#### Requirements and limitations
+### Using wildcards/regex when filtering queries
 
-Depending on the version of the NetBox API used, the API supports this option for a specific set of parameters and endpoints. Due to this current limitation, the module can only support case insensitivity for the same set of cases.
+By default, the module uses filter queries, that ask for an exact match.\
+You can influence this behaviour by choosing between three modes: Exact, Wildcard, Regex. Every API string parameter, which supports regex/iregex operators, is enabled
+
+1. Exact: The search string is sent 1:1 through the API
+2. Wildcard: [Wildcard characters](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_wildcards) in the search string, are taken into account for filtering query results.
+3. Regex: Search strings accept Regex tokens for filtering result sets. Please keep in mind, that regex is matching parts of a string!
+
+#### Activating advanced match modes
+
+`Set-NBQueryOption -MatchMode Wildcard|Regex` or `Connect-NBAPI -Matchmode`.
+
+### Requirements and limitations
+
+Depending on the version of the NetBox API used, the API supports these options for a specific set of parameters and endpoints. Due to this current limitation, the module can only support case insensitivity and wildcard searches for the same set of cases.
 
 - Minimum version of Netbox API is 4.4+.
 - A list of parameters offered by each API version can be found in the repository. See [_IgnoreCaseParameters.ps1](./Functions/Helpers/_IgnoreCaseParameters.ps1).

--- a/Tests/CodeQuality.Tests.ps1
+++ b/Tests/CodeQuality.Tests.ps1
@@ -53,7 +53,7 @@ Describe "Code Quality Tests" -Tag 'Quality' {
                 'Get-NBCredential', 'Get-NBHostname', 'Get-NBHostPort',
                 'Get-NBHostScheme', 'Get-NBInvokeParams', 'Get-NBTimeout',
                 'Get-NBRequestHeaders', 'Get-NBVersion', 'Get-NBBranchContext',
-                'Get-NBAPIDefinition', 'Get-NBQueryOption'
+                'Get-NBAPIDefinition', 'Get-NBQueryOption', 'Get-VersionQueryParameterSupport'
             )
             $getFunctions = $script:PublicFunctions | Where-Object {
                 $_.Verb -eq 'Get' -and $_.Name -notin $excludedFunctions

--- a/Tests/Helpers.Tests.ps1
+++ b/Tests/Helpers.Tests.ps1
@@ -109,9 +109,10 @@ Describe "Helpers tests" -Tag 'Core', 'Helpers' {
             }
         }
 
-        Context 'Build case insensitive query parameters' {
+        Context 'Build query parameters with query options' {
             BeforeAll {
-                $stateBefore = Get-NBQueryOption | Where-Object { $_.Name -eq 'IgnoreCase' }
+                $ignoreCaseBefore = Get-NBQueryOption | Where-Object { $_.Name -eq 'IgnoreCase' }
+                $matchModeBefore = Get-NBQueryOption | Where-Object { $_.Name -eq 'MatchMode' }
                 # We need to set the parsed version to a value for testing, but we will restore it after the tests
                 $parsedVersionBefore = InModuleScope -ModuleName 'PowerNetbox' {
                     $script:NetboxConfig.ParsedVersion
@@ -123,12 +124,13 @@ Describe "Helpers tests" -Tag 'Core', 'Helpers' {
                 $null = Set-NBQueryOption -IgnoreCase
             }
             AfterAll {
-                $null = Set-NBQueryOption -IgnoreCase:$stateBefore.Value
+                $null = Set-NBQueryOption -IgnoreCase:$ignoreCaseBefore.Value
+                $null = Set-NBQueryOption -MatchMode:$matchModeBefore.Value
                 InModuleScope -ModuleName 'PowerNetbox' {
                     $script:NetboxConfig.ParsedVersion = $parsedVersionBefore
                 }
             }
-            It "Should not use __ie if parameter is not in the list" {
+            It "Should not use __ie/__regex/__iregex if parameter is not in the list" {
                 InModuleScope -ModuleName 'PowerNetbox' {
                     $Script:QueryParameterHash=@{}  # simulate parameter not in the list
                     $URIParameters = @{
@@ -140,7 +142,7 @@ Describe "Helpers tests" -Tag 'Core', 'Helpers' {
                     $URIBuilder.URI.AbsoluteURI | Should -Match 'https://netbox.domain.com/api/seg1/seg2/\?name=NameValue'
                 }
             }
-            It "Should  not use __ie if parameter is in the list but endpoint is in the ignore list" {
+            It "Should  not use __ie/__regex/__iregex if parameter is in the list but endpoint is in the ignore list" {
                 InModuleScope -ModuleName 'PowerNetbox' {
                     $Script:QueryParameterHash['name'] = @('api/seg1/seg2/','api/otherexcludedendpoint/')  # simulate endpoint in ignore list
                     $URIParameters = @{
@@ -152,31 +154,49 @@ Describe "Helpers tests" -Tag 'Core', 'Helpers' {
                     $URIBuilder.URI.AbsoluteURI | Should -Match 'https://netbox.domain.com/api/seg1/seg2/\?name=NameValue'
                 }
             }
-            It "Should use __ie if parameter is in the list and endpoint list is empty" {
-                InModuleScope -ModuleName 'PowerNetbox' {
-                    $Script:NetboxConfig.IgnoreCaseInQueries = $true                 # can be set by Connect-NBAPI
-                    $Script:QueryParameterHash['name'] = @()  # simulate endpoint list is empty
-                    $URIParameters = @{
-                        'name' = 'NameValue'
-                    }
-
-                    $URIBuilder = BuildNewURI -Segments 'seg1', 'seg2' -Parameters $URIParameters -SkipConnectedCheck
-                    $URIBuilder.Query | Should -Match 'name__ie=NameValue'
-                    $URIBuilder.URI.AbsoluteURI | Should -Match 'https://netbox.domain.com/api/seg1/seg2/\?name__ie=NameValue'
+            Context "Query option combinations <Usecase>" -Foreach @(
+                @{ IgnoreCase = $false; MatchMode = 'Exact';    ParamDecoration = '';          Usecase = 'Exact' }
+                @{ IgnoreCase = $false; MatchMode = 'Regex';    ParamDecoration = '__regex';   Usecase = 'Regex'  }
+                @{ IgnoreCase = $false; MatchMode = 'Wildcard'; ParamDecoration = '__regex';   Usecase = 'Wildcard' }
+                @{ IgnoreCase = $true;  MatchMode = 'Exact';    ParamDecoration = '__ie';      Usecase = 'IgnoreCase+Exact' }
+                @{ IgnoreCase = $true;  MatchMode = 'Regex';    ParamDecoration = '__iregex';  Usecase = 'IgnoreCase+Regex' }
+                @{ IgnoreCase = $true;  MatchMode = 'Wildcard'; ParamDecoration = '__iregex';  Usecase = 'IgnoreCase+Wildcard' }
+            ) {
+                BeforeAll {
+                    Mock 'CheckNetboxIsConnected' -ModuleName 'PowerNetbox' -MockWith {}        # We must look like connected
                 }
-            }
-            It "Should use __ie if parameter is in the list and endpoint is not in the ignore list; it should also work with array values" {
-                InModuleScope -ModuleName 'PowerNetbox' {
-                    $Script:NetboxConfig.IgnoreCaseInQueries = $true                 # can be set by Connect-NBAPI
-                    $Script:QueryParameterHash['name'] = @('api/otherendpoint/')  # simulate endpoint not in ignore list
-                    $URIParameters = @{
-                        'name' = @('NameValue', 'AnotherNameValue')  # test that array values are also supported with __ie
-                        'casesensitiveparam' = 'value2'
-                    }
+                BeforeEach {
+                    $null = Set-NbQueryOption -IgnoreCase:$IgnoreCase
+                    $null = Set-NbQueryOption -MatchMode:$MatchMode
+                }
+                It "<Usecase> should use [<ParamDecoration>] if parameter is in the list and endpoint list is empty" {
+                    InModuleScope -ModuleName 'PowerNetbox' -Parameters @{ IgnoreCase = $IgnoreCase; MatchMode = $MatchMode; ParamDecoration = $ParamDecoration } {
+                        # $Script:NetboxConfig.IgnoreCaseInQueries = $IgnoreCase                 # can be set by Connect-NBAPI
+                        # $Script:NetboxConfig.QueryMatchMode = $MatchMode
+                        $Script:QueryParameterHash['name'] = @()  # simulate endpoint list is empty
+                        $URIParameters = @{
+                            'name' = 'NameValue'
+                        }
 
-                    $URIBuilder = BuildNewURI -Segments 'seg1', 'seg2' -Parameters $URIParameters -SkipConnectedCheck
-                    $URIBuilder.Query | Should -Match '(?=.*name__ie=NameValue)(?=.*name__ie=AnotherNameValue)(?=.*casesensitiveparam=value2)'
-                    $URIBuilder.URI.AbsoluteURI | Should -Match 'https://netbox.domain.com/api/seg1/seg2/\?(?=.*name__ie=NameValue)(?=.*name__ie=AnotherNameValue)(?=.*casesensitiveparam=value2)'
+                        $URIBuilder = BuildNewURI -Segments 'seg1', 'seg2' -Parameters $URIParameters -SkipConnectedCheck
+                        $URIBuilder.Query | Should -Match "name$($ParamDecoration)=NameValue"
+                        $URIBuilder.URI.AbsoluteURI | Should -Match "https://netbox.domain.com/api/seg1/seg2/\?name$($ParamDecoration)=NameValue"
+                    }
+                }
+                It "<Usecase> should use [<ParamDecoration>] if parameter is in the list and endpoint is not in the ignore list; it should also work with array values" {
+                    InModuleScope -ModuleName 'PowerNetbox' -Parameters @{ IgnoreCase = $IgnoreCase; MatchMode = $MatchMode; ParamDecoration = $ParamDecoration } {
+                        $Script:NetboxConfig.IgnoreCaseInQueries = $true                 # can be set by Connect-NBAPI
+                        $Script:QueryParameterHash['name'] = @('api/otherendpoint/')  # simulate endpoint not in ignore list
+                        $URIParameters = @{
+                            'name' = @('NameValue', 'AnotherNameValue')  # test that array values are also supported with __ie
+                            'casesensitiveparam' = 'value2'
+                        }
+
+                        $URIBuilder = BuildNewURI -Segments 'seg1', 'seg2' -Parameters $URIParameters -SkipConnectedCheck
+                        $matchString = "(?=.*name$($ParamDecoration)=NameValue)(?=.*name$($ParamDecoration)=AnotherNameValue)(?=.*casesensitiveparam=value2)"
+                        $URIBuilder.Query | Should -Match $matchString
+                        $URIBuilder.URI.AbsoluteURI | Should -Match "https://netbox.domain.com/api/seg1/seg2/\?$matchString"
+                    }
                 }
             }
         }

--- a/Tests/Helpers.Tests.ps1
+++ b/Tests/Helpers.Tests.ps1
@@ -188,33 +188,45 @@ Describe "Helpers tests" -Tag 'Core', 'Helpers' {
                     $null = Set-NbQueryOption -IgnoreCase:$IgnoreCase
                     $null = Set-NbQueryOption -MatchMode:$MatchMode
                 }
+                AfterAll {
+                    $null = Set-NBQueryOption -IgnoreCase:$false
+                    $null = Set-NBQueryOption -MatchMode:'Exact'
+                }
                 It "<Usecase> should use [<ParamDecoration>] if parameter is in the list and endpoint list is empty" {
                     InModuleScope -ModuleName 'PowerNetbox' -Parameters @{ IgnoreCase = $IgnoreCase; MatchMode = $MatchMode; ParamDecoration = $ParamDecoration } {
-                        # $Script:NetboxConfig.IgnoreCaseInQueries = $IgnoreCase                 # can be set by Connect-NBAPI
-                        # $Script:NetboxConfig.QueryMatchMode = $MatchMode
-                        $Script:QueryParameterHash['name'] = @()  # simulate endpoint list is empty
+                        $Script:QueryParameterHash['ParamSupportQO'] = @()  # simulate endpoint list is empty
                         $URIParameters = @{
-                            'name' = 'NameValue'
+                            'ParamSupportQO' = 'NameValue'
                         }
 
                         $URIBuilder = BuildNewURI -Segments 'seg1', 'seg2' -Parameters $URIParameters -SkipConnectedCheck
-                        $URIBuilder.Query | Should -Match "name$($ParamDecoration)=NameValue"
-                        $URIBuilder.URI.AbsoluteURI | Should -Match "https://netbox.domain.com/api/seg1/seg2/\?name$($ParamDecoration)=NameValue"
+                        if ($MatchMode -ne 'Wildcard') {
+                            $URIBuilder.Query | Should -Match "ParamSupportQO$($ParamDecoration)=NameValue"
+                            $URIBuilder.URI.AbsoluteURI | Should -Match "https://netbox.domain.com/api/seg1/seg2/\?ParamSupportQO$($ParamDecoration)=NameValue"
+                        } else {
+                            $URIBuilder.Query | Should -Match "ParamSupportQO$($ParamDecoration)=%5ENameValue%24"
+                            $URIBuilder.URI.AbsoluteURI | Should -Match "https://netbox.domain.com/api/seg1/seg2/\?ParamSupportQO$($ParamDecoration)=%5ENameValue%24" -Because "regex strings are ^parametervalue$'"
+                        }
                     }
                 }
                 It "<Usecase> should use [<ParamDecoration>] if parameter is in the list and endpoint is not in the ignore list; it should also work with array values" {
                     InModuleScope -ModuleName 'PowerNetbox' -Parameters @{ IgnoreCase = $IgnoreCase; MatchMode = $MatchMode; ParamDecoration = $ParamDecoration } {
-                        $Script:NetboxConfig.IgnoreCaseInQueries = $true                 # can be set by Connect-NBAPI
-                        $Script:QueryParameterHash['name'] = @('api/otherendpoint/')  # simulate endpoint not in ignore list
+                        $Script:QueryParameterHash['ParamSupportQO'] = @('api/otherendpoint/')  # simulate endpoint not in ignore list
                         $URIParameters = @{
-                            'name' = @('NameValue', 'AnotherNameValue')  # test that array values are also supported with __ie
-                            'casesensitiveparam' = 'value2'
+                            'ParamSupportQO' = @('NameValue', 'AnotherNameValue')  # test that array values are also supported with __ie
+                            'NoQoSupport' = 'value2'                               # test a parameter that is not in the list, to ensure it does not get decorated
                         }
 
                         $URIBuilder = BuildNewURI -Segments 'seg1', 'seg2' -Parameters $URIParameters -SkipConnectedCheck
-                        $matchString = "(?=.*name$($ParamDecoration)=NameValue)(?=.*name$($ParamDecoration)=AnotherNameValue)(?=.*casesensitiveparam=value2)"
-                        $URIBuilder.Query | Should -Match $matchString
-                        $URIBuilder.URI.AbsoluteURI | Should -Match "https://netbox.domain.com/api/seg1/seg2/\?$matchString"
+                        if ($MatchMode -ne 'Wildcard') {
+                            $matchString = "(?=.*ParamSupportQO$($ParamDecoration)=NameValue)(?=.*ParamSupportQO$($ParamDecoration)=AnotherNameValue)(?=.*NoQoSupport=value2)"
+                            $URIBuilder.Query | Should -Match $matchString
+                            $URIBuilder.URI.AbsoluteURI | Should -Match "https://netbox.domain.com/api/seg1/seg2/\?$matchString"
+                        } else {
+                            $matchString = "(?=.*ParamSupportQO$($ParamDecoration)=%5ENameValue%24)(?=.*ParamSupportQO$($ParamDecoration)=%5EAnotherNameValue%24)(?=.*NoQoSupport=value2)"
+                            $URIBuilder.Query | Should -Match $matchString
+                            $URIBuilder.URI.AbsoluteURI | Should -Match "https://netbox.domain.com/api/seg1/seg2/\?$matchString"
+                        }
                     }
                 }
             }

--- a/Tests/Helpers.Tests.ps1
+++ b/Tests/Helpers.Tests.ps1
@@ -130,7 +130,7 @@ Describe "Helpers tests" -Tag 'Core', 'Helpers' {
             }
             It "Should not use __ie if parameter is not in the list" {
                 InModuleScope -ModuleName 'PowerNetbox' {
-                    $Script:IgnoreCaseParameterHash=@{}  # simulate parameter not in the list
+                    $Script:QueryParameterHash=@{}  # simulate parameter not in the list
                     $URIParameters = @{
                         'name' = 'NameValue'
                     }
@@ -142,7 +142,7 @@ Describe "Helpers tests" -Tag 'Core', 'Helpers' {
             }
             It "Should  not use __ie if parameter is in the list but endpoint is in the ignore list" {
                 InModuleScope -ModuleName 'PowerNetbox' {
-                    $Script:IgnoreCaseParameterHash['name'] = @('api/seg1/seg2/','api/otherexcludedendpoint/')  # simulate endpoint in ignore list
+                    $Script:QueryParameterHash['name'] = @('api/seg1/seg2/','api/otherexcludedendpoint/')  # simulate endpoint in ignore list
                     $URIParameters = @{
                         'name' = 'NameValue'
                     }
@@ -155,7 +155,7 @@ Describe "Helpers tests" -Tag 'Core', 'Helpers' {
             It "Should use __ie if parameter is in the list and endpoint list is empty" {
                 InModuleScope -ModuleName 'PowerNetbox' {
                     $Script:NetboxConfig.IgnoreCaseInQueries = $true                 # can be set by Connect-NBAPI
-                    $Script:IgnoreCaseParameterHash['name'] = @()  # simulate endpoint list is empty
+                    $Script:QueryParameterHash['name'] = @()  # simulate endpoint list is empty
                     $URIParameters = @{
                         'name' = 'NameValue'
                     }
@@ -168,7 +168,7 @@ Describe "Helpers tests" -Tag 'Core', 'Helpers' {
             It "Should use __ie if parameter is in the list and endpoint is not in the ignore list; it should also work with array values" {
                 InModuleScope -ModuleName 'PowerNetbox' {
                     $Script:NetboxConfig.IgnoreCaseInQueries = $true                 # can be set by Connect-NBAPI
-                    $Script:IgnoreCaseParameterHash['name'] = @('api/otherendpoint/')  # simulate endpoint not in ignore list
+                    $Script:QueryParameterHash['name'] = @('api/otherendpoint/')  # simulate endpoint not in ignore list
                     $URIParameters = @{
                         'name' = @('NameValue', 'AnotherNameValue')  # test that array values are also supported with __ie
                         'casesensitiveparam' = 'value2'

--- a/Tests/Helpers.Tests.ps1
+++ b/Tests/Helpers.Tests.ps1
@@ -135,7 +135,7 @@ Describe "Helpers tests" -Tag 'Core', 'Helpers' {
                 # We need to set the parsed version to a value for testing, but we will restore it after the tests
                 $parsedVersionBefore = InModuleScope -ModuleName 'PowerNetbox' {
                     $script:NetboxConfig.ParsedVersion
-                    $script:NetboxConfig.ParsedVersion = '4.6.1'
+                    $script:NetboxConfig.ParsedVersion = [version]'4.6.1'
                 }
 
                 # We must be connected to check the API version

--- a/Tests/Helpers.Tests.ps1
+++ b/Tests/Helpers.Tests.ps1
@@ -20,6 +20,25 @@ Describe "Helpers tests" -Tag 'Core', 'Helpers' {
         }
     }
 
+    Context 'Regex conversion tests' {
+        It "<WildcardString> should return <Expected> for <InputString>" -ForEach @(
+                @{ InputString = 'abc*';        WildcardString = 'abc*';        ExpectedRegex = '^abc.*$';      ExpectedResult = $true }
+                @{ InputString = 'abcd';        WildcardString = 'abc*';        ExpectedRegex = '^abc.*$';      ExpectedResult = $true }
+                @{ InputString = 'ab';          WildcardString = 'abc*';        ExpectedRegex = '^abc.*$';      ExpectedResult = $false }
+                @{ InputString = 'abcd';        WildcardString = '*[b]*';       ExpectedRegex = '^.*[b].*$';    ExpectedResult = $true }
+                @{ InputString = 'abcd';        WildcardString = '*[b-z]*';     ExpectedRegex = '^.*[b-z].*$';  ExpectedResult = $true }
+            ) {
+            InModuleScope -ModuleName 'PowerNetbox' -Parameters @{ WildcardString = $WildcardString; InputString = $InputString; ExpectedRegex = $ExpectedRegex; ExpectedResult = $ExpectedResult } {
+                $likeResult = $InputString -like $WildcardString
+                $likeResult | Should -Be $ExpectedResult -Because 'Wildcard comparison should return expected result'
+                $converted = Convert-PSWildcardToRegex -String $WildcardString
+                $converted | Should -BeExactly $ExpectedRegex -Because 'Converted regex should match expected regex'
+                $convertedResult = $InputString -match $converted
+                $convertedResult | Should -Be $ExpectedResult -Because 'Converted regex should return expected result'
+            }
+        }
+    }
+
     Context "Building URIBuilder" {
         BeforeAll {
             # Configure the module's NetboxConfig since BuildNewURI now reads from it directly

--- a/Tests/Integration.Tests.ps1
+++ b/Tests/Integration.Tests.ps1
@@ -1506,11 +1506,13 @@ Describe "Live Integration Tests" -Tag 'Integration', 'Live' -Skip:(-not $script
         }
         Context "Query Options" {
             BeforeAll {
-                # Reset query options to defaults
+                # NOTE: Set-ItResult is NOT allowed here -- in a BeforeAll/AfterAll it fails the whole
+                # Context instead of skipping it. Guard fixture creation with a plain return and let each
+                # It block call Set-ItResult -Skipped itself (Netbox < 4.4 has no __ie/__regex lookups).
                 if ($null -eq $Script:QueryWildcardSupport.UsedVersion) {
-                    Set-ItResult -Skipped -Because 'Case-insensitive (__ie) query support requires Netbox 4.4+ and is tested to work up to 4.6.x'
                     return
                 }
+                # Reset query options to defaults
                 $savedQueryOption = Get-NBQueryOption
                 $null = Set-NBQueryOption -IgnoreCase:$false
                 $null = Set-NBQueryOption -MatchMode 'Exact'
@@ -1529,9 +1531,8 @@ Describe "Live Integration Tests" -Tag 'Integration', 'Live' -Skip:(-not $script
                 }
             }
             AfterAll {
-                # Cleanup: delete contacts created for query option tests
+                # Cleanup: delete contacts created for query option tests (nothing was created below 4.4)
                 if ($null -eq $Script:QueryWildcardSupport.UsedVersion) {
-                    Set-ItResult -Skipped -Because 'Case-insensitive (__ie) query support requires Netbox 4.4+ and is tested to work up to 4.6.x'
                     return
                 }
                 foreach ($contactInfo in $Script:QueryOptionContacts) {
@@ -1648,7 +1649,7 @@ Describe "Live Integration Tests" -Tag 'Integration', 'Live' -Skip:(-not $script
         }
 
         It "Should get contact assignment by Object_Type" {
-            $assignment = Get-NBContactAssignment -Object_Type 'dcim.site' -Verbose
+            $assignment = Get-NBContactAssignment -Object_Type 'dcim.site'
 
             $assignment | Should -Not -BeNullOrEmpty
             $assignment.id | Should -Be $script:TestContactAssignmentId

--- a/Tests/Integration.Tests.ps1
+++ b/Tests/Integration.Tests.ps1
@@ -1430,6 +1430,7 @@ Describe "Live Integration Tests" -Tag 'Integration', 'Live' -Skip:(-not $script
                 $Script:TestContactGroup2Id = $null
             }
             $null = Set-NBQueryOption -IgnoreCase:$false
+            $null = Set-NBQueryOption -MatchMode 'Exact'
         }
 
         It "Should create a contact" {
@@ -1516,6 +1517,58 @@ Describe "Live Integration Tests" -Tag 'Integration', 'Live' -Skip:(-not $script
             $contact.id | Should -Be $script:TestContactId
             $contact.name | Should -Be $script:TestContactName
         }
+        It "Should find contact name using case-insensitive search using regex" {
+            # Case-insensitive (__ie) query support requires Netbox 4.4+. On 4.3.x
+            # Set-NBQueryOption -IgnoreCase safely no-ops (warns), so an upper-cased
+            # search would not match -- skip rather than assert case-insensitivity.
+            $nbVersionString = (Get-NBVersion).'netbox-version'
+            if ($nbVersionString -notmatch '^\d+\.\d+' -or [version]($nbVersionString -replace '-.*$') -lt [version]'4.4.0') {
+                Set-ItResult -Skipped -Because 'Case-insensitive (__iregex) query support requires Netbox 4.4+'
+                return
+            }
+            $null = Set-NBQueryOption -IgnoreCase
+            $null = Set-NBQueryOption -MatchMode 'Regex'
+            $contact = Get-NBContact -Name ".*-contact$"
+
+            $contact | Should -Not -BeNullOrEmpty
+            $contact.id | Should -Be $script:TestContactId
+            $contact.name | Should -Be $script:TestContactName
+        }
+        It "Should find contact name using case-sensitive search using regex" {
+            # Case-insensitive (__ie) query support requires Netbox 4.4+. On 4.3.x
+            # Set-NBQueryOption -IgnoreCase safely no-ops (warns), so an upper-cased
+            # search would not match -- skip rather than assert case-insensitivity.
+            $nbVersionString = (Get-NBVersion).'netbox-version'
+            if ($nbVersionString -notmatch '^\d+\.\d+' -or [version]($nbVersionString -replace '-.*$') -lt [version]'4.4.0') {
+                Set-ItResult -Skipped -Because 'Case-sensitive (__regex) query support requires Netbox 4.4+'
+                return
+            }
+            $null = Set-NBQueryOption -IgnoreCase:$false
+            $null = Set-NBQueryOption -MatchMode 'Regex'
+            $contact = Get-NBContact -Name ".*-contact$"
+            $contact | Should -BeNullOrEmpty -Because "-contact is lower-case, and the contact name ends with -Contact (upper-case C), so a case-sensitive regex should not match"
+
+            $contact = Get-NBContact -Name ".*-Contact$"
+            $contact | Should -Not -BeNullOrEmpty -Because ".*-Contact$ and case insensitive regex should match *-Contact"
+            $contact.id | Should -Be $script:TestContactId
+            $contact.name | Should -Be $script:TestContactName
+        }
+        It "Should find contact name using case-insensitive search using wildcard" {
+            # Case-insensitive (__ie) query support requires Netbox 4.4+. On 4.3.x
+            # Set-NBQueryOption -IgnoreCase safely no-ops (warns), so an upper-cased
+            # search would not match -- skip rather than assert case-insensitivity.
+            $nbVersionString = (Get-NBVersion).'netbox-version'
+            if ($nbVersionString -notmatch '^\d+\.\d+' -or [version]($nbVersionString -replace '-.*$') -lt [version]'4.4.0') {
+                Set-ItResult -Skipped -Because 'Case-insensitive (__iregex) query support requires Netbox 4.4+'
+                return
+            }
+            $null = Set-NBQueryOption -IgnoreCase:$true
+            $null = Set-NBQueryOption -MatchMode 'Wildcard'
+            $contact = Get-NBContact -Name "*-contact"
+            $contact | Should -Not -BeNullOrEmpty -Because ".*-Contact$ and case insensitive regex should match *-Contact"
+            $contact.id | Should -Be $script:TestContactId
+            $contact.name | Should -Be $script:TestContactName
+        }
     }
 
     Context "Contact Assignment CRUD" {
@@ -1529,14 +1582,28 @@ Describe "Live Integration Tests" -Tag 'Integration', 'Live' -Skip:(-not $script
             $assignmentSite = New-NBDCIMSite -Name $script:AssignmentSiteName -Slug $script:AssignmentSiteSlug -Status 'active'
             $script:AssignmentSiteId = $assignmentSite.id
             [void]$script:CreatedResources.Sites.Add($assignmentSite.id)
+
+            $script:TestContactAssignmentContactRoleName = "$($script:TestPrefix)-AssignmentContactRole"
+            $script:TestContactAssignmentContactRoleSlug = $script:TestContactAssignmentContactRoleName.ToLower() -replace '[^a-z0-9-]', '-'
+
+            $role = New-NBContactRole -Name $script:TestContactAssignmentContactRoleName -Slug $script:TestContactAssignmentContactRoleSlug
+            $script:TestContactAssignmentContactRoleId = $role.id
+            [void]$script:CreatedResources.ContactRoles.Add($role.id)
+
+            $Script:TestContactAssignmentContactName = "$($script:TestPrefix)-AssignmentContact"
+            $script:TestContactAssignmentContactSlug = $Script:TestContactAssignmentContactName.ToLower() -replace '[^a-z0-9-]', '-'
+
+            $contact = New-NBContact -Name $Script:TestContactAssignmentContactName
+            $script:TestContactAssignmentContactId = $contact.id
+            [void]$script:CreatedResources.Contacts.Add($contact.id)
         }
 
         It "Should create a contact assignment to a site" {
-            $assignment = New-NBContactAssignment -Object_Type 'dcim.site' -Object_Id $script:AssignmentSiteId -Contact $script:TestContactId -Role $script:TestContactRoleId
+            $assignment = New-NBContactAssignment -Object_Type 'dcim.site' -Object_Id $script:AssignmentSiteId -Contact $script:TestContactAssignmentContactId -Role $script:TestContactAssignmentContactRoleId
 
             $assignment | Should -Not -BeNullOrEmpty
-            $assignment.contact.id | Should -Be $script:TestContactId
-            $assignment.role.id | Should -Be $script:TestContactRoleId
+            $assignment.contact.id | Should -Be $script:TestContactAssignmentContactId
+            $assignment.role.id | Should -Be $script:TestContactAssignmentContactRoleId
             $assignment.priority | Should -BeNullOrEmpty
 
             $script:TestContactAssignmentId = $assignment.id
@@ -1550,17 +1617,17 @@ Describe "Live Integration Tests" -Tag 'Integration', 'Live' -Skip:(-not $script
 
             $assignment | Should -Not -BeNullOrEmpty
             $assignment.id | Should -Be $script:TestContactAssignmentId
-            $assignment.contact.id | Should -Be $script:TestContactId
-            $assignment.role.id | Should -Be $script:TestContactRoleId
+            $assignment.contact.id | Should -Be $script:TestContactAssignmentContactId
+            $assignment.role.id | Should -Be $script:TestContactAssignmentContactRoleId
         }
 
         It "Should get contact assignment by Contact_ID" {
-            $assignment = Get-NBContactAssignment -Contact_Id $script:TestContactId
+            $assignment = Get-NBContactAssignment -Contact_Id $script:TestContactAssignmentContactId
 
             $assignment | Should -Not -BeNullOrEmpty
             $assignment.id | Should -Be $script:TestContactAssignmentId
-            $assignment.contact.id | Should -Be $script:TestContactId
-            $assignment.role.id | Should -Be $script:TestContactRoleId
+            $assignment.contact.id | Should -Be $script:TestContactAssignmentContactId
+            $assignment.role.id | Should -Be $script:TestContactAssignmentContactRoleId
         }
 
         It "Should get contact assignment by Object_ID" {
@@ -1568,8 +1635,8 @@ Describe "Live Integration Tests" -Tag 'Integration', 'Live' -Skip:(-not $script
 
             $assignment | Should -Not -BeNullOrEmpty
             $assignment.id | Should -Be $script:TestContactAssignmentId
-            $assignment.contact.id | Should -Be $script:TestContactId
-            $assignment.role.id | Should -Be $script:TestContactRoleId
+            $assignment.contact.id | Should -Be $script:TestContactAssignmentContactId
+            $assignment.role.id | Should -Be $script:TestContactAssignmentContactRoleId
         }
 
         It "Should get contact assignment by Object_Type_ID" {
@@ -1578,8 +1645,8 @@ Describe "Live Integration Tests" -Tag 'Integration', 'Live' -Skip:(-not $script
 
             $assignment | Should -Not -BeNullOrEmpty
             $assignment.id | Should -Be $script:TestContactAssignmentId
-            $assignment.contact.id | Should -Be $script:TestContactId
-            $assignment.role.id | Should -Be $script:TestContactRoleId
+            $assignment.contact.id | Should -Be $script:TestContactAssignmentContactId
+            $assignment.role.id | Should -Be $script:TestContactAssignmentContactRoleId
         }
 
         It "Should get contact assignment by Object_Type" {
@@ -1587,8 +1654,8 @@ Describe "Live Integration Tests" -Tag 'Integration', 'Live' -Skip:(-not $script
 
             $assignment | Should -Not -BeNullOrEmpty
             $assignment.id | Should -Be $script:TestContactAssignmentId
-            $assignment.contact.id | Should -Be $script:TestContactId
-            $assignment.role.id | Should -Be $script:TestContactRoleId
+            $assignment.contact.id | Should -Be $script:TestContactAssignmentContactId
+            $assignment.role.id | Should -Be $script:TestContactAssignmentContactRoleId
         }
 
         It "Should update contact assignment" {

--- a/Tests/Integration.Tests.ps1
+++ b/Tests/Integration.Tests.ps1
@@ -414,6 +414,11 @@ Describe "Live Integration Tests" -Tag 'Integration', 'Live' -Skip:(-not $script
         }
 
         Write-Host "Test Run ID: $script:TestRunId" -ForegroundColor Cyan
+
+        #control execution of case-insensitive/regex query tests based on API version
+        $Script:QueryWildcardSupport = InModuleScope -ModuleName 'PowerNetbox' {
+             Get-VersionQueryParameterSupport -ShowWarning
+        }
     }
 
     AfterAll {
@@ -1429,8 +1434,6 @@ Describe "Live Integration Tests" -Tag 'Integration', 'Live' -Skip:(-not $script
                 $script:CreatedResources.ContactGroups.Remove($Script:TestContactGroup2Id)
                 $Script:TestContactGroup2Id = $null
             }
-            $null = Set-NBQueryOption -IgnoreCase:$false
-            $null = Set-NBQueryOption -MatchMode 'Exact'
         }
 
         It "Should create a contact" {
@@ -1484,7 +1487,7 @@ Describe "Live Integration Tests" -Tag 'Integration', 'Live' -Skip:(-not $script
 
         It "Should find two contacts in the same group" {
             # create contact
-            $contact2 = New-NBContact -Name "$($script:TestPrefix)-GroupContact2" -Group_Id $Script:TestContactGroup2Id
+            $contact2 = New-NBContact -Name "$($script:TestPrefix)-GroupContact2" -Group_Id $Script:TestContactGroup2Id -Title 'Test contact created for group search and query option tests'
             [void]$script:CreatedResources.Contacts.Add($contact2.id)
 
             $group = Get-NBContactGroup -Id $Script:TestContactGroup2Id
@@ -1501,73 +1504,68 @@ Describe "Live Integration Tests" -Tag 'Integration', 'Live' -Skip:(-not $script
             { Remove-NBContact -Id $contact2.id -Confirm:$false  } | Should -Not -Throw
             $script:CreatedResources.Contacts.Remove($contact2.id)
         }
-        It "Should find contact name using case-insensitive search" {
-            # Case-insensitive (__ie) query support requires Netbox 4.4+. On 4.3.x
-            # Set-NBQueryOption -IgnoreCase safely no-ops (warns), so an upper-cased
-            # search would not match -- skip rather than assert case-insensitivity.
-            $nbVersionString = (Get-NBVersion).'netbox-version'
-            if ($nbVersionString -notmatch '^\d+\.\d+' -or [version]($nbVersionString -replace '-.*$') -lt [version]'4.4.0') {
-                Set-ItResult -Skipped -Because 'Case-insensitive (__ie) query support requires Netbox 4.4+'
-                return
-            }
-            $null = Set-NBQueryOption -IgnoreCase
-            $contact = Get-NBContact -Name $script:TestContactName.ToUpper()
+        Context "Query Options" {
+            BeforeAll {
+                # Reset query options to defaults
+                if ($null -eq $Script:QueryWildcardSupport.UsedVersion) {
+                    Set-ItResult -Skipped -Because 'Case-insensitive (__ie) query support requires Netbox 4.4+ and is tested to work up to 4.6.x'
+                    return
+                }
+                $savedQueryOption = Get-NBQueryOption
+                $null = Set-NBQueryOption -IgnoreCase:$false
+                $null = Set-NBQueryOption -MatchMode 'Exact'
 
-            $contact | Should -Not -BeNullOrEmpty
-            $contact.id | Should -Be $script:TestContactId
-            $contact.name | Should -Be $script:TestContactName
-        }
-        It "Should find contact name using case-insensitive search using regex" {
-            # Case-insensitive (__ie) query support requires Netbox 4.4+. On 4.3.x
-            # Set-NBQueryOption -IgnoreCase safely no-ops (warns), so an upper-cased
-            # search would not match -- skip rather than assert case-insensitivity.
-            $nbVersionString = (Get-NBVersion).'netbox-version'
-            if ($nbVersionString -notmatch '^\d+\.\d+' -or [version]($nbVersionString -replace '-.*$') -lt [version]'4.4.0') {
-                Set-ItResult -Skipped -Because 'Case-insensitive (__iregex) query support requires Netbox 4.4+'
-                return
+                # create contacts for exact these tests
+                $Script:QueryOptionContacts = @(
+                    @{ Id = $null; Name = "$($script:TestPrefix)-QueryOptionContact"; Title = 'Test contact' }
+                    @{ Id = $null; Name = "$($script:TestPrefix)-QueryOptionContact2"; Title = 'Test contact 2' }
+                    @{ Id = $null; Name = "$($script:TestPrefix)-QueryOptionContact3"; Title = 'Test contact 3' }
+                )
+                foreach ($contactInfo in $Script:QueryOptionContacts) {
+                    Write-Host "    Creating contact for query option tests: $($contactInfo.Name) with title '$($contactInfo.Title)'" -ForegroundColor Green
+                    $contact = New-NBContact -Name $contactInfo.Name -Title $contactInfo.Title
+                    [void]$script:CreatedResources.Contacts.Add($contact.id)
+                    $contactInfo.Id = $contact.id
+                }
             }
-            $null = Set-NBQueryOption -IgnoreCase
-            $null = Set-NBQueryOption -MatchMode 'Regex'
-            $contact = Get-NBContact -Name ".*-contact$"
+            AfterAll {
+                # Cleanup: delete contacts created for query option tests
+                if ($null -eq $Script:QueryWildcardSupport.UsedVersion) {
+                    Set-ItResult -Skipped -Because 'Case-insensitive (__ie) query support requires Netbox 4.4+ and is tested to work up to 4.6.x'
+                    return
+                }
+                foreach ($contactInfo in $Script:QueryOptionContacts) {
+                    Remove-NBContact -Id $contactInfo.Id -Confirm:$false -ErrorAction SilentlyContinue
+                    [void]$script:CreatedResources.Contacts.Remove($contactInfo.Id)
+                }
+                $Script:QueryOptionContacts = @()
 
-            $contact | Should -Not -BeNullOrEmpty
-            $contact.id | Should -Be $script:TestContactId
-            $contact.name | Should -Be $script:TestContactName
-        }
-        It "Should find contact name using case-sensitive search using regex" {
-            # Case-insensitive (__ie) query support requires Netbox 4.4+. On 4.3.x
-            # Set-NBQueryOption -IgnoreCase safely no-ops (warns), so an upper-cased
-            # search would not match -- skip rather than assert case-insensitivity.
-            $nbVersionString = (Get-NBVersion).'netbox-version'
-            if ($nbVersionString -notmatch '^\d+\.\d+' -or [version]($nbVersionString -replace '-.*$') -lt [version]'4.4.0') {
-                Set-ItResult -Skipped -Because 'Case-sensitive (__regex) query support requires Netbox 4.4+'
-                return
+                # Restore query options to their original values
+                $null = Set-NBQueryOption -IgnoreCase:$savedQueryOption[0].Value
+                $null = Set-NBQueryOption -MatchMode $savedQueryOption[1].Value
             }
-            $null = Set-NBQueryOption -IgnoreCase:$false
-            $null = Set-NBQueryOption -MatchMode 'Regex'
-            $contact = Get-NBContact -Name ".*-contact$"
-            $contact | Should -BeNullOrEmpty -Because "-contact is lower-case, and the contact name ends with -Contact (upper-case C), so a case-sensitive regex should not match"
+            It "IgnoreCase $<IgnoreCase> + MatchMode <MatchMode>: <searchString> should find <expectedCount> contact(s)" -ForEach @(
+                @{ searchString = 'Test contact';      expectedCount = 1;  IgnoreCase = $false;    MatchMode = 'Exact   ' }
+                @{ searchString = 'Test contact';      expectedCount = 1;  IgnoreCase = $false;    MatchMode = 'Wildcard' }     # resolves to '^Test contact$' => 1 match
+                @{ searchString = 'Test contact';      expectedCount = 3;  IgnoreCase = $false;    MatchMode = 'Regex   ' }     # regex match hits substrings => 3 matches
+                @{ searchString = 'test contact';      expectedCount = 0;  IgnoreCase = $false;    MatchMode = 'Exact   ' }
+                @{ searchString = '*test contact*';    expectedCount = 0;  IgnoreCase = $false;    MatchMode = 'Wildcard' }
+                @{ searchString = '.*test contact.*';  expectedCount = 0;  IgnoreCase = $false;    MatchMode = 'Regex   ' }
+                @{ searchString = 'test contact';      expectedCount = 1;  IgnoreCase = $true;     MatchMode = 'Exact   ' }
+                @{ searchString = '*test contact*';    expectedCount = 3;  IgnoreCase = $true;     MatchMode = 'Wildcard' }
+                @{ searchString = '.*test contact.*';  expectedCount = 3;  IgnoreCase = $true;     MatchMode = 'Regex   ' }
+            ) {
+                if ($null -eq $Script:QueryWildcardSupport.UsedVersion) {
+                    Set-ItResult -Skipped -Because 'Case-insensitive (__ie) query support requires Netbox 4.4+ and is tested to work up to 4.6.x'
+                    return
+                }
 
-            $contact = Get-NBContact -Name ".*-Contact$"
-            $contact | Should -Not -BeNullOrEmpty -Because ".*-Contact$ and case insensitive regex should match *-Contact"
-            $contact.id | Should -Be $script:TestContactId
-            $contact.name | Should -Be $script:TestContactName
-        }
-        It "Should find contact name using case-insensitive search using wildcard" {
-            # Case-insensitive (__ie) query support requires Netbox 4.4+. On 4.3.x
-            # Set-NBQueryOption -IgnoreCase safely no-ops (warns), so an upper-cased
-            # search would not match -- skip rather than assert case-insensitivity.
-            $nbVersionString = (Get-NBVersion).'netbox-version'
-            if ($nbVersionString -notmatch '^\d+\.\d+' -or [version]($nbVersionString -replace '-.*$') -lt [version]'4.4.0') {
-                Set-ItResult -Skipped -Because 'Case-insensitive (__iregex) query support requires Netbox 4.4+'
-                return
+                $null = Set-NBQueryOption -IgnoreCase:$IgnoreCase
+                $null = Set-NBQueryOption -MatchMode $MatchMode.Trim()
+                $contact = Get-NBContact -Title $searchString
+
+                $contact | Should -HaveCount $expectedCount
             }
-            $null = Set-NBQueryOption -IgnoreCase:$true
-            $null = Set-NBQueryOption -MatchMode 'Wildcard'
-            $contact = Get-NBContact -Name "*-contact"
-            $contact | Should -Not -BeNullOrEmpty -Because ".*-Contact$ and case insensitive regex should match *-Contact"
-            $contact.id | Should -Be $script:TestContactId
-            $contact.name | Should -Be $script:TestContactName
         }
     }
 
@@ -1650,7 +1648,7 @@ Describe "Live Integration Tests" -Tag 'Integration', 'Live' -Skip:(-not $script
         }
 
         It "Should get contact assignment by Object_Type" {
-            $assignment = Get-NBContactAssignment -Object_Type 'dcim.site'
+            $assignment = Get-NBContactAssignment -Object_Type 'dcim.site' -Verbose
 
             $assignment | Should -Not -BeNullOrEmpty
             $assignment.id | Should -Be $script:TestContactAssignmentId

--- a/Tests/Setup.Tests.ps1
+++ b/Tests/Setup.Tests.ps1
@@ -314,7 +314,7 @@ Describe "Setup tests" -Tag 'Core', 'Setup' {
                 { Set-NBQueryOption -IgnoreCase:$true } | Should -Throw "Not connected*"
                 { Set-NBQueryOption -MatchMode 'Wildcard' } | Should -Throw "Not connected*"
             }
-            It "Should call Set-NBQueryOption inside Connect-NBAPI" {
+            It "Should call Set-NBQueryOption inside Connect-NBAPI (default parameters)" {
                 Mock -CommandName 'Set-NBQueryOption' -ModuleName 'PowerNetbox' -MockWith { return $true } -ParameterFilter { $IgnoreCase -eq $false } -Verifiable
                 Mock -CommandName 'Set-NBQueryOption' -ModuleName 'PowerNetbox' -MockWith { return $true } -ParameterFilter { $MatchMode -eq 'Exact' } -Verifiable
                 Mock -CommandName 'Set-NBQueryOption' -ModuleName 'PowerNetbox' -MockWith { Throw "Should not be called" }
@@ -322,11 +322,27 @@ Describe "Setup tests" -Tag 'Core', 'Setup' {
                 Assert-MockCalled -CommandName 'Set-NBQueryOption' -ModuleName 'PowerNetbox' -Times 2
                 $null = Get-NbQueryOption
             }
-            It "Should call Set-NBQueryOption inside Connect-NBAPI" {
-                Mock -CommandName 'Set-NBQueryOption' -ModuleName 'PowerNetbox' -MockWith { Throw "Should not be called" } -ParameterFilter { $IgnoreCase -eq $false -or $MatchMode -ne 'Exact' }
+            It "Should call Set-NBQueryOption inside Connect-NBAPI (both parameters set)" {
+                Mock -CommandName 'Set-NBQueryOption' -ModuleName 'PowerNetbox' -MockWith { Throw "Should not be called" } -ParameterFilter { $IgnoreCase -eq $false -or $MatchMode -ne 'Regex' }
                 Mock -CommandName 'Set-NBQueryOption' -ModuleName 'PowerNetbox' -MockWith { return $true } -ParameterFilter { $IgnoreCase -eq $true } -Verifiable
                 Mock -CommandName 'Set-NBQueryOption' -ModuleName 'PowerNetbox' -MockWith { return $true } -ParameterFilter { $MatchMode -eq 'Regex' } -Verifiable
                 Connect-NBAPI -Hostname 'netbox.domain.local' -Scheme 'https' -Port 443 -IgnoreCase -MatchMode 'Regex'
+                Assert-MockCalled -CommandName 'Set-NBQueryOption' -ModuleName 'PowerNetbox' -Times 2
+                $null = Get-NbQueryOption
+            }
+            It "Should call Set-NBQueryOption inside Connect-NBAPI (Ignorecase set)" {
+                Mock -CommandName 'Set-NBQueryOption' -ModuleName 'PowerNetbox' -MockWith { Throw "Should not be called" } -ParameterFilter { $IgnoreCase -eq $false -or $MatchMode -ne 'Exact' }
+                Mock -CommandName 'Set-NBQueryOption' -ModuleName 'PowerNetbox' -MockWith { return $true } -ParameterFilter { $IgnoreCase -eq $true } -Verifiable
+                Mock -CommandName 'Set-NBQueryOption' -ModuleName 'PowerNetbox' -MockWith { return $true } -ParameterFilter { $MatchMode -eq 'Exact' } -Verifiable
+                Connect-NBAPI -Hostname 'netbox.domain.local' -Scheme 'https' -Port 443 -IgnoreCase
+                Assert-MockCalled -CommandName 'Set-NBQueryOption' -ModuleName 'PowerNetbox' -Times 2
+                $null = Get-NbQueryOption
+            }
+            It "Should call Set-NBQueryOption inside Connect-NBAPI (MatchMode set)" {
+                Mock -CommandName 'Set-NBQueryOption' -ModuleName 'PowerNetbox' -MockWith { Throw "Should not be called" } -ParameterFilter { $IgnoreCase -eq $true -or $MatchMode -ne 'Wildcard' }
+                Mock -CommandName 'Set-NBQueryOption' -ModuleName 'PowerNetbox' -MockWith { return $true } -ParameterFilter { $IgnoreCase -eq $false } -Verifiable
+                Mock -CommandName 'Set-NBQueryOption' -ModuleName 'PowerNetbox' -MockWith { return $true } -ParameterFilter { $MatchMode -eq 'Wildcard' } -Verifiable
+                Connect-NBAPI -Hostname 'netbox.domain.local' -Scheme 'https' -Port 443 -MatchMode 'Wildcard'
                 Assert-MockCalled -CommandName 'Set-NBQueryOption' -ModuleName 'PowerNetbox' -Times 2
                 $null = Get-NbQueryOption
             }

--- a/Tests/Setup.Tests.ps1
+++ b/Tests/Setup.Tests.ps1
@@ -361,7 +361,7 @@ Describe "Setup tests" -Tag 'Core', 'Setup' {
                     # Check internal state is also reset
                     $script:NetboxConfig.IgnoreCaseInQueries | Should -Be $false
                     $Script:NetboxConfig.MatchMode | Should -Be 'Exact'
-                    ($Script:IgnoreCaseParameterHash.Keys).Count | Should -Be 0
+                    ($Script:QueryParameterHash.Keys).Count | Should -Be 0
                 }
             }
             It "Should set and get query option MatchMode" {
@@ -388,7 +388,7 @@ Describe "Setup tests" -Tag 'Core', 'Setup' {
                     # Check internal state is also reset
                     $script:NetboxConfig.MatchMode | Should -Be 'Exact'
                     $script:NetboxConfig.IgnoreCaseInQueries | Should -Be $false
-                    ($Script:IgnoreCaseParameterHash.Keys).Count | Should -Be 0
+                    ($Script:QueryParameterHash.Keys).Count | Should -Be 0
                 }
             }
             It "For API v3.0.0 should not use any case-insensitive parameters" {
@@ -396,28 +396,28 @@ Describe "Setup tests" -Tag 'Core', 'Setup' {
                     $script:NetboxConfig.ParsedVersion = '3.0.0'
                     $ret = Set-NBQueryOption -IgnoreCase -WarningAction SilentlyContinue -WarningVariable warn
                     $warn | Should -BeLike '*less than the minimum supported version*'
-                    $Script:IgnoreCaseParameterHash.Keys.Count | Should -Be 0
+                    $Script:QueryParameterHash.Keys.Count | Should -Be 0
                 }
             }
             It "For API version < 4.5.0 should use the baseline + v4.4.9 list" {
                 InModuleScope -ModuleName 'PowerNetbox' {
                     $script:NetboxConfig.ParsedVersion = '4.4.8'          # 4.4.9 is the first baseline version, 4.4.8 is less than that, but we only use <major>.<minor> => 4.4. is defined
                     $ret = Set-NBQueryOption -IgnoreCase
-                    $Script:IgnoreCaseParameterHash.Keys.Count | Should -BeExactly ($Script:IgnoreCaseParameterBaseline.Count + $Script:IgnoreCaseParameterV449.Count)
+                    $Script:QueryParameterHash.Keys.Count | Should -BeExactly ($Script:IgnoreCaseParameterBaseline.Count + $Script:IgnoreCaseParameterV449.Count)
                 }
             }
             It "For API version >= 4.5.0 and < 4.6.0 should use the baseline + v4.5.0 list" {
                 InModuleScope -ModuleName 'PowerNetbox' {
                     $script:NetboxConfig.ParsedVersion = '4.5.0'
                     $ret = Set-NBQueryOption -IgnoreCase
-                    $Script:IgnoreCaseParameterHash.Keys.Count | Should -BeExactly ($Script:IgnoreCaseParameterBaseline.Count + $Script:IgnoreCaseParameterV450.Count)
+                    $Script:QueryParameterHash.Keys.Count | Should -BeExactly ($Script:IgnoreCaseParameterBaseline.Count + $Script:IgnoreCaseParameterV450.Count)
                 }
             }
             It "For API version >= 4.6.0 should use the baseline + v4.6.1 list" {
                 InModuleScope -ModuleName 'PowerNetbox' {
                     $script:NetboxConfig.ParsedVersion = '4.6.0'
                     $ret = Set-NBQueryOption -IgnoreCase
-                    $Script:IgnoreCaseParameterHash.Keys.Count | Should -BeExactly ($Script:IgnoreCaseParameterBaseline.Count + $Script:IgnoreCaseParameterV461.Count)
+                    $Script:QueryParameterHash.Keys.Count | Should -BeExactly ($Script:IgnoreCaseParameterBaseline.Count + $Script:IgnoreCaseParameterV461.Count)
                 }
             }
             It "For API versions newer than our last known version, it should use the latest known version" {
@@ -425,7 +425,7 @@ Describe "Setup tests" -Tag 'Core', 'Setup' {
                     $script:NetboxConfig.ParsedVersion = '99.99.99'
                     $ret = Set-NBQueryOption -IgnoreCase -WarningAction SilentlyContinue -WarningVariable warn
                     $warn | Should -BeLike '*taking the latest known version*'
-                    $Script:IgnoreCaseParameterHash.Keys.Count | Should -BeExactly ($Script:IgnoreCaseParameterBaseline.Count + $Script:IgnoreCaseParameterV461.Count)
+                    $Script:QueryParameterHash.Keys.Count | Should -BeExactly ($Script:IgnoreCaseParameterBaseline.Count + $Script:IgnoreCaseParameterV461.Count)
                 }
             }
         }

--- a/Tests/Setup.Tests.ps1
+++ b/Tests/Setup.Tests.ps1
@@ -304,14 +304,6 @@ Describe "Setup tests" -Tag 'Core', 'Setup' {
             $fakeCredential = [PSCredential]::new('notapplicable', (ConvertTo-SecureString -String "faketoken" -AsPlainText -Force))
             Set-NBCredential -Credential $fakeCredential | Out-Null
         }
-        AfterAll {
-            # Reset the query option to its previous state
-            Set-NBQueryOption -IgnoreCase:$ignoreCaseBefore.Value | Out-Null
-            Set-NBQueryOption -MatchMode:$matchModeBefore.Value | Out-Null
-            InModuleScope -ModuleName 'PowerNetbox' {
-                $script:NetboxConfig.ParsedVersion = $parsedVersionBefore
-            }
-        }
         Context "While not connected" {
             It "Should return the current query option" {
                 $result = Get-NbQueryOption
@@ -344,6 +336,16 @@ Describe "Setup tests" -Tag 'Core', 'Setup' {
                 # calling the real connect function here, but having mocked the internal request in the context of this Describe
                 Connect-NBAPI -Hostname 'netbox.domain.local' -Scheme 'https' -Port 443
             }
+            AfterAll {
+                # Reset the query option to its previous state
+                InModuleScope -ModuleName 'PowerNetbox' -Parameters @{ IgnoreCase = $ignoreCaseBefore.Value; MatchMode = $matchModeBefore.Value; ParsedVersion = $parsedVersionBefore } {
+                    $Script:NetboxConfig.IgnoreCaseInQueries = $IgnoreCase
+                    $Script:NetboxConfig.MatchMode = $MatchMode
+                    $Script:QueryParameterDecoration = ''
+                    $Script:QueryParameterHash = @{}
+                    $script:NetboxConfig.ParsedVersion = $ParsedVersion
+                }
+            }
 
             It "Should set and get query option IgnoreCase" {
                 Set-NBQueryOption -IgnoreCase:$true | Should -Be $true
@@ -352,6 +354,7 @@ Describe "Setup tests" -Tag 'Core', 'Setup' {
                 InModuleScope -ModuleName 'PowerNetbox' {
                     $script:NetboxConfig.IgnoreCaseInQueries | Should -Be $true
                     $Script:NetboxConfig.MatchMode | Should -Be 'Exact'
+                    $script:QueryParameterDecoration | Should -Be '__ie'
                 }
 
                 Set-NBQueryOption -IgnoreCase:$false | Should -Be $false
@@ -361,6 +364,7 @@ Describe "Setup tests" -Tag 'Core', 'Setup' {
                     # Check internal state is also reset
                     $script:NetboxConfig.IgnoreCaseInQueries | Should -Be $false
                     $Script:NetboxConfig.MatchMode | Should -Be 'Exact'
+                    $script:QueryParameterDecoration | Should -Be ''
                     ($Script:QueryParameterHash.Keys).Count | Should -Be 0
                 }
             }
@@ -371,6 +375,7 @@ Describe "Setup tests" -Tag 'Core', 'Setup' {
                 InModuleScope -ModuleName 'PowerNetbox' {
                     $script:NetboxConfig.MatchMode | Should -Be 'Wildcard'
                     $script:NetboxConfig.IgnoreCaseInQueries | Should -Be $false
+                    $script:QueryParameterDecoration | Should -Be '__regex'
                 }
 
                 Set-NBQueryOption -MatchMode 'Regex' | Should -Be 'Regex'
@@ -379,6 +384,7 @@ Describe "Setup tests" -Tag 'Core', 'Setup' {
                 InModuleScope -ModuleName 'PowerNetbox' {
                     $script:NetboxConfig.MatchMode | Should -Be 'Regex'
                     $script:NetboxConfig.IgnoreCaseInQueries | Should -Be $false
+                    $script:QueryParameterDecoration | Should -Be '__regex'
                 }
 
                 Set-NBQueryOption -MatchMode 'Exact' | Should -Be 'Exact'
@@ -388,6 +394,7 @@ Describe "Setup tests" -Tag 'Core', 'Setup' {
                     # Check internal state is also reset
                     $script:NetboxConfig.MatchMode | Should -Be 'Exact'
                     $script:NetboxConfig.IgnoreCaseInQueries | Should -Be $false
+                    $script:QueryParameterDecoration | Should -Be ''
                     ($Script:QueryParameterHash.Keys).Count | Should -Be 0
                 }
             }

--- a/Tests/Setup.Tests.ps1
+++ b/Tests/Setup.Tests.ps1
@@ -319,7 +319,7 @@ Describe "Setup tests" -Tag 'Core', 'Setup' {
                 Mock -CommandName 'Set-NBQueryOption' -ModuleName 'PowerNetbox' -MockWith { return $true } -ParameterFilter { $MatchMode -eq 'Exact' } -Verifiable
                 Mock -CommandName 'Set-NBQueryOption' -ModuleName 'PowerNetbox' -MockWith { Throw "Should not be called" }
                 Connect-NBAPI -Hostname 'netbox.domain.local' -Scheme 'https' -Port 443
-                Assert-MockCalled -CommandName 'Set-NBQueryOption' -ModuleName 'PowerNetbox' -Times 2
+                Should -Invoke -CommandName 'Set-NBQueryOption' -ModuleName 'PowerNetbox' -Times 2 -Exactly
                 $null = Get-NbQueryOption
             }
             It "Should call Set-NBQueryOption inside Connect-NBAPI (both parameters set)" {
@@ -327,7 +327,7 @@ Describe "Setup tests" -Tag 'Core', 'Setup' {
                 Mock -CommandName 'Set-NBQueryOption' -ModuleName 'PowerNetbox' -MockWith { return $true } -ParameterFilter { $IgnoreCase -eq $true } -Verifiable
                 Mock -CommandName 'Set-NBQueryOption' -ModuleName 'PowerNetbox' -MockWith { return $true } -ParameterFilter { $MatchMode -eq 'Regex' } -Verifiable
                 Connect-NBAPI -Hostname 'netbox.domain.local' -Scheme 'https' -Port 443 -IgnoreCase -MatchMode 'Regex'
-                Assert-MockCalled -CommandName 'Set-NBQueryOption' -ModuleName 'PowerNetbox' -Times 2
+                Should -Invoke -CommandName 'Set-NBQueryOption' -ModuleName 'PowerNetbox' -Times 2 -Exactly
                 $null = Get-NbQueryOption
             }
             It "Should call Set-NBQueryOption inside Connect-NBAPI (Ignorecase set)" {
@@ -335,7 +335,7 @@ Describe "Setup tests" -Tag 'Core', 'Setup' {
                 Mock -CommandName 'Set-NBQueryOption' -ModuleName 'PowerNetbox' -MockWith { return $true } -ParameterFilter { $IgnoreCase -eq $true } -Verifiable
                 Mock -CommandName 'Set-NBQueryOption' -ModuleName 'PowerNetbox' -MockWith { return $true } -ParameterFilter { $MatchMode -eq 'Exact' } -Verifiable
                 Connect-NBAPI -Hostname 'netbox.domain.local' -Scheme 'https' -Port 443 -IgnoreCase
-                Assert-MockCalled -CommandName 'Set-NBQueryOption' -ModuleName 'PowerNetbox' -Times 2
+                Should -Invoke -CommandName 'Set-NBQueryOption' -ModuleName 'PowerNetbox' -Times 2 -Exactly
                 $null = Get-NbQueryOption
             }
             It "Should call Set-NBQueryOption inside Connect-NBAPI (MatchMode set)" {
@@ -343,7 +343,7 @@ Describe "Setup tests" -Tag 'Core', 'Setup' {
                 Mock -CommandName 'Set-NBQueryOption' -ModuleName 'PowerNetbox' -MockWith { return $true } -ParameterFilter { $IgnoreCase -eq $false } -Verifiable
                 Mock -CommandName 'Set-NBQueryOption' -ModuleName 'PowerNetbox' -MockWith { return $true } -ParameterFilter { $MatchMode -eq 'Wildcard' } -Verifiable
                 Connect-NBAPI -Hostname 'netbox.domain.local' -Scheme 'https' -Port 443 -MatchMode 'Wildcard'
-                Assert-MockCalled -CommandName 'Set-NBQueryOption' -ModuleName 'PowerNetbox' -Times 2
+                Should -Invoke -CommandName 'Set-NBQueryOption' -ModuleName 'PowerNetbox' -Times 2 -Exactly
                 $null = Get-NbQueryOption
             }
         }

--- a/Tests/Setup.Tests.ps1
+++ b/Tests/Setup.Tests.ps1
@@ -287,7 +287,8 @@ Describe "Setup tests" -Tag 'Core', 'Setup' {
 
     Context "Query options" {
         BeforeAll {
-            $stateBefore = Get-NBQueryOption | Where-Object { $_.Name -eq 'IgnoreCase' }
+            $ignoreCaseBefore = Get-NBQueryOption | Where-Object { $_.Name -eq 'IgnoreCase' }
+            $matchModeBefore = Get-NBQueryOption | Where-Object { $_.Name -eq 'MatchMode' }
             # We need to set the parsed version to a value for testing, so mocking the connect request
             Mock -CommandName 'InvokeNetboxRequest' -ModuleName 'PowerNetbox' -MockWith {
                 @'
@@ -305,7 +306,8 @@ Describe "Setup tests" -Tag 'Core', 'Setup' {
         }
         AfterAll {
             # Reset the query option to its previous state
-            Set-NBQueryOption -IgnoreCase:$stateBefore.Value | Out-Null
+            Set-NBQueryOption -IgnoreCase:$ignoreCaseBefore.Value | Out-Null
+            Set-NBQueryOption -MatchMode:$matchModeBefore.Value | Out-Null
             InModuleScope -ModuleName 'PowerNetbox' {
                 $script:NetboxConfig.ParsedVersion = $parsedVersionBefore
             }
@@ -314,22 +316,26 @@ Describe "Setup tests" -Tag 'Core', 'Setup' {
             It "Should return the current query option" {
                 $result = Get-NbQueryOption
                 $result.Name | Should -Contain 'IgnoreCase'
+                $result.Name | Should -Contain 'MatchMode'
             }
             It "Should throw if try to set query options, because we need a parsed API version" {
                 { Set-NBQueryOption -IgnoreCase:$true } | Should -Throw "Not connected*"
+                { Set-NBQueryOption -MatchMode 'Wildcard' } | Should -Throw "Not connected*"
             }
             It "Should call Set-NBQueryOption inside Connect-NBAPI" {
                 Mock -CommandName 'Set-NBQueryOption' -ModuleName 'PowerNetbox' -MockWith { return $true } -ParameterFilter { $IgnoreCase -eq $false } -Verifiable
-                Mock -CommandName 'Set-NBQueryOption' -ModuleName 'PowerNetbox' -MockWith { Throw "Should not be called" } -ParameterFilter { $IgnoreCase -eq $true }
+                Mock -CommandName 'Set-NBQueryOption' -ModuleName 'PowerNetbox' -MockWith { return $true } -ParameterFilter { $MatchMode -eq 'Exact' } -Verifiable
+                Mock -CommandName 'Set-NBQueryOption' -ModuleName 'PowerNetbox' -MockWith { Throw "Should not be called" }
                 Connect-NBAPI -Hostname 'netbox.domain.local' -Scheme 'https' -Port 443
-                Assert-MockCalled -CommandName 'Set-NBQueryOption' -ModuleName 'PowerNetbox' -Times 1
+                Assert-MockCalled -CommandName 'Set-NBQueryOption' -ModuleName 'PowerNetbox' -Times 2
                 $null = Get-NbQueryOption
             }
             It "Should call Set-NBQueryOption inside Connect-NBAPI" {
-                Mock -CommandName 'Set-NBQueryOption' -ModuleName 'PowerNetbox' -MockWith { Throw "Should not be called" } -ParameterFilter { $IgnoreCase -eq $false }
+                Mock -CommandName 'Set-NBQueryOption' -ModuleName 'PowerNetbox' -MockWith { Throw "Should not be called" } -ParameterFilter { $IgnoreCase -eq $false -or $MatchMode -ne 'Exact' }
                 Mock -CommandName 'Set-NBQueryOption' -ModuleName 'PowerNetbox' -MockWith { return $true } -ParameterFilter { $IgnoreCase -eq $true } -Verifiable
-                Connect-NBAPI -Hostname 'netbox.domain.local' -Scheme 'https' -Port 443 -IgnoreCase
-                Assert-MockCalled -CommandName 'Set-NBQueryOption' -ModuleName 'PowerNetbox' -Times 1
+                Mock -CommandName 'Set-NBQueryOption' -ModuleName 'PowerNetbox' -MockWith { return $true } -ParameterFilter { $MatchMode -eq 'Regex' } -Verifiable
+                Connect-NBAPI -Hostname 'netbox.domain.local' -Scheme 'https' -Port 443 -IgnoreCase -MatchMode 'Regex'
+                Assert-MockCalled -CommandName 'Set-NBQueryOption' -ModuleName 'PowerNetbox' -Times 2
                 $null = Get-NbQueryOption
             }
         }
@@ -343,16 +349,44 @@ Describe "Setup tests" -Tag 'Core', 'Setup' {
                 Set-NBQueryOption -IgnoreCase:$true | Should -Be $true
                 $options = Get-NbQueryOption
                 $options | Where-Object Name -eq 'IgnoreCase' | Select-Object -ExpandProperty Value | Should -Be $true
-                $optionsInternal = InModuleScope -ModuleName 'PowerNetbox' {
-                    $script:NetboxConfig.IgnoreCaseInQueries
+                InModuleScope -ModuleName 'PowerNetbox' {
+                    $script:NetboxConfig.IgnoreCaseInQueries | Should -Be $true
+                    $Script:NetboxConfig.MatchMode | Should -Be 'Exact'
                 }
-                $optionsInternal | Should -Be $true
 
                 Set-NBQueryOption -IgnoreCase:$false | Should -Be $false
                 $options = Get-NbQueryOption
                 $options | Where-Object Name -eq 'IgnoreCase' | Select-Object -ExpandProperty Value | Should -Be $false
                 InModuleScope -ModuleName 'PowerNetbox' {
                     # Check internal state is also reset
+                    $script:NetboxConfig.IgnoreCaseInQueries | Should -Be $false
+                    $Script:NetboxConfig.MatchMode | Should -Be 'Exact'
+                    ($Script:IgnoreCaseParameterHash.Keys).Count | Should -Be 0
+                }
+            }
+            It "Should set and get query option MatchMode" {
+                Set-NBQueryOption -MatchMode 'Wildcard' | Should -Be 'Wildcard'
+                $options = Get-NbQueryOption
+                $options | Where-Object Name -eq 'MatchMode' | Select-Object -ExpandProperty Value | Should -Be 'Wildcard'
+                InModuleScope -ModuleName 'PowerNetbox' {
+                    $script:NetboxConfig.MatchMode | Should -Be 'Wildcard'
+                    $script:NetboxConfig.IgnoreCaseInQueries | Should -Be $false
+                }
+
+                Set-NBQueryOption -MatchMode 'Regex' | Should -Be 'Regex'
+                $options = Get-NbQueryOption
+                $options | Where-Object Name -eq 'MatchMode' | Select-Object -ExpandProperty Value | Should -Be 'Regex'
+                InModuleScope -ModuleName 'PowerNetbox' {
+                    $script:NetboxConfig.MatchMode | Should -Be 'Regex'
+                    $script:NetboxConfig.IgnoreCaseInQueries | Should -Be $false
+                }
+
+                Set-NBQueryOption -MatchMode 'Exact' | Should -Be 'Exact'
+                $options = Get-NbQueryOption
+                $options | Where-Object Name -eq 'MatchMode' | Select-Object -ExpandProperty Value | Should -Be 'Exact'
+                InModuleScope -ModuleName 'PowerNetbox' {
+                    # Check internal state is also reset
+                    $script:NetboxConfig.MatchMode | Should -Be 'Exact'
                     $script:NetboxConfig.IgnoreCaseInQueries | Should -Be $false
                     ($Script:IgnoreCaseParameterHash.Keys).Count | Should -Be 0
                 }

--- a/Tests/Setup.Tests.ps1
+++ b/Tests/Setup.Tests.ps1
@@ -400,7 +400,7 @@ Describe "Setup tests" -Tag 'Core', 'Setup' {
             }
             It "For API v3.0.0 should not use any case-insensitive parameters" {
                 InModuleScope -ModuleName 'PowerNetbox' {
-                    $script:NetboxConfig.ParsedVersion = '3.0.0'
+                    $script:NetboxConfig.ParsedVersion = [version]'3.0.0'
                     $ret = Set-NBQueryOption -IgnoreCase -WarningAction SilentlyContinue -WarningVariable warn
                     $warn | Should -BeLike '*less than the minimum supported version*'
                     $Script:QueryParameterHash.Keys.Count | Should -Be 0
@@ -408,28 +408,28 @@ Describe "Setup tests" -Tag 'Core', 'Setup' {
             }
             It "For API version < 4.5.0 should use the baseline + v4.4.9 list" {
                 InModuleScope -ModuleName 'PowerNetbox' {
-                    $script:NetboxConfig.ParsedVersion = '4.4.8'          # 4.4.9 is the first baseline version, 4.4.8 is less than that, but we only use <major>.<minor> => 4.4. is defined
+                    $script:NetboxConfig.ParsedVersion = [version]'4.4.8'          # 4.4.9 is the first baseline version, 4.4.8 is less than that, but we only use <major>.<minor> => 4.4. is defined
                     $ret = Set-NBQueryOption -IgnoreCase
                     $Script:QueryParameterHash.Keys.Count | Should -BeExactly ($Script:IgnoreCaseParameterBaseline.Count + $Script:IgnoreCaseParameterV449.Count)
                 }
             }
             It "For API version >= 4.5.0 and < 4.6.0 should use the baseline + v4.5.0 list" {
                 InModuleScope -ModuleName 'PowerNetbox' {
-                    $script:NetboxConfig.ParsedVersion = '4.5.0'
+                    $script:NetboxConfig.ParsedVersion = [version]'4.5.0'
                     $ret = Set-NBQueryOption -IgnoreCase
                     $Script:QueryParameterHash.Keys.Count | Should -BeExactly ($Script:IgnoreCaseParameterBaseline.Count + $Script:IgnoreCaseParameterV450.Count)
                 }
             }
             It "For API version >= 4.6.0 should use the baseline + v4.6.1 list" {
                 InModuleScope -ModuleName 'PowerNetbox' {
-                    $script:NetboxConfig.ParsedVersion = '4.6.0'
+                    $script:NetboxConfig.ParsedVersion = [version]'4.6.0'
                     $ret = Set-NBQueryOption -IgnoreCase
                     $Script:QueryParameterHash.Keys.Count | Should -BeExactly ($Script:IgnoreCaseParameterBaseline.Count + $Script:IgnoreCaseParameterV461.Count)
                 }
             }
             It "For API versions newer than our last known version, it should use the latest known version" {
                 InModuleScope -ModuleName 'PowerNetbox' {
-                    $script:NetboxConfig.ParsedVersion = '99.99.99'
+                    $script:NetboxConfig.ParsedVersion = [version]'99.99.99'
                     $ret = Set-NBQueryOption -IgnoreCase -WarningAction SilentlyContinue -WarningVariable warn
                     $warn | Should -BeLike '*taking the latest known version*'
                     $Script:QueryParameterHash.Keys.Count | Should -BeExactly ($Script:IgnoreCaseParameterBaseline.Count + $Script:IgnoreCaseParameterV461.Count)

--- a/scripts/Verify-QueryParameterHandling.Tests.ps1
+++ b/scripts/Verify-QueryParameterHandling.Tests.ps1
@@ -1,0 +1,166 @@
+#Requires -Version 7
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingConvertToSecureStringWithPlainText", "")]
+param()
+BeforeAll {
+    $saveNetboxHost = $env:NETBOX_HOST
+    $saveNetboxScheme = $env:NETBOX_SCHEME
+    $saveNetboxToken = $env:NETBOX_TOKEN
+    $saveNetboxVersion = $env:NETBOX_VERSION
+
+    $Script:ScriptPath = Join-Path $PSScriptRoot 'Verify-QueryParameterHandling.ps1'
+    $Script:ProjectRoot = Split-Path $Script:ScriptPath -Parent
+
+    $psdPath = Join-Path -Path $Script:ProjectRoot -ChildPath '..' -AdditionalChildPath 'PowerNetbox','PowerNetbox.psd1'
+    Import-Module $psdPath -Force -ErrorAction Stop
+}
+
+AfterAll {
+    $env:NETBOX_HOST = $saveNetboxHost
+    $env:NETBOX_SCHEME = $saveNetboxScheme
+    $env:NETBOX_TOKEN = $saveNetboxToken
+    $env:NETBOX_VERSION = $saveNetboxVersion
+}
+Describe 'Verify-QueryParameterHandling' {
+    Context 'Basic tests' {
+        It 'exists' {
+            Test-Path $Script:ScriptPath | Should -BeTrue
+        }
+
+        It 'Uses the environment variable by default' {
+            Mock Invoke-RestMethod { Throw "This should not happen" }
+            Mock Invoke-RestMethod { Throw "Used expected default parameters" }-ParameterFilter { $uri -eq 'http://localhost/api/schema/?format=json' }
+
+            $env:NETBOX_HOST = 'localhost'
+            $env:NETBOX_SCHEME = 'http'
+            $env:NETBOX_TOKEN = 'dummy'
+            $env:NETBOX_VERSION = 'v1'
+
+            { & $Script:ScriptPath } | Should -Throw "Used expected default parameters"
+        }
+}
+    Context 'Query parameter handling' {
+        BeforeAll {
+            # restore environment variables to ensure a clean state for the tests
+            $env:NETBOX_HOST = $saveNetboxHost
+            $env:NETBOX_SCHEME = $saveNetboxScheme
+            $env:NETBOX_TOKEN = $saveNetboxToken
+            $env:NETBOX_VERSION = $saveNetboxVersion
+
+            #region connection setup (taken from Integration tests)
+            $secureToken = ConvertTo-SecureString -String $env:NETBOX_TOKEN -AsPlainText -Force
+            $credential = [PSCredential]::new('api', $secureToken)
+
+            # Parse hostname and port (supports "hostname" or "hostname:port" format)
+            $hostValue = $env:NETBOX_HOST
+            $hostname = $hostValue
+            $port = $null
+
+            if ($hostValue -match '^(.+):(\d+)$') {
+                $hostname = $Matches[1]
+                $port = [int]$Matches[2]
+            }
+
+            # Determine scheme - default to http for Docker CI, https for cloud
+            $scheme = $env:NETBOX_SCHEME
+            if ([string]::IsNullOrEmpty($scheme)) {
+                # Docker CI uses http on localhost
+                if ($hostname -match 'localhost|127\.0\.0\.1') {
+                    $scheme = 'http'
+                }
+                else {
+                    $scheme = 'https'
+                }
+            }
+
+            $connectParams = @{
+                Hostname   = $hostname
+                Port       = 443
+                Credential = $credential
+                Scheme     = $scheme
+            }
+
+            # Add port if specified
+            if ($port) {
+                $connectParams['Port'] = $port
+            }
+
+            # Only skip certificate check for https
+            if ($scheme -eq 'https') {
+                $connectParams['SkipCertificateCheck'] = $true
+            }
+
+            Connect-NBAPI @connectParams
+            #endregion
+
+            # read the API schema for later use in the tests (avoids multiple calls to the API schema endpoint)
+            $url = "$($connectParams['Scheme'])://$($connectParams['Hostname']):$($connectParams['Port'])/api/schema/?format=json"
+            $ApiSchema = Invoke-RestMethod -Uri $url -ContentType 'application/json'
+
+            #region determine, which mapping of query parameters to endpoints is currently used in the module
+            $nbVersion = [version] (Get-NbVersion).'netbox-version'
+            $ApiVersion = $nbVersion.Major.ToString() + '.' + $nbVersion.Minor.ToString()
+
+            $OriginalCaseParameterDictonary = InModuleScope -ModuleName PowerNetBox {
+                $Script:IgnoreCaseParameterDictonary
+            }
+            $OriginalCaseParameterDictonary | Should -Not -BeNullOrEmpty
+            #endregion
+            $saveParameterHash = $OriginalCaseParameterDictonary[$ApiVersion]
+
+            $spaltScriptParams = @{
+                OutputFormat = 'Object'
+                QueryParameterHash = $null          # Be sure to add this parameter on every test
+                ApiSchema = $ApiSchema              # Avoid multiple calls to the API schema endpoint
+            }
+        }
+        BeforeEach {
+        }
+        It 'Should not detect anything about query parameters' {
+            $thisParameterHash = $saveParameterHash.Clone()
+            $ret = & $Script:ScriptPath @spaltScriptParams -QueryParameterHash $thisParameterHash | Where-Object finding -ne 'function name not found in module'
+            $ret | Should -BeNullOrEmpty
+        }
+        It 'Should detect a missing query parameter' {
+            $thisParameterHash = $saveParameterHash.Clone()
+            $key = $thisParameterHash.Keys | Select-Object -First 1
+            $thisParameterHash.Remove($key) | Out-Null
+
+            $ret = & $Script:ScriptPath @spaltScriptParams -QueryParameterHash $thisParameterHash | Where-Object finding -ne 'function name not found in module'
+            $ret | Should -Not -BeNullOrEmpty
+            $ret.Finding | Should -Be 'not in dictionary'
+            $ret.Data.Parameter | Should -Be $key
+        }
+        It 'Should find parameter which is not part of any API endpoint' {
+            $thisParameterHash = $saveParameterHash.Clone()
+            $thisParameterHash['nonexistent_parameter'] = @('nonexistent_endpoint')
+
+            $ret = & $Script:ScriptPath @spaltScriptParams -QueryParameterHash $thisParameterHash | Where-Object finding -ne 'function name not found in module'
+            $ret | Should -Not -BeNullOrEmpty
+            $ret.Finding | Should -Be 'Dictionary entry without corresponding parametername'
+            $ret.Data | Should -Be 'nonexistent_parameter'
+        }
+        It 'Should find notexisting endpoint, when there is no exception list for the parameter' {
+            $thisParameterHash = $saveParameterHash.Clone()
+            $key = $thisParameterHash.Keys | Where-Object { $thisParameterHash[$_].Count -eq 0 } | Select-Object -First 1
+            $thisParameterHash[$key] = @('api/unknwon/endpoint/')
+
+            $ret = & $Script:ScriptPath @spaltScriptParams -QueryParameterHash $thisParameterHash | Where-Object finding -ne 'function name not found in module'
+            $ret | Should -Not -BeNullOrEmpty
+            $ret.Finding | Should -Be 'exception list not empty'
+            $ret.Data | Should -Be $key
+        }
+        It 'Should find missing endpoint' {
+            $thisParameterHash = $saveParameterHash.Clone()
+            $key = $thisParameterHash.Keys | Where-Object { $thisParameterHash[$_].Count -gt 2 } | Select-Object -First 1
+            $exceptionListBefore = $thisParameterHash[$key]
+            $thisParameterHash[$key] = $thisParameterHash[$key] | Select-Object -First ($thisParameterHash[$key].Count - 2)
+
+            $ret = & $Script:ScriptPath @spaltScriptParams -QueryParameterHash $thisParameterHash | Where-Object finding -ne 'function name not found in module'
+            $ret.Count | Should -Be 2 -Because 'We removed 2 endpoints from the exception list'
+            $ret[0].Finding | Should -Be 'missing in exception list'
+            $ret[0].Data.Parameter | Should -Be $key
+            $ret[1].Finding | Should -Be 'missing in exception list'
+            $ret[1].Data.Parameter | Should -Be $key
+        }
+    }
+}

--- a/scripts/Verify-QueryParameterHandling.Tests.ps1
+++ b/scripts/Verify-QueryParameterHandling.Tests.ps1
@@ -111,13 +111,28 @@ Describe 'Verify-QueryParameterHandling' {
                 OutputFormat = 'Object'
                 QueryParameterHash = $null          # Be sure to add this parameter on every test
                 ApiSchema = $ApiSchema              # Avoid multiple calls to the API schema endpoint
+                Check = @('IgnoreCase', 'Regex', 'IgnoreCaseRegex')
             }
         }
         BeforeEach {
         }
+        Context 'Check for function names' {
+            It 'Will find endpoint names which do not have a corresponding function in the module' {
+                $thisParameterHash = $saveParameterHash.Clone()
+                $ret = & $Script:ScriptPath @spaltScriptParams -QueryParameterHash $thisParameterHash -Check 'FunctionNames'
+                $ret | Should -Not -BeNullOrEmpty
+                $ret.Finding | Select-Object -Unique | Should -Be 'function name not found in module'
+            }
+            It 'When using "-All"' {
+                $thisParameterHash = $saveParameterHash.Clone()
+                $ret = & $Script:ScriptPath @spaltScriptParams -QueryParameterHash $thisParameterHash -Check 'All'
+                $ret | Should -Not -BeNullOrEmpty
+                $ret.Finding | Select-Object -Unique | Should -Contain 'function name not found in module'
+            }
+        }
         It 'Should not detect anything about query parameters' {
             $thisParameterHash = $saveParameterHash.Clone()
-            $ret = & $Script:ScriptPath @spaltScriptParams -QueryParameterHash $thisParameterHash | Where-Object finding -ne 'function name not found in module'
+            $ret = & $Script:ScriptPath @spaltScriptParams -QueryParameterHash $thisParameterHash
             $ret | Should -BeNullOrEmpty
         }
         It 'Should detect a missing query parameter' {
@@ -125,7 +140,7 @@ Describe 'Verify-QueryParameterHandling' {
             $key = $thisParameterHash.Keys | Select-Object -First 1
             $thisParameterHash.Remove($key) | Out-Null
 
-            $ret = & $Script:ScriptPath @spaltScriptParams -QueryParameterHash $thisParameterHash | Where-Object finding -ne 'function name not found in module'
+            $ret = & $Script:ScriptPath @spaltScriptParams -QueryParameterHash $thisParameterHash # | Where-Object finding -ne 'function name not found in module'
             $ret | Should -Not -BeNullOrEmpty
             $ret.Finding | Should -Be 'not in dictionary'
             $ret.Data.Parameter | Should -Be $key
@@ -134,7 +149,7 @@ Describe 'Verify-QueryParameterHandling' {
             $thisParameterHash = $saveParameterHash.Clone()
             $thisParameterHash['nonexistent_parameter'] = @('nonexistent_endpoint')
 
-            $ret = & $Script:ScriptPath @spaltScriptParams -QueryParameterHash $thisParameterHash | Where-Object finding -ne 'function name not found in module'
+            $ret = & $Script:ScriptPath @spaltScriptParams -QueryParameterHash $thisParameterHash  # | Where-Object finding -ne 'function name not found in module'
             $ret | Should -Not -BeNullOrEmpty
             $ret.Finding | Should -Be 'Dictionary entry without corresponding parametername'
             $ret.Data | Should -Be 'nonexistent_parameter'
@@ -144,7 +159,7 @@ Describe 'Verify-QueryParameterHandling' {
             $key = $thisParameterHash.Keys | Where-Object { $thisParameterHash[$_].Count -eq 0 } | Select-Object -First 1
             $thisParameterHash[$key] = @('api/unknwon/endpoint/')
 
-            $ret = & $Script:ScriptPath @spaltScriptParams -QueryParameterHash $thisParameterHash | Where-Object finding -ne 'function name not found in module'
+            $ret = & $Script:ScriptPath @spaltScriptParams -QueryParameterHash $thisParameterHash # | Where-Object finding -ne 'function name not found in module'
             $ret | Should -Not -BeNullOrEmpty
             $ret.Finding | Should -Be 'exception list not empty'
             $ret.Data | Should -Be $key
@@ -155,7 +170,7 @@ Describe 'Verify-QueryParameterHandling' {
             $exceptionListBefore = $thisParameterHash[$key]
             $thisParameterHash[$key] = $thisParameterHash[$key] | Select-Object -First ($thisParameterHash[$key].Count - 2)
 
-            $ret = & $Script:ScriptPath @spaltScriptParams -QueryParameterHash $thisParameterHash | Where-Object finding -ne 'function name not found in module'
+            $ret = & $Script:ScriptPath @spaltScriptParams -QueryParameterHash $thisParameterHash # | Where-Object finding -ne 'function name not found in module'
             $ret.Count | Should -Be 2 -Because 'We removed 2 endpoints from the exception list'
             $ret[0].Finding | Should -Be 'missing in exception list'
             $ret[0].Data.Parameter | Should -Be $key

--- a/scripts/Verify-QueryParameterHandling.Tests.ps1
+++ b/scripts/Verify-QueryParameterHandling.Tests.ps1
@@ -100,12 +100,12 @@ Describe 'Verify-QueryParameterHandling' {
             $nbVersion = [version] (Get-NbVersion).'netbox-version'
             $ApiVersion = $nbVersion.Major.ToString() + '.' + $nbVersion.Minor.ToString()
 
-            $OriginalCaseParameterDictonary = InModuleScope -ModuleName PowerNetBox {
-                $Script:IgnoreCaseParameterDictonary
+            $OriginalCaseParameterDictionary = InModuleScope -ModuleName PowerNetBox {
+                $Script:IgnoreCaseParameterDictionary
             }
-            $OriginalCaseParameterDictonary | Should -Not -BeNullOrEmpty
+            $OriginalCaseParameterDictionary | Should -Not -BeNullOrEmpty
             #endregion
-            $saveParameterHash = $OriginalCaseParameterDictonary[$ApiVersion]
+            $saveParameterHash = $OriginalCaseParameterDictionary[$ApiVersion]
 
             $spaltScriptParams = @{
                 OutputFormat = 'Object'

--- a/scripts/Verify-QueryParameterHandling.ps1
+++ b/scripts/Verify-QueryParameterHandling.ps1
@@ -78,15 +78,15 @@ function Import-QueryParameterDictionaryFromSourceFile {
     )
     # TODO: Currently untested for other scenerios
     . (Join-Path -Path $PathProjectRoot -ChildPath 'Functions' -AdditionalChildPath  'Helpers','_IgnoreCaseParameters.ps1')
-    $thisVersionDict = $Script:IgnoreCaseParameterDictonary[$objApiVersion.tostring()]
+    $thisVersionDict = $Script:IgnoreCaseParameterDictionary[$objApiVersion.tostring()]
     if ($null -eq $thisVersionDict) {
-        $latestVersion = $Script:IgnoreCaseParameterDictonary.Keys | Sort-Object -Descending | Select-Object -First 1
+        $latestVersion = $Script:IgnoreCaseParameterDictionary.Keys | Sort-Object -Descending | Select-Object -First 1
         Write-Warning "No dictionary entry found for API version $($objApiVersion.tostring()). Testing against the latest known version $($latestVersion)."
         $findings.Add([pscustomobject]@{
             Finding = 'No dictionary entry for this API version'
             Data = "API version $($objApiVersion.tostring())."
         })
-        $thisVersionDict = $Script:IgnoreCaseParameterDictonary[$latestVersion]
+        $thisVersionDict = $Script:IgnoreCaseParameterDictionary[$latestVersion]
     }
     $thisVersionDict
 }

--- a/scripts/Verify-QueryParameterHandling.ps1
+++ b/scripts/Verify-QueryParameterHandling.ps1
@@ -57,28 +57,39 @@ param (
 
     [hashtable] $QueryParameterHash = $null,
 
-    [ValidateSet('IgnoreCase', 'Regex', 'IgnoreCaseRegex', 'FunctionNames')]
-    [string] $Check = 'IgnoreCase',
+    [ValidateSet('All', 'IgnoreCase', 'Regex', 'IgnoreCaseRegex', 'FunctionNames')]
+    [string[]] $Check = @('All'),
 
     [PSObject] $ApiSchema = $null
 )
 $previousErrorActionPreference = $ErrorActionPreference
 $ErrorActionPreference = 'Stop'
 
-function Get-QueryParameterHashToCheck {
+function Import-QueryParameterDictionaryFromSourceFile {
+    # Imports the query parameter hash from the source file based on the API version
+    # by dot-sourcing the source code and returning the query parameter hash for the given API version (using the $Script: variables).
     [CmdletBinding()]
     param(
         [ValidateNotNullOrEmpty()]
-        [string] $PathDefinitionFile,
+        [string] $PathProjectRoot,
 
         [ValidateNotNullOrEmpty()]
-        [string] $ApiVersion,
-
-    [ValidateSet('All','IgnoreCase', 'Regex', 'IgnoreCaseRegex', 'FunctionNames')]
-        [string] $Check
+        [version] $objApiVersion
     )
+    # TODO: Currently untested for other scenerios
+    . (Join-Path -Path $PathProjectRoot -ChildPath 'Functions' -AdditionalChildPath  'Helpers','_IgnoreCaseParameters.ps1')
+    $thisVersionDict = $Script:IgnoreCaseParameterDictonary[$objApiVersion.tostring()]
+    if ($null -eq $thisVersionDict) {
+        $latestVersion = $Script:IgnoreCaseParameterDictonary.Keys | Sort-Object -Descending | Select-Object -First 1
+        Write-Warning "No dictionary entry found for API version $($objApiVersion.tostring()). Testing against the latest known version $($latestVersion)."
+        $findings.Add([pscustomobject]@{
+            Finding = 'No dictionary entry for this API version'
+            Data = "API version $($objApiVersion.tostring())."
+        })
+        $thisVersionDict = $Script:IgnoreCaseParameterDictonary[$latestVersion]
+    }
+    $thisVersionDict
 }
-
 function Get-DerivedFunctionNameFromEndpoint {
     param (
         [string] $endpoint
@@ -324,6 +335,145 @@ function Expand-FunctionAndParameterFromModule {
     }
 }
 
+function Find-ParameterDefinitionIssues {
+    <#
+        .SYNOPSIS
+        Determines which API parameters of type 'string' support a given operator and identifies exceptions.
+
+        .PARAMETER APIParameters
+        The list of API parameters to check.
+
+        .PARAMETER Operator
+        The operator to check for support ('ie', 'regex', 'iregex').
+
+        .PARAMETER OperatorParameterDictionary
+        A hashtable mapping parameter names to the list of endpoints where the operator is supported.
+    #>
+    [CmdletBinding()]
+    [OutputType([PSCustomObject])]
+    param (
+        [Object[]] $APIParameters,
+        [ValidateSet('ie', 'regex', 'iregex')]
+        [string] $Operator,
+        [ValidateNotNullOrEmpty()]
+        [hashtable] $OperatorParameterDictionary
+    )
+
+    $objParamsSupporting__operator = $APIParameters | Where-Object { ($_.Operators -contains $Operator -and $_.ItemsType -eq 'string') }
+    $nameParamsSupporting__operator = $objParamsSupporting__operator | Select-Object -ExpandProperty Parameter | Sort-Object -Unique
+
+    # Those supporting __operator, but would not support it in all endpoints (will need an exception list of those endpoints))
+    # Possible reasons: somewhere used as [int] or as selection from a list of choices, which do not support __ie/__regex/__iregex (and are case sensitive!)
+    $objParamsSupporting__operator_Exceptions = $APIParameters | Where-Object { $_.Parameter -in $nameParamsSupporting__operator -and $_.Operators -notcontains $Operator }
+    $nameParamsSupporting__operator_Exceptions = $objParamsSupporting__operator_Exceptions | Select-Object -ExpandProperty Parameter | Sort-Object -Unique
+    # Group by parameter to get the list of endpoints for each parameter that needs an exception list entry
+    $grpParamsSupporting__operator_Exceptions = $objParamsSupporting__operator_Exceptions | Group-Object -Property Parameter
+
+    #region every parametername must have a corresponding entry
+    $allParamNamesNotInDictionary = $nameParamsSupporting__operator | Where-Object { $_ -notin $OperatorParameterDictionary.Keys }
+    if ($allParamNamesNotInDictionary.Count -gt 0) {
+        # Report only the first occurence for each parameter
+        foreach ($pName in $allParamNamesNotInDictionary) {
+            $firstOccurence = $objParamsSupporting__operator | Where-Object { $_.Parameter -eq $pName } | Select-Object -First 1
+            $toReport = [pscustomobject] @{
+                Finding = 'not in dictionary'
+                Data = $firstOccurence
+            }
+            $toReport
+        }
+    }
+    #endregion
+
+    #region every dictionary entry must have a corresponding parametername
+    $allParamNamesNotInApi = $OperatorParameterDictionary.Keys | Where-Object {
+        $_ -notin $nameParamsSupporting__operator
+    }
+    if ($allParamNamesNotInApi.Count -gt 0) {
+        $toReport = [pscustomobject] @{
+            Finding = 'Dictionary entry without corresponding parametername'
+            Data = $allParamNamesNotInApi
+        }
+        $toReport
+    }
+    #endregion
+
+    #region every parametername which is not fully supporting __operator must have an entry in the exception list for each endpoint where it is not supported
+    $missingExceptionList = foreach ($paramName in $nameParamsSupporting__operator_Exceptions) {
+        if (-not $OperatorParameterDictionary.ContainsKey($paramName)) {
+            $exceptionListInDict = @()
+        } else {
+            $exceptionListInDict = $OperatorParameterDictionary[$paramName]
+        }
+        $exceptionListInApi = $grpParamsSupporting__operator_Exceptions | Where-Object { $_.Name -eq $paramName } | Select-Object -ExpandProperty Group
+        foreach ($param in $exceptionListInApi) {
+            foreach ($endpoint in $param.Endpoint) {
+                # endpoints in the dictionary are stored without the leading slash, because that's how they are checked inside 'BuildNewURI'
+                $endpoint = $endpoint.TrimStart('/')
+                if ($endpoint -notin $exceptionListInDict) {
+                    $thisEndpointData = $param
+                    $thisEndpointData.Endpoint = $endpoint              # report each endpoint separately
+                    $thisEndpointData
+                }
+            }
+        }
+    }
+    if ($missingExceptionList.Count -gt 0) {
+        foreach ($item in ($missingExceptionList | Sort-Object Parameter, endpoint)) {
+            $toReport = [pscustomobject] @{
+                Finding = 'missing in exception list'
+                Data = $item
+            }
+            $toReport
+        }
+    }
+    #endregion
+
+    #region every parametername which is fully supporting __operator must have an empty array of endpoints in the dictionary, as there are no exceptions
+    $allParamNamesFullySupporting__operator = $nameParamsSupporting__operator | Where-Object { $_ -notin $nameParamsSupporting__operator_Exceptions }
+    $nonEmptyExceptionList = foreach ($paramName in $allParamNamesFullySupporting__operator) {
+        if (-not $OperatorParameterDictionary.ContainsKey($paramName)) {
+            continue            # will be reported in another check
+        }
+        $exceptionListInDict = $OperatorParameterDictionary[$paramName]
+        if ($exceptionListInDict.Count -gt 0) {
+            $paramName
+        }
+    }
+    if ($nonEmptyExceptionList.Count -gt 0) {
+        $toReport = [pscustomobject] @{
+            Finding = 'exception list not empty'
+            Data = $nonEmptyExceptionList
+        }
+        $toReport
+    }
+    #endregion
+}
+
+function Find-FunctionNameMissing {
+    # every derived function name should exist in the module
+    [CmdletBinding()]
+    [OutputType([PSCustomObject])]
+    param(
+        [Object[]] $flatApiParameters,
+        [Object[]] $flatFunctionParameters
+    )
+    $derivedFunctionNames = $flatApiParameters | Select-Object -ExpandProperty FunctionName | Sort-Object -Unique
+    $functionNamesInModule = $flatFunctionParameters | Select-Object -ExpandProperty FunctionName | Sort-Object -Unique
+    $derivedFunctionNamesNotInModule = $derivedFunctionNames | Where-Object { $_ -notin $functionNamesInModule } | Sort-Object -Unique
+    if ($derivedFunctionNamesNotInModule.Count -gt 0) {
+        foreach ($fn in $derivedFunctionNamesNotInModule) {
+            $toReport = [pscustomobject] @{
+                Finding = 'function name not found in module'
+                Data = [PSCustomObject] @{
+                    FunctionName = $fn
+                }
+            }
+            $toReport
+        }
+    }
+    #endregion
+}
+
 # We will use the currently loaded module for function definitions. If it is not loaded, we will load it from the project root.
 if (-not (Get-Module -Name PowerNetbox)) {
     $psdPath = Join-Path -Path $PathProjectRoot -ChildPath 'PowerNetbox' -AdditionalChildPath 'PowerNetbox.psd1'
@@ -373,156 +523,47 @@ if (-not (Get-Module -Name PowerNetbox)) {
 
     #region Load the dictionary of query parameter handling for this scenario.
     if ($null -eq $QueryParameterHash) {
-        # TODO: Currently untested for other scenerios
-        . (Join-Path -Path $PathProjectRoot -ChildPath 'Functions' -AdditionalChildPath  'Helpers','_IgnoreCaseParameters.ps1')
-        $thisVersionDict = $Script:IgnoreCaseParameterDictonary[$objApiVersion.tostring()]
-        if ($null -eq $thisVersionDict) {
-            $latestVersion = $Script:IgnoreCaseParameterDictonary.Keys | Sort-Object -Descending | Select-Object -First 1
-            Write-Warning "No dictionary entry found for API version $($objApiVersion.tostring()). Testing against the latest known version $($latestVersion)."
-            $findings.Add([pscustomobject]@{
-                Finding = 'No dictionary entry for this API version'
-                Data = "API version $($objApiVersion.tostring())."
-            })
-            $thisVersionDict = $Script:IgnoreCaseParameterDictonary[$latestVersion]
-        }
-        $QueryParameterHash = $thisVersionDict
-    } else {
-        $thisVersionDict = $QueryParameterHash
+        $QueryParameterHash = Import-QueryParameterDictionaryFromSourceFile -PathProjectRoot $PathProjectRoot -objApiVersion $objApiVersion
     }
     #endregion
 
     $findings = [System.Collections.Generic.List[object]]::new()
-
-#region check for parameters that support __ie and build an exception list of endpoints, where a parameter is not supporting __ie
-    # Parameters to check
-    # Those supporting __ie at least once
-    $objParamsSupporting__ie = $flatApiParameters | Where-Object { ($_.Operators -contains 'ie' -and $_.ItemsType -eq 'string') }
-    $nameParamsSupporting__ie = $objParamsSupporting__ie | Select-Object -ExpandProperty Parameter | Sort-Object -Unique
-
-    # Those supporting __ie, but would not support it in all endpoints (will need an exception list of those endpoints))
-    # Possible reasons: somewhere used as [int] od as selection from a list of choices, which do not support __ie (and are case sensitive!)
-    $objParamsSupporting__ie_Exceptions = $flatApiParameters | Where-Object { $_.Parameter -in $nameParamsSupporting__ie -and $_.Operators -notcontains 'ie' }
-    $nameParamsSupporting__ie_Exceptions = $objParamsSupporting__ie_Exceptions | Select-Object -ExpandProperty Parameter | Sort-Object -Unique
-    # Group by parameter to get the list of endpoints for each parameter that needs an exception list entry
-    $grpParamsSupporting__ie_Exceptions = $objParamsSupporting__ie_Exceptions | Group-Object -Property Parameter
-
-    #region Find those supporting __ie but would not support __regex or __iregex
-    $objMissingRegexSupport = [System.Collections.Generic.List[object]]::new()
-    foreach ($param in $objParamsSupporting__ie) {
-        if ($param.Operators -notcontains 'regex' -or $param.Operators -notcontains 'iregex') {
-            $objMissingRegexSupport.Add($param)
-        }
-        if ($param.Operators.Count -lt 4) {
-            Write-Warning "Parameter $($param.Parameter) for endpoint $($param.Endpoint) supports regex operators but has less than 4 operators. This would be surprising."
-            $objMissingRegexSupport.Add($param)
-        }
+    $ChecksToPerform = $Check
+    if ($Check -eq 'All') {
+        $ChecksToPerform = @('IgnoreCase', 'Regex', 'IgnoreCaseRegex', 'FunctionNames')
     }
-    if ($objMissingRegexSupport.Count -gt 0) {
-        $toReport = [pscustomobject] @{
-            Finding = 'Supports __ie, but not __regex or __iregex'
-            Data = $objMissingRegexSupport
-        }
-        $findings.Add($toReport)
-    }
-    #endregion
-
-    #region check against the dictionary for this API version
-
-    # every parametername must have a corresponding entry
-    $allParamNamesNotInDictionary = $nameParamsSupporting__ie | Where-Object { $_ -notin $thisVersionDict.Keys }
-    if ($allParamNamesNotInDictionary.Count -gt 0) {
-        # Report only the first occurence for each parameter
-        foreach ($pName in $allParamNamesNotInDictionary) {
-            $firstOccurence = $objParamsSupporting__ie | Where-Object { $_.Parameter -eq $pName } | Select-Object -First 1
-            $toReport = [pscustomobject] @{
-                Finding = 'not in dictionary'
-                Data = $firstOccurence
+    switch ($ChecksToPerform) {
+        'IgnoreCase' {
+            Write-Verbose "Perform IgnoreCase check"
+            $paramFindings = Find-ParameterDefinitionIssues -APIParameters $flatApiParameters -Operator 'ie' -OperatorParameterDictionary $QueryParameterHash
+            if ($paramFindings.Count -gt 0) {
+                $findings.AddRange(@($paramFindings))
             }
-            $findings.Add($toReport)
+            continue
         }
-    }
-
-    # every dictionary entry must have a corresponding parametername
-    $allParamNamesNotInApi = $thisVersionDict.Keys | Where-Object {
-        $_ -notin $nameParamsSupporting__ie
-    }
-    if ($allParamNamesNotInApi.Count -gt 0) {
-        $toReport = [pscustomobject] @{
-            Finding = 'Dictionary entry without corresponding parametername'
-            Data = $allParamNamesNotInApi
+        'Regex' {
+            Write-Verbose "Perform Regex check"
+            continue
         }
-        $findings.Add($toReport)
-    }
-
-    # every parametername which has an exception list must have a non-empty array of endpoints in the dictionary containing each endpoint,
-    # where the parameter does not support __ie
-    $missingExceptionList = foreach ($param in $nameParamsSupporting__ie_Exceptions) {
-        if (-not $thisVersionDict.ContainsKey($param)) {
-            $exceptionListInDict = @()
-        } else {
-            $exceptionListInDict = $thisVersionDict[$param]
+        'IgnoreCaseRegex' {
+            Write-Verbose "Perform IgnoreCaseRegex check"
+            continue
         }
-        $exceptionListInApi = $grpParamsSupporting__ie_Exceptions | Where-Object { $_.Name -eq $param } | Select-Object -ExpandProperty Group
-        foreach ($param in $exceptionListInApi) {
-            foreach ($endpoint in $param.Endpoint) {
-                # endpoints in the dictionary are stored without the leading slash, because that's how they are checked inside 'BuildNewURI'
-                $endpoint = $endpoint.TrimStart('/')
-                if ($endpoint -notin $exceptionListInDict) {
-                    $thisEndpointData = $param
-                    $thisEndpointData.Endpoint = $endpoint              # report each endpoint separately
-                    $thisEndpointData
-                }
+        'FunctionNames' {
+            Write-Verbose "Perform FunctionNames check"
+            $functionFindings = Find-FunctionNameMissing -flatApiParameters $flatApiParameters -flatFunctionParameters $flatFunctionParameters
+            if ($functionFindings.Count -gt 0) {
+                $findings.AddRange(@($functionFindings))
             }
+            continue
         }
-    }
-    if ($missingExceptionList.Count -gt 0) {
-        foreach ($item in ($missingExceptionList | Sort-Object Parameter, endpoint)) {
-            $toReport = [pscustomobject] @{
-                Finding = 'missing in exception list'
-                Data = $item
-            }
-            $findings.Add($toReport)
+        Default {
+            Write-Warning "Unknown check: $ChecksToPerform"
+            continue
         }
     }
 
-    # every parametername which is fully supporting __ie must have an empty array of endpoints in the dictionary, as there are no exceptions
-    $allParamNamesFullySupporting__ie = $nameParamsSupporting__ie | Where-Object { $_ -notin $nameParamsSupporting__ie_Exceptions }
-    $nonEmptyExceptionList = foreach ($param in $allParamNamesFullySupporting__ie) {
-        if (-not $thisVersionDict.ContainsKey($param)) {
-            continue            # will be reported in another check
-        }
-        $exceptionListInDict = $thisVersionDict[$param]
-        if ($exceptionListInDict.Count -gt 0) {
-            $param
-        }
-    }
-    if ($nonEmptyExceptionList.Count -gt 0) {
-        $toReport = [pscustomobject] @{
-            Finding = 'exception list not empty'
-            Data = $nonEmptyExceptionList
-        }
-        $findings.Add($toReport)
-    }
-    #endregion
 
-    #region function checks
-    # every derived function name should exist in the module
-    $derivedFunctionNames = $flatApiParameters | Select-Object -ExpandProperty FunctionName | Sort-Object -Unique
-    $functionNamesInModule = $flatFunctionParameters | Select-Object -ExpandProperty FunctionName | Sort-Object -Unique
-    $derivedFunctionNamesNotInModule = $derivedFunctionNames | Where-Object { $_ -notin $functionNamesInModule } | Sort-Object -Unique
-    if ($derivedFunctionNamesNotInModule.Count -gt 0) {
-        foreach ($fn in $derivedFunctionNamesNotInModule) {
-            $toReport = [pscustomobject] @{
-                Finding = 'function name not found in module'
-                Data = [PSCustomObject] @{
-                    FunctionName = $fn
-                }
-            }
-            $findings.Add($toReport)
-        }
-    }
-    #endregion
-#endregion
 
 switch -regex ($OutputFormat) {
     'ConsoleList|ConsoleTable' {

--- a/scripts/Verify-QueryParameterHandling.ps1
+++ b/scripts/Verify-QueryParameterHandling.ps1
@@ -19,20 +19,32 @@
     .PARAMETER OutputFormat
         The format for the output of the findings. Default is 'ConsoleList'. Possible values are 'ConsoleList', 'ConsoleTable', 'Json', and 'Object'.
 
+    .PARAMETER QueryParameterHash
+        Verify against this definition hashtable. Default is taken from 'Functions/Helpers/_IgnoreCaseParameters.ps1' depending on the API version.
+        It must reflect the API version and the corresponding check to be done.
+        We use this parameter for testing the script itself to test against different scenarios.
+
+    .PARAMETER Check
+        The type of check to perform. Default is 'IgnoreCase'. Possible values are 'IgnoreCase', 'Regex', 'IgnoreCaseRegex', and 'FunctionNames'.
+
+    .PARAMETER ApiSchema
+        Provide the API schema as a PSObject. If not provided, the script will fetch it from the API schema endpoint.
+        We use this in the tests to provide a mock API schema for testing different scenarios.
+        For validation against the current running module and API, leave it $null.
+
     .NOTES
         The parameter/exception list is based on the API v4.4.9 list of fully supported case-insensitive parameters, which is the minimum version
         supported by this module. The list is based on the API schema of NetBox.
 
-        # Goal 1: Cleaner reimplementation of an internal parameter-validation script.
-        # Goal 2: Validate whether the functions' array parameters are supported by the API, and where they could be a possible extension.
+
 #>
 [CmdletBinding()]
 param (
     [ValidateNotNullOrEmpty()]
     [string]$Hostname = $env:NETBOX_HOST,
 
-    [ValidateSet('https', 'http', IgnoreCase = $true)]
-    [string]$Scheme = 'https',
+    [ValidateSet('https', 'http')]
+    [string]$Scheme = ($env:NETBOX_SCHEME ?? 'https' ),
 
     [ValidateNotNullOrEmpty()]
     [string] $NetboxVersion = $env:NETBOX_VERSION,
@@ -41,10 +53,31 @@ param (
     [string] $PathProjectRoot = (Join-Path -Path $PSScriptRoot -ChildPath '..'),
 
     [ValidateSet('ConsoleTable', 'ConsoleList', 'Json', 'Object')]
-    [string]$OutputFormat = 'ConsoleTable'
+    [string] $OutputFormat = 'ConsoleTable',
+
+    [hashtable] $QueryParameterHash = $null,
+
+    [ValidateSet('IgnoreCase', 'Regex', 'IgnoreCaseRegex', 'FunctionNames')]
+    [string] $Check = 'IgnoreCase',
+
+    [PSObject] $ApiSchema = $null
 )
 $previousErrorActionPreference = $ErrorActionPreference
 $ErrorActionPreference = 'Stop'
+
+function Get-QueryParameterHashToCheck {
+    [CmdletBinding()]
+    param(
+        [ValidateNotNullOrEmpty()]
+        [string] $PathDefinitionFile,
+
+        [ValidateNotNullOrEmpty()]
+        [string] $ApiVersion,
+
+    [ValidateSet('All','IgnoreCase', 'Regex', 'IgnoreCaseRegex', 'FunctionNames')]
+        [string] $Check
+    )
+}
 
 function Get-DerivedFunctionNameFromEndpoint {
     param (
@@ -291,21 +324,6 @@ function Expand-FunctionAndParameterFromModule {
     }
 }
 
-#region prepare query parameter definitions from source file and load module for later getting function definitions
-$pathDefinitionFile = Join-Path -Path $PathProjectRoot -ChildPath 'Functions','Helpers','_IgnoreCaseParameters.ps1'
-if (-not (Test-Path -Path $PathDefinitionFile)) {
-    Write-Error "Definition file not found: $PathDefinitionFile"
-}
-
-Try {
-    . $PathDefinitionFile
-}
-Catch {
-    Write-Error "Failed to load definition file: $PathDefinitionFile" -ErrorAction Continue
-    Write-Error $_.Exception.Message
-    exit 1
-}
-
 # We will use the currently loaded module for function definitions. If it is not loaded, we will load it from the project root.
 if (-not (Get-Module -Name PowerNetbox)) {
     $psdPath = Join-Path -Path $PathProjectRoot -ChildPath 'PowerNetbox' -AdditionalChildPath 'PowerNetbox.psd1'
@@ -315,12 +333,13 @@ if (-not (Get-Module -Name PowerNetbox)) {
     }
     Import-Module $psdPath -Force -ErrorAction Stop
 }
-#endregion
 
-#region Read API schema and extract functions and query parameters
-    $url = "$($Scheme)://$Hostname/api/schema/?format=json"
-    $apiSchema = Invoke-RestMethod $url -ContentType 'application/json'
-    Write-Host "API schema version: $($apiSchema.info.version)"
+    #region Read API schema and extract functions and query parameters
+    if ($null -eq $ApiSchema) {
+        $url = "$($Scheme)://$Hostname/api/schema/?format=json"
+        $ApiSchema = Invoke-RestMethod -Uri $url -ContentType 'application/json'
+        Write-Host "API schema version: $($ApiSchema.info.version)"
+    }
 
     #region verify that the API schema version matches the expected version, if provided (e.g. should look like 4.5.10-Docker-4.0.2 (4.5))
     # only major and minor version are used for the validation, as patch versions should not introduce breaking changes.
@@ -350,12 +369,32 @@ if (-not (Get-Module -Name PowerNetbox)) {
 
     $flatApiParameters = Expand-FunctionAndParameterFromApiSchema -schema $apiSchema
     $flatFunctionParameters = Expand-FunctionAndParameterFromModule
-#endregion
+    #endregion
+
+    #region Load the dictionary of query parameter handling for this scenario.
+    if ($null -eq $QueryParameterHash) {
+        # TODO: Currently untested for other scenerios
+        . (Join-Path -Path $PathProjectRoot -ChildPath 'Functions' -AdditionalChildPath  'Helpers','_IgnoreCaseParameters.ps1')
+        $thisVersionDict = $Script:IgnoreCaseParameterDictonary[$objApiVersion.tostring()]
+        if ($null -eq $thisVersionDict) {
+            $latestVersion = $Script:IgnoreCaseParameterDictonary.Keys | Sort-Object -Descending | Select-Object -First 1
+            Write-Warning "No dictionary entry found for API version $($objApiVersion.tostring()). Testing against the latest known version $($latestVersion)."
+            $findings.Add([pscustomobject]@{
+                Finding = 'No dictionary entry for this API version'
+                Data = "API version $($objApiVersion.tostring())."
+            })
+            $thisVersionDict = $Script:IgnoreCaseParameterDictonary[$latestVersion]
+        }
+        $QueryParameterHash = $thisVersionDict
+    } else {
+        $thisVersionDict = $QueryParameterHash
+    }
+    #endregion
 
     $findings = [System.Collections.Generic.List[object]]::new()
 
 #region check for parameters that support __ie and build an exception list of endpoints, where a parameter is not supporting __ie
-    # Parameters to ccheck
+    # Parameters to check
     # Those supporting __ie at least once
     $objParamsSupporting__ie = $flatApiParameters | Where-Object { ($_.Operators -contains 'ie' -and $_.ItemsType -eq 'string') }
     $nameParamsSupporting__ie = $objParamsSupporting__ie | Select-Object -ExpandProperty Parameter | Sort-Object -Unique
@@ -388,17 +427,6 @@ if (-not (Get-Module -Name PowerNetbox)) {
     #endregion
 
     #region check against the dictionary for this API version
-    # Evaluate the dictionary for this API version. If not found, use the latest known version and report a finding.
-    $thisVersionDict = $Script:IgnoreCaseParameterDictonary[$objApiVersion.tostring()]
-    if ($null -eq $thisVersionDict) {
-        $latestVersion = $Script:IgnoreCaseParameterDictonary.Keys | Sort-Object -Descending | Select-Object -First 1
-        Write-Warning "No dictionary entry found for API version $($objApiVersion.tostring()). Testing against the latest known version $($latestVersion)."
-        $findings.Add([pscustomobject]@{
-            Finding = 'No dictionary entry for this API version'
-            Data = "API version $($objApiVersion.tostring())."
-        })
-        $thisVersionDict = $Script:IgnoreCaseParameterDictonary[$latestVersion]
-    }
 
     # every parametername must have a corresponding entry
     $allParamNamesNotInDictionary = $nameParamsSupporting__ie | Where-Object { $_ -notin $thisVersionDict.Keys }


### PR DESCRIPTION
## Description

Implement `-Matchmode` to enable query fields search using wildcards or regex.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] CI/CD or build changes

## Related Issues

Implements #464 

## Checklist

<!-- Ensure all items are checked before requesting review -->

### Code Quality
- [x] Code follows the [PowerShell Practice and Style Guidelines](https://poshcode.gitbook.io/powershell-practice-and-style/)
- [x] Functions use `[CmdletBinding()]` attribute
- [x] State-changing functions use `SupportsShouldProcess`
- [x] No hardcoded paths or credentials
- [x] `Write-Verbose` used for debugging (not `Write-Host`)
- [x] Every new/changed parameter has a `.PARAMETER` help entry, and every `.PARAMETER`/body `$var` maps to a real `param()` entry (CI gate: CodeQuality "parameter parity")
- [x] New `$script:NetboxConfig` keys are seeded in `SetupNetboxConfigVariable.ps1`; companion getters return a default rather than throwing on a fresh import

### Testing
- [x] Existing tests pass (`Invoke-Pester ./Tests/`)
- [x] New tests added for new functionality — at least one **pre-merge** (not `Live`/`Integration`-tagged) Pester assertion per new/changed parameter (URI or request body). Array-widened params assert repeat-key emission (`?k=a&k=b`)
- [x] Tested manually against Netbox instance (if applicable)

### API Correctness
- [x] Filters widened to an array type are confirmed multi-value in the OpenAPI schema (`schema.type: array`) — scalar filters silently honor only the first repeated value
- [x] Any case-insensitive / `__ie` (or other lookup-suffix) mapping is intersected against the schema's actual capable fields per endpoint; numeric/datetime/relational/CIDR/choice fields excluded
- [x] Filters/params marked NetBox 4.x+ degrade safely on older servers (NetBox silently ignores unknown filters → verify no false unfiltered results)

### Documentation
- [x] Function has proper comment-based help (`.SYNOPSIS`, `.DESCRIPTION`, `.EXAMPLE`)
- [x] README updated (if needed)
- [ ] Wiki updated (if needed)

## Testing Performed

- Running all tests against a dockerized 4.6 version
- Running all tests against a dockerized 4.4 version
- Using this branches version manually against our Q&A

- Netbox version tested: 4.6.4-Docker-5.0.1
- PowerShell version: 7.6.3 & 5.1
- Platform (Windows/Linux/macOS): Windows

## Screenshots (if applicable)

<!-- Add screenshots for UI-related changes -->

## Additional Notes

- New Parameter for Set-NBQueryOption
    - `-MatchMode <Exact|Wildcard|Regex>`\
        Design is, that each parameter (IgnoreCase/MatchMode) is set separately to avoid ambiguity. If only one parameter is set, it would not be clear for the user whether the other parameter is set to its default value or left as is.
- New parameter for Connect-NbAPI
    - `-MatchMode <Exact|Wildcard|Regex>`\
        As it is for the first time setup, IgnoreCase/MatchMode are allowed to be set together.
- Changed scripts/Verify-QueryParameterHandling.ps1
    - Refactored to make it reusable for regex/ireg operators
    - Make it testable and added scripts/Verify-QueryParameterHandling.Tests.ps1
- Updated BuildNewUri
    - Added support for regex/ireg operators
- Updated several tests
- New integration tests for query options (IgnoreCase/MatchMode) in several combinations @ .\Tests\Integration.Tests.ps1 for contacts.
