### PR TITLE
ci: pin Pester to 5.7.1; replace removed Assert-MockCalled (Pester 6)

### DIFF
--- a/.github/workflows/branching-integration.yml
+++ b/.github/workflows/branching-integration.yml
@@ -239,7 +239,7 @@ jobs:
         run: |
           Write-Host "Installing Pester..." -ForegroundColor Cyan
           Set-PSRepository PSGallery -InstallationPolicy Trusted
-          Install-Module Pester -Force -Scope CurrentUser -MinimumVersion 5.0.0
+          Install-Module Pester -Force -Scope CurrentUser -RequiredVersion 5.7.1 -SkipPublisherCheck
 
       - name: Build PowerNetbox module
         shell: pwsh

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -201,7 +201,7 @@ jobs:
         shell: pwsh
         run: |
           Set-PSRepository PSGallery -InstallationPolicy Trusted
-          Install-Module Pester -Force -Scope CurrentUser -MinimumVersion 5.0.0
+          Install-Module Pester -Force -Scope CurrentUser -RequiredVersion 5.7.1 -SkipPublisherCheck
 
       - name: Build module
         shell: pwsh

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -186,7 +186,7 @@ jobs:
         run: |
           Write-Host "Installing Pester..." -ForegroundColor Cyan
           Set-PSRepository PSGallery -InstallationPolicy Trusted
-          Install-Module Pester -Force -Scope CurrentUser -MinimumVersion 5.0.0
+          Install-Module Pester -Force -Scope CurrentUser -RequiredVersion 5.7.1 -SkipPublisherCheck
 
           $pesterVersion = (Get-Module Pester -ListAvailable | Select-Object -First 1).Version
           Write-Host "Pester version: $pesterVersion" -ForegroundColor Green

--- a/.github/workflows/pre-release-validation.yml
+++ b/.github/workflows/pre-release-validation.yml
@@ -73,7 +73,7 @@ jobs:
               Register-PSRepository -Default
           }
           Set-PSRepository PSGallery -InstallationPolicy Trusted
-          Install-Module Pester -Force -Scope CurrentUser -MinimumVersion 5.0.0
+          Install-Module Pester -Force -Scope CurrentUser -RequiredVersion 5.7.1 -SkipPublisherCheck
           Install-Module PSScriptAnalyzer -Force -Scope CurrentUser
 
       - name: Install dependencies (powershell 5.1)
@@ -84,7 +84,7 @@ jobs:
               Register-PSRepository -Default
           }
           Set-PSRepository PSGallery -InstallationPolicy Trusted
-          Install-Module Pester -Force -Scope CurrentUser -MinimumVersion 5.0.0
+          Install-Module Pester -Force -Scope CurrentUser -RequiredVersion 5.7.1 -SkipPublisherCheck
           Install-Module PSScriptAnalyzer -Force -Scope CurrentUser
 
       - name: Build module (pwsh)
@@ -154,7 +154,7 @@ jobs:
         shell: pwsh
         run: |
           Set-PSRepository PSGallery -InstallationPolicy Trusted
-          Install-Module Pester -Force -Scope CurrentUser -MinimumVersion 5.0.0
+          Install-Module Pester -Force -Scope CurrentUser -RequiredVersion 5.7.1 -SkipPublisherCheck
 
       - name: Build module
         shell: pwsh
@@ -715,7 +715,7 @@ jobs:
         shell: pwsh
         run: |
           Set-PSRepository PSGallery -InstallationPolicy Trusted
-          Install-Module Pester -Force -Scope CurrentUser -MinimumVersion 5.0.0
+          Install-Module Pester -Force -Scope CurrentUser -RequiredVersion 5.7.1 -SkipPublisherCheck
 
       - name: Build module
         shell: pwsh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,7 @@ jobs:
               Register-PSRepository -Default
           }
           Set-PSRepository PSGallery -InstallationPolicy Trusted
