### PR TITLE
chore(docs): bump mkdocs-material 9.7.7 + pymdown-extensions 11.0.1 (security)

### DIFF
--- a/docs-build/requirements.txt
+++ b/docs-build/requirements.txt
@@ -1,7 +1,7 @@
-mkdocs-material[imaging]==9.5.30
+mkdocs-material[imaging]==9.7.7
 mkdocs-awesome-pages-plugin==2.9.3
 mkdocs-macros-plugin==1.0.5
-pymdown-extensions==10.21.3
+pymdown-extensions==11.0.1
 
 # Transitive deps pinned for reproducibility. They are NOT covered by the
 # constraints above (mkdocs-material allows pygments~=2.16, markdown~=3.2),
@@ -9,9 +9,11 @@ pymdown-extensions==10.21.3
 # Pygments to 2.20.0, which broke pymdownx.superfences: it silently stopped
 # processing every fenced code block site-wide (fences rendered as literal
 # "```" text, # lines became <h1>). These pins reproduce a known-good build.
-# Re-verified 2026-05-16 with a local `mkdocs build`: pymdown-extensions
-# 10.16.1 + markdown 3.10.2 + pygments 2.19.2 renders every code block
-# correctly (528 highlight blocks, zero literal fences). Bump deliberately
-# together with pymdown-extensions and re-run the local render check.
+# Re-verified 2026-09-09 with a local `mkdocs build`: mkdocs-material 9.7.7 +
+# pymdown-extensions 11.0.1 + markdown 3.10.2 + pygments 2.19.2 renders every
+# code block correctly (528 highlight blocks, zero literal fences). Bump
+# deliberately together with pymdown-extensions and re-run the local render
+# check. (9.7.7 / 11.0.1 clear GHSA advisories: DOM XSS in Material search,
+# ReDoS + b64 path traversal in pymdownx.)
 markdown==3.10.2
 pygments==2.19.2


### PR DESCRIPTION
Clears three open Dependabot alerts on the docs build:

| Package | From | To | Advisory |
|---|---|---|---|
| pymdown-extensions | 10.21.3 | **11.0.1** | HIGH — exponential-backtracking ReDoS in caret/tilde/…; MEDIUM — path traversal in the b64 extension |
| mkdocs-material | 9.5.30 | **9.7.7** | MEDIUM — DOM XSS in search suggestions |

Dependabot's own #470 (pymdown 11.0 alone) could not resolve against material 9.5.30; the pair resolves. Verified locally with `mkdocs build`: 528 highlight blocks, 0 literal fences (same as the known-good baseline). `pygments` stays pinned at 2.19.2 (low-severity ReDoS left as documented tradeoff; 2.20.0 did not install alongside these pins).

Alerts are evaluated on `main`, so they clear at the next release merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rudf2aZUmnQQsbmpoLoWh5