-          Install-Module Pester -Force -Scope CurrentUser -MinimumVersion 5.0.0
+          Install-Module Pester -Force -Scope CurrentUser -RequiredVersion 5.7.1 -SkipPublisherCheck
           Install-Module PSScriptAnalyzer -Force -Scope CurrentUser
 
       - name: Install dependencies (powershell)
@@ -59,7 +59,7 @@ jobs:
               Register-PSRepository -Default
           }
           Set-PSRepository PSGallery -InstallationPolicy Trusted
-          Install-Module Pester -Force -Scope CurrentUser -MinimumVersion 5.0.0
+          Install-Module Pester -Force -Scope CurrentUser -RequiredVersion 5.7.1 -SkipPublisherCheck
           Install-Module PSScriptAnalyzer -Force -Scope CurrentUser
 
       - name: Build module (pwsh)

--- a/Tests/Setup.Tests.ps1
+++ b/Tests/Setup.Tests.ps1
@@ -322,14 +322,14 @@ Describe "Setup tests" -Tag 'Core', 'Setup' {
                 Mock -CommandName 'Set-NBQueryOption' -ModuleName 'PowerNetbox' -MockWith { return $true } -ParameterFilter { $IgnoreCase -eq $false } -Verifiable
                 Mock -CommandName 'Set-NBQueryOption' -ModuleName 'PowerNetbox' -MockWith { Throw "Should not be called" } -ParameterFilter { $IgnoreCase -eq $true }
                 Connect-NBAPI -Hostname 'netbox.domain.local' -Scheme 'https' -Port 443
-                Assert-MockCalled -CommandName 'Set-NBQueryOption' -ModuleName 'PowerNetbox' -Times 1
+                Should -Invoke -CommandName 'Set-NBQueryOption' -ModuleName 'PowerNetbox' -Times 1 -Exactly
                 $null = Get-NbQueryOption
             }
             It "Should call Set-NBQueryOption inside Connect-NBAPI" {
                 Mock -CommandName 'Set-NBQueryOption' -ModuleName 'PowerNetbox' -MockWith { Throw "Should not be called" } -ParameterFilter { $IgnoreCase -eq $false }
                 Mock -CommandName 'Set-NBQueryOption' -ModuleName 'PowerNetbox' -MockWith { return $true } -ParameterFilter { $IgnoreCase -eq $true } -Verifiable
                 Connect-NBAPI -Hostname 'netbox.domain.local' -Scheme 'https' -Port 443 -IgnoreCase
-                Assert-MockCalled -CommandName 'Set-NBQueryOption' -ModuleName 'PowerNetbox' -Times 1
+                Should -Invoke -CommandName 'Set-NBQueryOption' -ModuleName 'PowerNetbox' -Times 1 -Exactly
                 $null = Get-NbQueryOption
             }
         }


### PR DESCRIPTION
## Summary

PSGallery now serves **Pester 6.1.0**, which removed the legacy `Assert-MockCalled` command. All workflows installed Pester with `-MinimumVersion 5.0.0`, so every Pester leg (PS 7.x and PS 5.1) started failing the two `Connect-NBAPI` query-option tests in `Tests/Setup.Tests.ps1` — and any PR built on dev (e.g. #469) goes red for the same reason.

- Pin `Install-Module Pester` to `-RequiredVersion 5.7.1` (the version `release.yml` already pins) in `test.yml`, `integration.yml`, `compatibility.yml`, `pre-release-validation.yml`, `branching-integration.yml`.
- Replace the two `Assert-MockCalled` calls with `Should -Invoke ... -Exactly` (valid on Pester 5 and 6).

## Test plan
- [x] `Invoke-Pester ./Tests/Setup.Tests.ps1` green locally on Pester 5.7.1
- [ ] CI Pester matrix green (was red on dev-based PRs since Pester 6 landed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rudf2aZUmnQQsbmpoLoWh5