### PR TITLE
feat: NetBox 4.7 backlog (v4.7.1.0) - cooling, module bay types, 4.7 fields, cursor pagination, ETag, tag filters, background bulk

### DIFF
--- a/.claude/skills/new-netbox-endpoint/SKILL.md
+++ b/.claude/skills/new-netbox-endpoint/SKILL.md
@@ -41,7 +41,12 @@ endpoint look identical.
    not `Invoke-RestMethod`, unless the cmdlet bypasses it (file uploads, SVG).
 6. **Build + verify** — `./deploy.ps1 -Environment dev -SkipVersion`,
    then `Invoke-Pester ./Tests/<Module>.Tests.ps1`.
-7. **Revert build artefacts before commit** —
+7. **Live-verify against a local Docker NetBox** (the only live path since
+   2026-09-09; the exe.dev VMs are gone) — see "Live verification on Docker"
+   below. New -> Get by id + one filter -> Set -> Remove, then delete your
+   fixtures. Live-tagged Pester tests only run on push to `dev`, so a local
+   run is the pre-merge proof.
+8. **Revert build artefacts before commit** —
    `git checkout PowerNetbox.psd1` (deploy.ps1 updates its date).
 
 ## Cmdlet templates
@@ -84,6 +89,14 @@ function Get-NB[Module][Resource] {
         # [string]$Status,                                # <-- filter params go here
         # [Parameter(ParameterSetName = 'Query')]
         # [uint64]$Site_Id,
+        # Every list endpoint whose model carries tags exposes `tag` / `tag_id`
+        # filters (check the schema); expose them as this pair. Multiple values
+        # are AND on the server; Set-NBQueryOption -TagMatch Any switches the
+        # key to tag__any (4.6.6+) centrally in BuildNewURI.
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tag_Id,
         [uint16]$Limit,
         [uint32]$Offset,   # uint32, not uint16 — NetBox datasets (IPAM, Circuits) exceed 65 535 items
         [switch]$Brief,
@@ -259,6 +272,62 @@ function Remove-NB[Module][Resource] {
 }
 ```
 
+## Version-gated parameters (field only exists on NetBox X.Y+)
+
+A whole new endpoint needs no gate (older servers 404 and the error says so).
+A new *field on an existing cmdlet* must not be sent to older servers, which
+silently ignore unknown body fields and unknown filters (a filter that is
+ignored returns the WHOLE table). Gate it with the helper, then drop it from
+the request (pattern from `Set-NBDCIMCable`):
+
+```powershell
+$skipParams = @('Id', 'Raw')
+if (Test-NBMinimumVersion -ParameterName 'Cooling_Method' -MinimumVersion '4.7.0' `
+        -BoundParameters $PSBoundParameters -FeatureName 'Cooling method') {
+    $skipParams += 'Cooling_Method'   # warns once, then excluded
+}
+$URIComponents = BuildURIComponents -URISegments $Segments.Clone() `
+    -ParametersDictionary $PSBoundParameters -SkipParameterByName $skipParams
+```
+
+Cmdlets that build the body by hand wrap the assignment instead:
+`if ($PSBoundParameters.ContainsKey('X') -and -not $excludeX) { $Body['x'] = $X }`.
+Unit-test both sides: at `ParsedVersion = 4.7.0` the field is in the body /
+query, at `4.6.10` it is absent and `-WarningVariable` matches
+`requires Netbox 4.7.0` (see `Tests/IPAM.Tests.ps1`, Context "Service port
+mappings (Netbox 4.7+)").
+
+Module-wide behaviours (not per-cmdlet) live in `Set-NBQueryOption` and are
+applied centrally: `-IgnoreCase`/`-MatchMode` (BuildNewURI lookup
+decoration), `-TagMatch` (tag__any), `-Pagination Cursor` (`?start=` in the
+`-All` loop) and `-OptimisticConcurrency` (ETag/If-Match in
+InvokeNetboxRequest). Add a new option there rather than sprinkling switches
+over hundreds of cmdlets.
+
+## Live verification on Docker
+
+```bash
+open -a Docker                                                    # Docker Desktop must be running
+NETBOX_VERSION=v4.7.0-5.1.0 docker compose -p pn47 -f docker-compose.ci.yml up -d
+# ALWAYS pass NETBOX_VERSION on EVERY compose command for that project (also
+# `up -d netbox-worker`, `restart`, ...): without it compose falls back to the
+# default image tag and RECREATES the netbox container on an older release
+# against the newer database (crash loop: "column users_user.is_staff does not exist").
+```
+
+| netbox-docker | NetBox | token to use |
+|---|---|---|
+| <= 3.x | 4.3 / 4.4 | v1 `0123456789abcdef0123456789abcdef01234567` (`Token` header) |
+| 4.0.x | 4.5 | v2 with random key -> create one via `manage.py shell` (snippet in the CI "Setup API Token" step) |
+| 5.0.2+ | 4.6.10 / 4.7 | v2 `nbt_powernetbox1.0123456789abcdef0123456789abcdef01234567` (`Bearer`, from `SUPERUSER_API_KEY`) |
+
+Run a second version on another port with an override file
+(`services: { netbox: { ports: !override ["8001:8080"] } }`) and a different
+`-p` name. `--profile worker` adds an RQ worker (needed for `?background=true`
+bulk writes and other 4.7 background jobs). Connect with
+`Connect-NBAPI -Hostname localhost -Port 8000 -Scheme http -Credential $cred`
+(the module picks `Bearer` for `nbt_` tokens automatically).
+
 ## Test pattern
 
 Most test files mock at the **module API surface** — that is,
@@ -329,6 +398,11 @@ meta-values like `'Both'` for rack elevation), add an exemption to
 | Bulk operations pipeline runs unboundedly | No client throttle by default | `Send-NBBulkRequest` has `MaxItems = 10000` cap; pass `-BatchSize` to size each POST |
 | Pagination `.next` follow to wrong host | Server-controlled URL could be attacker-controlled | `InvokeNetboxRequest` validates origin against original URI via `GetLeftPart(Authority)` (PR #404) |
 | Array-widened filter silently returns only one match | NetBox honors only the FIRST value of a repeated query key when the underlying filter is scalar, even though #447 sends all values | Verify the filter is `schema.type: array` in the OpenAPI schema before changing `[T]` → `[T[]]`. Scalar example: contact-assignments `object_type_id` (PR #456) |
+| `Set-ItResult -Skipped` inside `BeforeAll`/`AfterAll` FAILS the whole Context | Pester 5 only honours it inside `It` | Guard fixture creation with a plain `return`; put `Set-ItResult -Skipped` in each `It` (PR #469 maintainer-edit) |
+| `Assert-MockCalled` / `Assert-VerifiableMock` not found in CI | PSGallery serves Pester 6.x, which removed them; CI is pinned to 5.7.1 but keep tests valid on both | Use `Should -Invoke -CommandName X -ModuleName M -Times N -Exactly` |
+| `-Tags 'web'` returns `400 Related objects must be referenced by numeric ID or by dictionary of attributes` | NetBox never accepted bare tag names in a body | `BuildURIComponents` (and `ConvertToNBTagReference` for hand-built bodies) now turns names into `@{ name = '<tag>' }`; do not bypass it |
+| `$x -is [PSCustomObject]` is `$true` for a plain string | Any PSObject-wrapped value matches `[PSCustomObject]` | Test `-is [string]` / `-is [ValueType]` first, or look at `$x.PSObject.BaseObject` |
+| Get cmdlet test hangs forever in CI | A generic test invoked a cmdlet whose Query set has a Mandatory param -> interactive prompt | Run Pester with `pwsh -NonInteractive`; skip/feed cmdlets with mandatory params in generic loops |
 | Case-insensitive (`__ie`) filter returns the FULL unfiltered list | NetBox SILENTLY ignores an unknown lookup (HTTP 200, everything) — it does not 400; and `__ie` (iexact) support is per-endpoint (e.g. no `role__ie` on `/dcim/devices/`) | Only rewrite a key to `__ie` if that field exposes `*__ie` for THAT endpoint in the schema; never for numeric/datetime/relational/CIDR/choice fields. Intersect against the live schema, don't hand-curate (PR #454) |
 | Param/switch referenced in body or help but missing from `param()` | Author added `.PARAMETER` help + a body reference but forgot the `[switch]$X` declaration → unbound `$null` (and hard-throws under `Set-StrictMode`) | Every `.PARAMETER` and every `$Var` read in the body needs a matching `param()` entry. The `CodeQuality.Tests.ps1` parity gate catches the help side (PR #454 `-IgnoreCase`) |
 | `Get-NB*Option`/config getter throws on a fresh import | A new `$script:NetboxConfig` key read by the getter was never seeded in `SetupNetboxConfigVariable.ps1` | When adding a Set-/Get- pair backed by `$script:NetboxConfig`, seed the key (e.g. `$false`) in `SetupNetboxConfigVariable.ps1`; getters return the value, don't throw (match `Get-NBTimeout`) (PR #454) |
@@ -355,6 +429,7 @@ meta-values like `'Both'` for rack elevation), add an exemption to
 - [ ] `./scripts/Verify-ValidateSetParity.ps1` — no new drift findings
 - [ ] `./scripts/Verify-FilterExclusion.ps1` — if you touched any `Get-NB*.ps1`, see `docs/guides/` if unfamiliar
 - [ ] `grep -nP "[^\x00-\x7F]" Functions/... Tests/...` — no non-ASCII in `.ps1` files
+- [ ] Live run against the Docker stack for the target version (and the lowest supported one if you version-gated anything): create -> read -> update -> delete, fixtures removed
 - [ ] `git checkout PowerNetbox.psd1` — revert build-artefact drift before committing
 
 ## Pointers

--- a/Functions/Circuits/CircuitGroupAssignments/Get-NBCircuitGroupAssignment.ps1
+++ b/Functions/Circuits/CircuitGroupAssignments/Get-NBCircuitGroupAssignment.ps1
@@ -17,7 +17,14 @@
 .PARAMETER Priority
     Filter by priority.
 
-.PARAMETER Limit
+.PARAMETER Tag
+        Filter by tag slug(s). Several values are combined with AND (object must carry all of them);
+        use Set-NBQueryOption -TagMatch Any (Netbox 4.6.6+) for OR semantics.
+
+    .PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
+    .PARAMETER Limit
     Number of results to return.
 
 .PARAMETER Offset
@@ -81,6 +88,12 @@ function Get-NBCircuitGroupAssignment {
 
         [Parameter(ParameterSetName = 'Query')]
         [string]$Priority,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tag_Id,
 
         [ValidateRange(1, 1000)]
         [uint16]$Limit,

--- a/Functions/Circuits/CircuitGroups/Get-NBCircuitGroup.ps1
+++ b/Functions/Circuits/CircuitGroups/Get-NBCircuitGroup.ps1
@@ -17,7 +17,14 @@
 .PARAMETER Query
     Search query.
 
-.PARAMETER Limit
+.PARAMETER Tag
+        Filter by tag slug(s). Several values are combined with AND (object must carry all of them);
+        use Set-NBQueryOption -TagMatch Any (Netbox 4.6.6+) for OR semantics.
+
+    .PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
+    .PARAMETER Limit
     Number of results to return.
 
 .PARAMETER Offset
@@ -84,6 +91,12 @@ function Get-NBCircuitGroup {
 
         [Parameter(ParameterSetName = 'Query')]
         [string]$Query,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tag_Id,
 
         [ValidateRange(1, 1000)]
         [uint16]$Limit,

--- a/Functions/Circuits/Circuits/Get-NBCircuit.ps1
+++ b/Functions/Circuits/Circuits/Get-NBCircuit.ps1
@@ -39,6 +39,13 @@ function Get-NBCircuit {
     .PARAMETER Tenant
         Tenant assigned to circuit. Provide either [string] or [uint64]. String will search tenant names, integer will search database IDs
 
+    .PARAMETER Tag
+        Filter by tag slug(s). Several values are combined with AND (object must carry all of them);
+        use Set-NBQueryOption -TagMatch Any (Netbox 4.6.6+) for OR semantics.
+
+    .PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
     .PARAMETER Limit
         Maximum number of results to return (1-1000). Default is determined by Netbox server.
 
@@ -120,6 +127,12 @@ function Get-NBCircuit {
 
         [Parameter(ParameterSetName = 'Query')]
         [string]$Tenant,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tag_Id,
 
         [ValidateRange(1, 1000)]
         [uint16]$Limit,

--- a/Functions/Circuits/ProviderAccounts/Get-NBCircuitProviderAccount.ps1
+++ b/Functions/Circuits/ProviderAccounts/Get-NBCircuitProviderAccount.ps1
@@ -20,7 +20,14 @@
 .PARAMETER Query
     Search query.
 
-.PARAMETER Limit
+.PARAMETER Tag
+        Filter by tag slug(s). Several values are combined with AND (object must carry all of them);
+        use Set-NBQueryOption -TagMatch Any (Netbox 4.6.6+) for OR semantics.
+
+    .PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
+    .PARAMETER Limit
     Number of results to return.
 
 .PARAMETER Offset
@@ -87,6 +94,12 @@ function Get-NBCircuitProviderAccount {
 
         [Parameter(ParameterSetName = 'Query')]
         [string]$Query,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tag_Id,
 
         [ValidateRange(1, 1000)]
         [uint16]$Limit,

--- a/Functions/Circuits/ProviderNetworks/Get-NBCircuitProviderNetwork.ps1
+++ b/Functions/Circuits/ProviderNetworks/Get-NBCircuitProviderNetwork.ps1
@@ -17,7 +17,14 @@
 .PARAMETER Query
     Search query.
 
-.PARAMETER Limit
+.PARAMETER Tag
+        Filter by tag slug(s). Several values are combined with AND (object must carry all of them);
+        use Set-NBQueryOption -TagMatch Any (Netbox 4.6.6+) for OR semantics.
+
+    .PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
+    .PARAMETER Limit
     Number of results to return.
 
 .PARAMETER Offset
@@ -81,6 +88,12 @@ function Get-NBCircuitProviderNetwork {
 
         [Parameter(ParameterSetName = 'Query')]
         [string]$Query,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tag_Id,
 
         [ValidateRange(1, 1000)]
         [uint16]$Limit,

--- a/Functions/Circuits/Providers/Get-NBCircuitProvider.ps1
+++ b/Functions/Circuits/Providers/Get-NBCircuitProvider.ps1
@@ -46,7 +46,14 @@
 .PARAMETER Account
     Filter by account.
 
-.PARAMETER Limit
+.PARAMETER Tag
+        Filter by tag slug(s). Several values are combined with AND (object must carry all of them);
+        use Set-NBQueryOption -TagMatch Any (Netbox 4.6.6+) for OR semantics.
+
+    .PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
+    .PARAMETER Limit
     Maximum number of results to return per request (1-1000).
 
 .PARAMETER Offset
@@ -97,6 +104,12 @@ function Get-NBCircuitProvider {
 
         [Parameter(ParameterSetName = 'Query')]
         [string]$Account,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tag_Id,
 
         [ValidateRange(1, 1000)]
         [uint16]$Limit,

--- a/Functions/Circuits/Terminations/Get-NBCircuitTermination.ps1
+++ b/Functions/Circuits/Terminations/Get-NBCircuitTermination.ps1
@@ -52,7 +52,14 @@
 .PARAMETER XConnect_ID
     Filter by xconnect database ID.
 
-.PARAMETER Limit
+.PARAMETER Tag
+        Filter by tag slug(s). Several values are combined with AND (object must carry all of them);
+        use Set-NBQueryOption -TagMatch Any (Netbox 4.6.6+) for OR semantics.
+
+    .PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
+    .PARAMETER Limit
     Maximum number of results to return per request (1-1000).
 
 .PARAMETER Offset
@@ -107,6 +114,12 @@ function Get-NBCircuitTermination {
 
         [Parameter(ParameterSetName = 'Query')]
         [string]$XConnect_ID,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tag_Id,
 
         [ValidateRange(1, 1000)]
         [uint16]$Limit,

--- a/Functions/Circuits/Types/Get-NBCircuitType.ps1
+++ b/Functions/Circuits/Types/Get-NBCircuitType.ps1
@@ -40,7 +40,14 @@
 .PARAMETER Query
     Free-text search across the object (NetBox 'q' parameter).
 
-.PARAMETER Limit
+.PARAMETER Tag
+        Filter by tag slug(s). Several values are combined with AND (object must carry all of them);
+        use Set-NBQueryOption -TagMatch Any (Netbox 4.6.6+) for OR semantics.
+
+    .PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
+    .PARAMETER Limit
     Maximum number of results to return per request (1-1000).
 
 .PARAMETER Offset
@@ -82,6 +89,12 @@ function Get-NBCircuitType {
 
         [Parameter(ParameterSetName = 'Query')]
         [string]$Query,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tag_Id,
 
         [ValidateRange(1, 1000)]
         [uint16]$Limit,

--- a/Functions/Circuits/VirtualCircuitTerminations/Get-NBVirtualCircuitTermination.ps1
+++ b/Functions/Circuits/VirtualCircuitTerminations/Get-NBVirtualCircuitTermination.ps1
@@ -20,7 +20,14 @@
 .PARAMETER Query
     Search query.
 
-.PARAMETER Limit
+.PARAMETER Tag
+        Filter by tag slug(s). Several values are combined with AND (object must carry all of them);
+        use Set-NBQueryOption -TagMatch Any (Netbox 4.6.6+) for OR semantics.
+
+    .PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
+    .PARAMETER Limit
     Number of results to return.
 
 .PARAMETER Offset
@@ -88,6 +95,12 @@ function Get-NBVirtualCircuitTermination {
 
         [Parameter(ParameterSetName = 'Query')]
         [string]$Query,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tag_Id,
 
         [ValidateRange(1, 1000)]
         [uint16]$Limit,

--- a/Functions/Circuits/VirtualCircuitTypes/Get-NBVirtualCircuitType.ps1
+++ b/Functions/Circuits/VirtualCircuitTypes/Get-NBVirtualCircuitType.ps1
@@ -17,7 +17,14 @@
 .PARAMETER Query
     Search query.
 
-.PARAMETER Limit
+.PARAMETER Tag
+        Filter by tag slug(s). Several values are combined with AND (object must carry all of them);
+        use Set-NBQueryOption -TagMatch Any (Netbox 4.6.6+) for OR semantics.
+
+    .PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
+    .PARAMETER Limit
     Number of results to return.
 
 .PARAMETER Offset
@@ -81,6 +88,12 @@ function Get-NBVirtualCircuitType {
 
         [Parameter(ParameterSetName = 'Query')]
         [string]$Query,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tag_Id,
 
         [ValidateRange(1, 1000)]
         [uint16]$Limit,

--- a/Functions/Circuits/VirtualCircuits/Get-NBVirtualCircuit.ps1
+++ b/Functions/Circuits/VirtualCircuits/Get-NBVirtualCircuit.ps1
@@ -32,7 +32,14 @@
 .PARAMETER Query
     Search query.
 
-.PARAMETER Limit
+.PARAMETER Tag
+        Filter by tag slug(s). Several values are combined with AND (object must carry all of them);
+        use Set-NBQueryOption -TagMatch Any (Netbox 4.6.6+) for OR semantics.
+
+    .PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
+    .PARAMETER Limit
     Number of results to return.
 
 .PARAMETER Offset
@@ -111,6 +118,12 @@ function Get-NBVirtualCircuit {
 
         [Parameter(ParameterSetName = 'Query')]
         [string]$Query,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tag_Id,
 
         [ValidateRange(1, 1000)]
         [uint16]$Limit,

--- a/Functions/Core/DataSources/Get-NBDataSource.ps1
+++ b/Functions/Core/DataSources/Get-NBDataSource.ps1
@@ -20,7 +20,14 @@
 .PARAMETER Query
     Search query.
 
-.PARAMETER Limit
+.PARAMETER Tag
+        Filter by tag slug(s). Several values are combined with AND (object must carry all of them);
+        use Set-NBQueryOption -TagMatch Any (Netbox 4.6.6+) for OR semantics.
+
+    .PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
+    .PARAMETER Limit
     Number of results to return.
 
 .PARAMETER Offset
@@ -88,6 +95,12 @@ function Get-NBDataSource {
 
         [Parameter(ParameterSetName = 'Query')]
         [string]$Query,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tag_Id,
 
         [ValidateRange(1, 1000)]
         [uint16]$Limit,

--- a/Functions/DCIM/CableBundles/Get-NBDCIMCableBundle.ps1
+++ b/Functions/DCIM/CableBundles/Get-NBDCIMCableBundle.ps1
@@ -35,7 +35,14 @@
 .PARAMETER PageSize
     Page size to request while -All follows pagination.
 
-.PARAMETER Limit
+.PARAMETER Tag
+        Filter by tag slug(s). Several values are combined with AND (object must carry all of them);
+        use Set-NBQueryOption -TagMatch Any (Netbox 4.6.6+) for OR semantics.
+
+    .PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
+    .PARAMETER Limit
     Maximum number of results to return per request (1-1000).
 
 .PARAMETER Offset
@@ -69,6 +76,12 @@ function Get-NBDCIMCableBundle {
 
         [Parameter(ParameterSetName = 'Query')]
         [string]$Query,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tag_Id,
 
         [ValidateRange(1, 1000)]
         [uint16]$Limit,

--- a/Functions/DCIM/Cables/Get-NBDCIMCable.ps1
+++ b/Functions/DCIM/Cables/Get-NBDCIMCable.ps1
@@ -12,7 +12,14 @@
 .PARAMETER PageSize
     Number of results per page (1-1000, default 100).
 
-.PARAMETER Limit
+.PARAMETER Tag
+        Filter by tag slug(s). Several values are combined with AND (object must carry all of them);
+        use Set-NBQueryOption -TagMatch Any (Netbox 4.6.6+) for OR semantics.
+
+    .PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
+    .PARAMETER Limit
     Maximum number of results to return.
 
 .PARAMETER Offset
@@ -112,6 +119,12 @@ function Get-NBDCIMCable {
         [string[]]$Fields,
 
         [string[]]$Omit,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tag_Id,
 
         [ValidateRange(1, 1000)]
         [uint16]$Limit,

--- a/Functions/DCIM/Cables/New-NBDCIMCable.ps1
+++ b/Functions/DCIM/Cables/New-NBDCIMCable.ps1
@@ -167,7 +167,7 @@ function New-NBDCIMCable {
         if ($PSBoundParameters.ContainsKey('Length_Unit')) { $body.length_unit = $Length_Unit }
         if ($PSBoundParameters.ContainsKey('Description')) { $body.description = $Description }
         if ($PSBoundParameters.ContainsKey('Comments')) { $body.comments = $Comments }
-        if ($PSBoundParameters.ContainsKey('Tags')) { $body.tags = $Tags }
+        if ($PSBoundParameters.ContainsKey('Tags')) { $body.tags = ConvertToNBTagReference -Tags $Tags }
         if ($PSBoundParameters.ContainsKey('Custom_Fields')) { $body.custom_fields = $Custom_Fields }
         if ($PSBoundParameters.ContainsKey('Cable_Profile') -and -not $excludeProfile) { $body.profile = $Cable_Profile }
 

--- a/Functions/DCIM/ConsolePorts/Get-NBDCIMConsolePort.ps1
+++ b/Functions/DCIM/ConsolePorts/Get-NBDCIMConsolePort.ps1
@@ -46,7 +46,14 @@
 .PARAMETER Query
     Free-text search across the object (NetBox 'q' parameter).
 
-.PARAMETER Limit
+.PARAMETER Tag
+        Filter by tag slug(s). Several values are combined with AND (object must carry all of them);
+        use Set-NBQueryOption -TagMatch Any (Netbox 4.6.6+) for OR semantics.
+
+    .PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
+    .PARAMETER Limit
     Maximum number of results to return per request (1-1000).
 
 .PARAMETER Offset
@@ -82,6 +89,12 @@ function Get-NBDCIMConsolePort {
         [Parameter(ParameterSetName = 'Query')][uint64]$Module_Id,
         [Parameter(ParameterSetName = 'Query')][string]$Type,
         [Parameter(ParameterSetName = 'Query')][string]$Query,
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tag_Id,
+
         [ValidateRange(1, 1000)]
         [uint16]$Limit,
         [ValidateRange(0, [int]::MaxValue)]

--- a/Functions/DCIM/ConsoleServerPorts/Get-NBDCIMConsoleServerPort.ps1
+++ b/Functions/DCIM/ConsoleServerPorts/Get-NBDCIMConsoleServerPort.ps1
@@ -46,7 +46,14 @@
 .PARAMETER Query
     Free-text search across the object (NetBox 'q' parameter).
 
-.PARAMETER Limit
+.PARAMETER Tag
+        Filter by tag slug(s). Several values are combined with AND (object must carry all of them);
+        use Set-NBQueryOption -TagMatch Any (Netbox 4.6.6+) for OR semantics.
+
+    .PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
+    .PARAMETER Limit
     Maximum number of results to return per request (1-1000).
 
 .PARAMETER Offset
@@ -82,6 +89,12 @@ function Get-NBDCIMConsoleServerPort {
         [Parameter(ParameterSetName = 'Query')][uint64]$Module_Id,
         [Parameter(ParameterSetName = 'Query')][string]$Type,
         [Parameter(ParameterSetName = 'Query')][string]$Query,
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tag_Id,
+
         [ValidateRange(1, 1000)]
         [uint16]$Limit,
         [ValidateRange(0, [int]::MaxValue)]

--- a/Functions/DCIM/CoolingFeeds/Get-NBDCIMCoolingFeed.ps1
+++ b/Functions/DCIM/CoolingFeeds/Get-NBDCIMCoolingFeed.ps1
@@ -75,6 +75,9 @@
 
 .PARAMETER Tag
     Filter by tag slug. Accepts multiple values.
+.PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
 
 .PARAMETER Query
     Free-text search across the object (NetBox 'q' parameter).
@@ -168,6 +171,11 @@ function Get-NBDCIMCoolingFeed {
 
         [Parameter(ParameterSetName = 'Query')]
         [string[]]$Tag,
+
+
+        [Parameter(ParameterSetName = 'Query')]
+
+        [uint64[]]$Tag_Id,
 
         [Parameter(ParameterSetName = 'Query')]
         [string]$Query,

--- a/Functions/DCIM/CoolingFeeds/Get-NBDCIMCoolingFeed.ps1
+++ b/Functions/DCIM/CoolingFeeds/Get-NBDCIMCoolingFeed.ps1
@@ -1,0 +1,205 @@
+<#
+.SYNOPSIS
+    Retrieves Cooling Feed objects from Netbox DCIM module.
+
+.DESCRIPTION
+    Retrieves Cooling Feed objects from Netbox DCIM module (NetBox 4.7+).
+    A cooling feed delivers cooling capacity from a cooling source to a
+    rack, analogous to a power feed in the power distribution model.
+
+.PARAMETER Raw
+    Return the raw API response instead of the results array.
+
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'cooling_source.name', 'rack.name').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+.PARAMETER Id
+    One or more database IDs to retrieve.
+
+.PARAMETER Name
+    Filter by name. Accepts multiple values.
+
+.PARAMETER Cooling_Source_Id
+    Filter by cooling source database ID. Accepts multiple values.
+
+.PARAMETER Rack_Id
+    Filter by rack database ID. Accepts multiple values.
+
+.PARAMETER Site_Id
+    Filter by site database ID (via the cooling source). Accepts multiple values.
+
+.PARAMETER Site
+    Filter by site slug (via the cooling source). Accepts multiple values.
+
+.PARAMETER Region_Id
+    Filter by region database ID. Accepts multiple values.
+
+.PARAMETER Tenant_Id
+    Filter by tenant database ID. Accepts multiple values.
+
+.PARAMETER Tenant
+    Filter by tenant slug. Accepts multiple values.
+
+.PARAMETER Status
+    Filter by operational status (offline, active, planned, failed).
+    Accepts multiple values.
+
+.PARAMETER Max_Flow_Unit
+    Filter by maximum flow unit (lpm, m3ph, gpm). Accepts multiple values.
+
+.PARAMETER Cooling_Capacity
+    Filter by rated cooling capacity in kW. Accepts multiple values.
+
+.PARAMETER Max_Flow
+    Filter by maximum flow rate. Accepts multiple values.
+
+.PARAMETER Description
+    Filter by description. Accepts multiple values.
+
+.PARAMETER Tag
+    Filter by tag slug. Accepts multiple values.
+
+.PARAMETER Query
+    Free-text search across the object (NetBox 'q' parameter).
+
+.PARAMETER Limit
+    Maximum number of results to return per request (1-1000).
+
+.PARAMETER Offset
+    Number of results to skip (pagination offset).
+
+.EXAMPLE
+    Get-NBDCIMCoolingFeed
+
+    Returns all cooling feeds.
+
+.EXAMPLE
+    Get-NBDCIMCoolingFeed -Cooling_Source_Id 3 -Status active
+
+    Returns all active cooling feeds provisioned from cooling source ID 3.
+
+.EXAMPLE
+    Get-NBDCIMCoolingFeed -Rack_Id 12
+
+    Returns the cooling feeds attached to rack ID 12.
+
+.NOTES
+    AddedInVersion: v4.7.1.0
+    Requires NetBox 4.7.0 or later.
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
+.LINK
+    https://netbox.readthedocs.io/en/stable/rest-api/overview/
+#>
+function Get-NBDCIMCoolingFeed {
+    [CmdletBinding(DefaultParameterSetName = 'Query')]
+    [OutputType([PSCustomObject])]
+    param(
+        [switch]$All,
+
+        [ValidateRange(1, 1000)]
+        [int]$PageSize = 100,
+
+        [switch]$Brief,
+
+        [string[]]$Fields,
+
+        [string[]]$Omit,
+
+        [Parameter(ParameterSetName = 'ByID', ValueFromPipelineByPropertyName = $true)]
+        [uint64[]]$Id,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Name,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Cooling_Source_Id,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Rack_Id,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Site_Id,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Site,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Region_Id,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tenant_Id,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tenant,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [ValidateSet('offline', 'active', 'planned', 'failed')]
+        [string[]]$Status,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [ValidateSet('lpm', 'm3ph', 'gpm')]
+        [string[]]$Max_Flow_Unit,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [decimal[]]$Cooling_Capacity,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [decimal[]]$Max_Flow,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Description,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string]$Query,
+
+        [ValidateRange(1, 1000)]
+        [uint16]$Limit,
+
+        [ValidateRange(0, [int]::MaxValue)]
+        [uint32]$Offset,
+
+        [switch]$Raw
+    )
+    process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
+        Write-Verbose "Retrieving DCIM Cooling Feed"
+        switch ($PSCmdlet.ParameterSetName) {
+            'ByID' {
+                foreach ($i in $Id) {
+                    $Segments = [System.Collections.ArrayList]::new(@('dcim', 'cooling-feeds', $i))
+                    $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw', 'All', 'PageSize'
+                    $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
+                    InvokeNetboxRequest -URI $URI -Raw:$Raw
+                }
+            }
+            default {
+                $Segments = [System.Collections.ArrayList]::new(@('dcim', 'cooling-feeds'))
+                $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'All', 'PageSize'
+                $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
+                InvokeNetboxRequest -URI $URI -Raw:$Raw -All:$All -PageSize $PageSize
+            }
+        }
+    }
+}

--- a/Functions/DCIM/CoolingFeeds/New-NBDCIMCoolingFeed.ps1
+++ b/Functions/DCIM/CoolingFeeds/New-NBDCIMCoolingFeed.ps1
@@ -1,0 +1,108 @@
+<#
+.SYNOPSIS
+    Creates a new Cooling Feed in Netbox DCIM module.
+
+.DESCRIPTION
+    Creates a new Cooling Feed in Netbox DCIM module (NetBox 4.7+).
+    A cooling feed delivers cooling capacity from a cooling source to a
+    rack, analogous to a power feed in the power distribution model.
+
+.PARAMETER Raw
+    Return the raw API response instead of the results array.
+
+.PARAMETER Cooling_Source
+    Cooling source this feed is provisioned from (database ID). Required.
+
+.PARAMETER Rack
+    Rack this feed supplies (database ID).
+
+.PARAMETER Name
+    Name of the cooling feed. Required.
+
+.PARAMETER Status
+    Operational status: offline, active, planned or failed. Defaults to active server-side.
+
+.PARAMETER Cooling_Capacity
+    Rated cooling capacity in kW.
+
+.PARAMETER Max_Flow
+    Maximum flow rate, expressed in the unit given by -Max_Flow_Unit.
+
+.PARAMETER Max_Flow_Unit
+    Unit for -Max_Flow: lpm (liters per minute), m3ph (cubic meters per hour) or gpm (gallons per minute).
+
+.PARAMETER Description
+    Brief description.
+
+.PARAMETER Tenant
+    Tenant assigned to this object (database ID).
+
+.PARAMETER Owner
+    Owner of this object (database ID).
+
+.PARAMETER Comments
+    Detailed comments (Markdown is supported).
+
+.PARAMETER Tags
+    One or more tags to assign to this object (tag names or IDs).
+
+.PARAMETER Custom_Fields
+    Hashtable of custom field values to set (cf_<name>).
+
+.EXAMPLE
+    New-NBDCIMCoolingFeed -Cooling_Source 3 -Name 'CF-01' -Rack 12 -Cooling_Capacity 25 -Max_Flow 40 -Max_Flow_Unit lpm
+
+    Creates a 25 kW cooling feed from cooling source ID 3 to rack ID 12 with a 40 L/min maximum flow.
+
+.LINK
+    https://netbox.readthedocs.io/en/stable/rest-api/overview/
+.NOTES
+    AddedInVersion: v4.7.1.0
+    Requires NetBox 4.7.0 or later.
+
+#>
+function New-NBDCIMCoolingFeed {
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Low')]
+    [OutputType([PSCustomObject])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [uint64]$Cooling_Source,
+
+        [uint64]$Rack,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Name,
+
+        [ValidateSet('offline', 'active', 'planned', 'failed')]
+        [string]$Status,
+
+        [decimal]$Cooling_Capacity,
+
+        [decimal]$Max_Flow,
+
+        [ValidateSet('lpm', 'm3ph', 'gpm')]
+        [string]$Max_Flow_Unit,
+
+        [string]$Description,
+
+        [uint64]$Tenant,
+
+        [uint64]$Owner,
+
+        [string]$Comments,
+
+        [object[]]$Tags,
+
+        [hashtable]$Custom_Fields,
+
+        [switch]$Raw
+    )
+    process {
+        Write-Verbose "Creating DCIM Cooling Feed"
+        $Segments = [System.Collections.ArrayList]::new(@('dcim', 'cooling-feeds'))
+        $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw'
+        if ($PSCmdlet.ShouldProcess($Name, 'Create cooling feed')) {
+            InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments) -Method POST -Body $URIComponents.Parameters -Raw:$Raw
+        }
+    }
+}

--- a/Functions/DCIM/CoolingFeeds/Remove-NBDCIMCoolingFeed.ps1
+++ b/Functions/DCIM/CoolingFeeds/Remove-NBDCIMCoolingFeed.ps1
@@ -1,0 +1,47 @@
+<#
+.SYNOPSIS
+    Removes a Cooling Feed from Netbox DCIM module.
+
+.DESCRIPTION
+    Removes a Cooling Feed from Netbox DCIM module (NetBox 4.7+).
+    Supports pipeline input for the Id parameter.
+
+.PARAMETER Raw
+    Return the raw API response instead of the results array.
+
+.PARAMETER Id
+    Database ID of the cooling feed to delete.
+
+.EXAMPLE
+    Remove-NBDCIMCoolingFeed -Id 7
+
+    Deletes cooling feed ID 7 after confirmation.
+
+.EXAMPLE
+    Get-NBDCIMCoolingFeed -Cooling_Source_Id 3 | Remove-NBDCIMCoolingFeed -Confirm:$false
+
+    Deletes every cooling feed provisioned from cooling source ID 3 without prompting.
+
+.LINK
+    https://netbox.readthedocs.io/en/stable/rest-api/overview/
+.NOTES
+    AddedInVersion: v4.7.1.0
+    Requires NetBox 4.7.0 or later.
+
+#>
+function Remove-NBDCIMCoolingFeed {
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
+    [OutputType([void])]
+    param(
+        [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
+        [uint64]$Id,
+
+        [switch]$Raw
+    )
+    process {
+        Write-Verbose "Removing DCIM Cooling Feed"
+        if ($PSCmdlet.ShouldProcess($Id, 'Delete cooling feed')) {
+            InvokeNetboxRequest -URI (BuildNewURI -Segments @('dcim', 'cooling-feeds', $Id)) -Method DELETE -Raw:$Raw
+        }
+    }
+}

--- a/Functions/DCIM/CoolingFeeds/Set-NBDCIMCoolingFeed.ps1
+++ b/Functions/DCIM/CoolingFeeds/Set-NBDCIMCoolingFeed.ps1
@@ -1,0 +1,133 @@
+<#
+.SYNOPSIS
+    Updates an existing Cooling Feed in Netbox DCIM module.
+
+.DESCRIPTION
+    Updates an existing Cooling Feed in Netbox DCIM module (NetBox 4.7+)
+    via a PATCH request. Only the parameters you supply are sent.
+    Supports pipeline input for the Id parameter.
+
+    Nullable fields can be cleared server-side:
+    - Pass $null to -Rack, -Tenant, -Cooling_Capacity or -Max_Flow.
+    - Pass '' (empty string) to -Max_Flow_Unit.
+
+.PARAMETER Raw
+    Return the raw API response instead of the results array.
+
+.PARAMETER Id
+    Database ID of the cooling feed to update.
+
+.PARAMETER Cooling_Source
+    Cooling source this feed is provisioned from (database ID).
+
+.PARAMETER Rack
+    Rack this feed supplies (database ID). Pass $null to clear.
+
+.PARAMETER Name
+    Name of the cooling feed.
+
+.PARAMETER Status
+    Operational status: offline, active, planned or failed.
+
+.PARAMETER Cooling_Capacity
+    Rated cooling capacity in kW. Pass $null to clear.
+
+.PARAMETER Max_Flow
+    Maximum flow rate, expressed in the unit given by -Max_Flow_Unit. Pass $null to clear.
+
+.PARAMETER Max_Flow_Unit
+    Unit for -Max_Flow: lpm (liters per minute), m3ph (cubic meters per hour) or gpm (gallons per minute).
+    Pass '' (empty string) to clear the field server-side.
+
+.PARAMETER Description
+    Brief description.
+
+.PARAMETER Tenant
+    Tenant assigned to this object (database ID). Pass $null to clear.
+
+.PARAMETER Owner
+    Owner of this object (database ID).
+
+.PARAMETER Comments
+    Detailed comments (Markdown is supported).
+
+.PARAMETER Tags
+    One or more tags to assign to this object (tag names or IDs).
+
+.PARAMETER Custom_Fields
+    Hashtable of custom field values to set (cf_<name>).
+
+.EXAMPLE
+    Set-NBDCIMCoolingFeed -Id 7 -Status offline
+
+    Marks cooling feed ID 7 as offline.
+
+.EXAMPLE
+    Set-NBDCIMCoolingFeed -Id 7 -Rack $null -Max_Flow_Unit ''
+
+    Detaches cooling feed ID 7 from its rack and clears the flow unit.
+
+.LINK
+    https://netbox.readthedocs.io/en/stable/rest-api/overview/
+.NOTES
+    AddedInVersion: v4.7.1.0
+    Requires NetBox 4.7.0 or later.
+
+#>
+function Set-NBDCIMCoolingFeed {
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
+    [OutputType([PSCustomObject])]
+    param(
+        [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
+        [uint64]$Id,
+
+        [uint64]$Cooling_Source,
+
+        [Nullable[uint64]]$Rack,
+
+        [string]$Name,
+
+        [ValidateSet('offline', 'active', 'planned', 'failed')]
+        [string]$Status,
+
+        [Nullable[decimal]]$Cooling_Capacity,
+
+        [Nullable[decimal]]$Max_Flow,
+
+        [AllowEmptyString()]
+        [ValidateSet('lpm', 'm3ph', 'gpm', '')]
+        [string]$Max_Flow_Unit,
+
+        [string]$Description,
+
+        [Nullable[uint64]]$Tenant,
+
+        [uint64]$Owner,
+
+        [string]$Comments,
+
+        [object[]]$Tags,
+
+        [hashtable]$Custom_Fields,
+
+        [switch]$Raw
+    )
+    process {
+        Write-Verbose "Updating DCIM Cooling Feed"
+
+        # Translate '' -> $null for clearable enum params BEFORE
+        # BuildURIComponents, so the PATCH body carries JSON null
+        # (NetBox rejects "" for these nullable enum fields).
+        foreach ($p in @('Max_Flow_Unit')) {
+            if ($PSBoundParameters.ContainsKey($p) -and $PSBoundParameters[$p] -eq '') {
+                $PSBoundParameters[$p] = $null
+            }
+        }
+
+        $Segments = [System.Collections.ArrayList]::new(@('dcim', 'cooling-feeds', $Id))
+        $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw'
+        if ($PSCmdlet.ShouldProcess($Id, 'Update cooling feed')) {
+            InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments) -Method PATCH -Body $URIComponents.Parameters -Raw:$Raw
+        }
+    }
+}

--- a/Functions/DCIM/CoolingIntakeTemplates/Get-NBDCIMCoolingIntakeTemplate.ps1
+++ b/Functions/DCIM/CoolingIntakeTemplates/Get-NBDCIMCoolingIntakeTemplate.ps1
@@ -1,0 +1,176 @@
+<#
+.SYNOPSIS
+    Retrieves Cooling Intake Templates objects from Netbox DCIM module.
+
+.DESCRIPTION
+    Retrieves Cooling Intake Templates objects from Netbox DCIM module (NetBox 4.7+).
+    Array-typed filters accept multiple values and are sent as repeated query keys.
+
+.PARAMETER Raw
+    Return the raw API response instead of the results array.
+
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'device.name', 'module.display').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+.PARAMETER Id
+    One or more database IDs to retrieve.
+
+.PARAMETER Name
+    Filter by name (one or more values).
+
+.PARAMETER Label
+    Filter by physical label (one or more values).
+
+.PARAMETER Device_Type_Id
+    Filter by device type database ID.
+
+.PARAMETER Module_Type_Id
+    Filter by module type database ID.
+
+.PARAMETER Type
+    Filter by connector type ('uqd', 'uqdb', 'qdc', 'camlock', 'npt', 'bsp', 'proprietary').
+
+.PARAMETER Diameter
+    Filter by connector diameter.
+
+.PARAMETER Diameter_Unit
+    Filter by diameter unit ('mm', 'cm', 'in').
+
+.PARAMETER Max_Flow
+    Filter by maximum flow rate.
+
+.PARAMETER Max_Flow_Unit
+    Filter by maximum flow unit ('lpm', 'm3ph', 'gpm').
+
+.PARAMETER Description
+    Filter by description (one or more values).
+
+.PARAMETER Query
+    Free-text search across the object (NetBox 'q' parameter).
+
+.PARAMETER Limit
+    Maximum number of results to return per request (1-1000).
+
+.PARAMETER Offset
+    Number of results to skip (pagination offset).
+
+.EXAMPLE
+    Get-NBDCIMCoolingIntakeTemplate
+
+    Retrieves all cooling intake templates.
+
+.EXAMPLE
+    Get-NBDCIMCoolingIntakeTemplate -Device_Type_Id 4
+
+    Lists the cooling intake templates of device type 4.
+
+.EXAMPLE
+    Get-NBDCIMCoolingIntakeTemplate -Id 5
+
+    Retrieves the cooling intake template with ID 5.
+
+.LINK
+    https://netbox.readthedocs.io/en/stable/rest-api/overview/
+.NOTES
+    AddedInVersion: v4.7.1.0
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
+#>
+function Get-NBDCIMCoolingIntakeTemplate {
+    [CmdletBinding(DefaultParameterSetName = 'Query')]
+    [OutputType([PSCustomObject])]
+    param(
+        [switch]$All,
+
+        [ValidateRange(1, 1000)]
+        [int]$PageSize = 100,
+
+        [switch]$Brief,
+
+        [string[]]$Fields,
+
+        [string[]]$Omit,
+
+        [Parameter(ParameterSetName = 'ByID', ValueFromPipelineByPropertyName = $true)]
+        [uint64[]]$Id,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Name,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Label,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Device_Type_Id,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Module_Type_Id,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Type,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [decimal[]]$Diameter,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Diameter_Unit,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [decimal[]]$Max_Flow,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Max_Flow_Unit,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Description,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string]$Query,
+
+        [ValidateRange(1, 1000)]
+        [uint16]$Limit,
+
+        [ValidateRange(0, [int]::MaxValue)]
+        [uint32]$Offset,
+
+        [switch]$Raw
+    )
+    process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
+        Write-Verbose "Retrieving DCIM Cooling Intake Template"
+        switch ($PSCmdlet.ParameterSetName) {
+            'ByID' {
+                foreach ($i in $Id) {
+                    $Segments = [System.Collections.ArrayList]::new(@('dcim', 'cooling-intake-templates', $i))
+                    $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw', 'All', 'PageSize'
+                    $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
+                    InvokeNetboxRequest -URI $URI -Raw:$Raw
+                }
+            }
+            default {
+                $Segments = [System.Collections.ArrayList]::new(@('dcim', 'cooling-intake-templates'))
+                $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'All', 'PageSize'
+                $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
+                InvokeNetboxRequest -URI $URI -Raw:$Raw -All:$All -PageSize $PageSize
+            }
+        }
+    }
+}

--- a/Functions/DCIM/CoolingIntakeTemplates/New-NBDCIMCoolingIntakeTemplate.ps1
+++ b/Functions/DCIM/CoolingIntakeTemplates/New-NBDCIMCoolingIntakeTemplate.ps1
@@ -1,0 +1,94 @@
+<#
+.SYNOPSIS
+    Creates a new DCIM CoolingIntakeTemplate in Netbox DCIM module.
+
+.DESCRIPTION
+    Creates a new Cooling Intake Template (NetBox 4.7+).
+    Supports pipeline input for bulk creation.
+
+.PARAMETER Raw
+    Return the raw API response instead of the results array.
+
+.PARAMETER Device_Type
+    Device type this template belongs to (database ID). Mutually exclusive with -Module_Type.
+
+.PARAMETER Module_Type
+    Module type this template belongs to (database ID). Mutually exclusive with -Device_Type.
+
+.PARAMETER Name
+    Name of the template. Use {module} as a placeholder for the module bay position on module type templates.
+
+.PARAMETER Label
+    Physical label.
+
+.PARAMETER Type
+    Connector type: 'uqd', 'uqdb', 'qdc', 'camlock', 'npt', 'bsp'
+    or 'proprietary'.
+
+.PARAMETER Diameter
+    Connector diameter (number, 0.01 - 1000000).
+
+.PARAMETER Diameter_Unit
+    Unit for -Diameter: 'mm', 'cm' or 'in'.
+
+.PARAMETER Max_Flow
+    Maximum coolant flow rate (number, 0.01 - 1000000).
+
+.PARAMETER Max_Flow_Unit
+    Unit for -Max_Flow: 'lpm', 'm3ph' or 'gpm'.
+
+.PARAMETER Description
+    Brief description.
+
+.EXAMPLE
+    New-NBDCIMCoolingIntakeTemplate -Device_Type 4 -Name 'Coolant In' -Type 'uqd' -Max_Flow 8 -Max_Flow_Unit 'lpm'
+
+    Creates a cooling intake template on device type 4.
+
+.LINK
+    https://netbox.readthedocs.io/en/stable/rest-api/overview/
+.NOTES
+    AddedInVersion: v4.7.1.0
+#>
+function New-NBDCIMCoolingIntakeTemplate {
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Low')]
+    [OutputType([PSCustomObject])]
+    param(
+        [uint64]$Device_Type,
+
+        [uint64]$Module_Type,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Name,
+
+        [string]$Label,
+
+        [ValidateSet('uqd', 'uqdb', 'qdc', 'camlock', 'npt', 'bsp', 'proprietary', IgnoreCase = $true)]
+        [string]$Type,
+
+        [ValidateRange(0.01, 1000000)]
+        [decimal]$Diameter,
+
+        [ValidateSet('mm', 'cm', 'in', IgnoreCase = $true)]
+        [string]$Diameter_Unit,
+
+        [ValidateRange(0.01, 1000000)]
+        [decimal]$Max_Flow,
+
+        [ValidateSet('lpm', 'm3ph', 'gpm', IgnoreCase = $true)]
+        [string]$Max_Flow_Unit,
+
+        [string]$Description,
+
+        [switch]$Raw
+    )
+    process {
+        Write-Verbose "Creating DCIM Cooling Intake Template"
+        $Segments = [System.Collections.ArrayList]::new(@('dcim', 'cooling-intake-templates'))
+        $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw'
+        if ($PSCmdlet.ShouldProcess($Name, 'Create cooling intake template')) {
+            InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments) -Method POST -Body $URIComponents.Parameters -Raw:$Raw
+        }
+    }
+}

--- a/Functions/DCIM/CoolingIntakeTemplates/Remove-NBDCIMCoolingIntakeTemplate.ps1
+++ b/Functions/DCIM/CoolingIntakeTemplates/Remove-NBDCIMCoolingIntakeTemplate.ps1
@@ -1,0 +1,45 @@
+<#
+.SYNOPSIS
+    Removes a DCIM CoolingIntakeTemplate from Netbox DCIM module.
+
+.DESCRIPTION
+    Removes a Cooling Intake Template (NetBox 4.7+).
+    Supports pipeline input for the Id parameter.
+
+.PARAMETER Raw
+    Return the raw API response instead of the results array.
+
+.PARAMETER Id
+    Database ID of the object to delete.
+
+.EXAMPLE
+    Remove-NBDCIMCoolingIntakeTemplate -Id 5
+
+    Deletes the cooling intake template with ID 5.
+
+.EXAMPLE
+    Get-NBDCIMCoolingIntakeTemplate -Device_Type_Id 12 | Remove-NBDCIMCoolingIntakeTemplate -Confirm:$false
+
+    Deletes every cooling intake template of device type 12 without prompting.
+
+.LINK
+    https://netbox.readthedocs.io/en/stable/rest-api/overview/
+.NOTES
+    AddedInVersion: v4.7.1.0
+#>
+function Remove-NBDCIMCoolingIntakeTemplate {
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
+    [OutputType([void])]
+    param(
+        [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
+        [uint64]$Id,
+
+        [switch]$Raw
+    )
+    process {
+        Write-Verbose "Removing DCIM Cooling Intake Template ID $Id"
+        if ($PSCmdlet.ShouldProcess($Id, 'Delete cooling intake template')) {
+            InvokeNetboxRequest -URI (BuildNewURI -Segments @('dcim', 'cooling-intake-templates', $Id)) -Method DELETE -Raw:$Raw
+        }
+    }
+}

--- a/Functions/DCIM/CoolingIntakeTemplates/Set-NBDCIMCoolingIntakeTemplate.ps1
+++ b/Functions/DCIM/CoolingIntakeTemplates/Set-NBDCIMCoolingIntakeTemplate.ps1
@@ -1,0 +1,117 @@
+<#
+.SYNOPSIS
+    Updates an existing DCIM CoolingIntakeTemplate in Netbox DCIM module.
+
+.DESCRIPTION
+    Updates an existing Cooling Intake Template (NetBox 4.7+) via PATCH.
+    Supports pipeline input for the Id parameter.
+    Nullable numeric and FK parameters accept $null to clear the field;
+    clearable enum parameters accept '' (empty string) to clear the field.
+
+.PARAMETER Raw
+    Return the raw API response instead of the results array.
+
+.PARAMETER Id
+    Database ID of the object to update.
+
+.PARAMETER Device_Type
+    Device type this template belongs to (database ID). Mutually exclusive with -Module_Type. Pass $null to clear.
+
+.PARAMETER Module_Type
+    Module type this template belongs to (database ID). Mutually exclusive with -Device_Type. Pass $null to clear.
+
+.PARAMETER Name
+    Name of the template. Use {module} as a placeholder for the module bay position on module type templates.
+
+.PARAMETER Label
+    Physical label.
+
+.PARAMETER Type
+    Connector type: 'uqd', 'uqdb', 'qdc', 'camlock', 'npt', 'bsp'
+    or 'proprietary'.
+    Pass '' to clear the field server-side (sent as JSON null).
+
+.PARAMETER Diameter
+    Connector diameter (number, 0.01 - 1000000). Pass $null to clear.
+
+.PARAMETER Diameter_Unit
+    Unit for -Diameter: 'mm', 'cm' or 'in'.
+    Pass '' to clear the field server-side (sent as JSON null).
+    NetBox requires a unit whenever -Diameter is set, so clear both
+    together: -Diameter $null -Diameter_Unit ''.
+
+.PARAMETER Max_Flow
+    Maximum coolant flow rate (number, 0.01 - 1000000). Pass $null to clear.
+
+.PARAMETER Max_Flow_Unit
+    Unit for -Max_Flow: 'lpm', 'm3ph' or 'gpm'.
+    Pass '' to clear the field server-side (sent as JSON null).
+    NetBox requires a unit whenever -Max_Flow is set, so clear both
+    together: -Max_Flow $null -Max_Flow_Unit ''.
+
+.PARAMETER Description
+    Brief description.
+
+.EXAMPLE
+    Set-NBDCIMCoolingIntakeTemplate -Id 5 -Label 'IN-1' -Type ''
+
+    Sets the label and clears the connector type of cooling intake template 5.
+
+.LINK
+    https://netbox.readthedocs.io/en/stable/rest-api/overview/
+.NOTES
+    AddedInVersion: v4.7.1.0
+#>
+function Set-NBDCIMCoolingIntakeTemplate {
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
+    [OutputType([PSCustomObject])]
+    param(
+        [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
+        [uint64]$Id,
+
+        [Nullable[uint64]]$Device_Type,
+
+        [Nullable[uint64]]$Module_Type,
+
+        [string]$Name,
+
+        [string]$Label,
+
+        [AllowEmptyString()]
+        [ValidateSet('uqd', 'uqdb', 'qdc', 'camlock', 'npt', 'bsp', 'proprietary', '', IgnoreCase = $true)]
+        [string]$Type,
+
+        [Nullable[decimal]]$Diameter,
+
+        [AllowEmptyString()]
+        [ValidateSet('mm', 'cm', 'in', '', IgnoreCase = $true)]
+        [string]$Diameter_Unit,
+
+        [Nullable[decimal]]$Max_Flow,
+
+        [AllowEmptyString()]
+        [ValidateSet('lpm', 'm3ph', 'gpm', '', IgnoreCase = $true)]
+        [string]$Max_Flow_Unit,
+
+        [string]$Description,
+
+        [switch]$Raw
+    )
+    process {
+        # Translate '' -> $null for clearable enum params BEFORE
+        # BuildURIComponents, so the PATCH body carries JSON null
+        # (NetBox rejects "" for these nullable enum fields).
+        foreach ($p in @('Type', 'Diameter_Unit', 'Max_Flow_Unit')) {
+            if ($PSBoundParameters.ContainsKey($p) -and $PSBoundParameters[$p] -eq '') {
+                $PSBoundParameters[$p] = $null
+            }
+        }
+
+        Write-Verbose "Updating DCIM Cooling Intake Template ID $Id"
+        $Segments = [System.Collections.ArrayList]::new(@('dcim', 'cooling-intake-templates', $Id))
+        $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw'
+        if ($PSCmdlet.ShouldProcess($Id, 'Update cooling intake template')) {
+            InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments) -Method PATCH -Body $URIComponents.Parameters -Raw:$Raw
+        }
+    }
+}

--- a/Functions/DCIM/CoolingIntakes/Get-NBDCIMCoolingIntake.ps1
+++ b/Functions/DCIM/CoolingIntakes/Get-NBDCIMCoolingIntake.ps1
@@ -85,6 +85,9 @@
 
 .PARAMETER Tag
     Filter by tag slug (one or more values).
+.PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
 
 .PARAMETER Query
     Free-text search across the object (NetBox 'q' parameter).
@@ -187,6 +190,11 @@ function Get-NBDCIMCoolingIntake {
 
         [Parameter(ParameterSetName = 'Query')]
         [string[]]$Tag,
+
+
+        [Parameter(ParameterSetName = 'Query')]
+
+        [uint64[]]$Tag_Id,
 
         [Parameter(ParameterSetName = 'Query')]
         [string]$Query,

--- a/Functions/DCIM/CoolingIntakes/Get-NBDCIMCoolingIntake.ps1
+++ b/Functions/DCIM/CoolingIntakes/Get-NBDCIMCoolingIntake.ps1
@@ -1,0 +1,224 @@
+<#
+.SYNOPSIS
+    Retrieves Cooling Intakes objects from Netbox DCIM module.
+
+.DESCRIPTION
+    Retrieves Cooling Intakes objects from Netbox DCIM module (NetBox 4.7+).
+    Array-typed filters accept multiple values and are sent as repeated query keys.
+
+.PARAMETER Raw
+    Return the raw API response instead of the results array.
+
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'device.name', 'module.display').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+.PARAMETER Id
+    One or more database IDs to retrieve.
+
+.PARAMETER Name
+    Filter by name (one or more values).
+
+.PARAMETER Label
+    Filter by physical label (one or more values).
+
+.PARAMETER Device_Id
+    Filter by device database ID.
+
+.PARAMETER Device
+    Filter by device name.
+
+.PARAMETER Device_Type_Id
+    Filter by the device type database ID of the parent device.
+
+.PARAMETER Module_Id
+    Filter by module database ID.
+
+.PARAMETER Site_Id
+    Filter by site database ID.
+
+.PARAMETER Site
+    Filter by site slug.
+
+.PARAMETER Location_Id
+    Filter by location database ID.
+
+.PARAMETER Rack_Id
+    Filter by rack database ID.
+
+.PARAMETER Type
+    Filter by connector type ('uqd', 'uqdb', 'qdc', 'camlock', 'npt', 'bsp', 'proprietary').
+
+.PARAMETER Diameter
+    Filter by connector diameter.
+
+.PARAMETER Diameter_Unit
+    Filter by diameter unit ('mm', 'cm', 'in').
+
+.PARAMETER Max_Flow
+    Filter by maximum flow rate.
+
+.PARAMETER Max_Flow_Unit
+    Filter by maximum flow unit ('lpm', 'm3ph', 'gpm').
+
+.PARAMETER Cooling_Outflow_Id
+    Filter by the upstream cooling outflow database ID.
+
+.PARAMETER Description
+    Filter by description (one or more values).
+
+.PARAMETER Tag
+    Filter by tag slug (one or more values).
+
+.PARAMETER Query
+    Free-text search across the object (NetBox 'q' parameter).
+
+.PARAMETER Limit
+    Maximum number of results to return per request (1-1000).
+
+.PARAMETER Offset
+    Number of results to skip (pagination offset).
+
+.EXAMPLE
+    Get-NBDCIMCoolingIntake
+
+    Retrieves all cooling intakes.
+
+.EXAMPLE
+    Get-NBDCIMCoolingIntake -Device_Id 12 -Type 'uqd'
+
+    Lists the UQD cooling intakes on device 12.
+
+.EXAMPLE
+    Get-NBDCIMCoolingIntake -Id 5
+
+    Retrieves the cooling intake with ID 5.
+
+.LINK
+    https://netbox.readthedocs.io/en/stable/rest-api/overview/
+.NOTES
+    AddedInVersion: v4.7.1.0
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
+#>
+function Get-NBDCIMCoolingIntake {
+    [CmdletBinding(DefaultParameterSetName = 'Query')]
+    [OutputType([PSCustomObject])]
+    param(
+        [switch]$All,
+
+        [ValidateRange(1, 1000)]
+        [int]$PageSize = 100,
+
+        [switch]$Brief,
+
+        [string[]]$Fields,
+
+        [string[]]$Omit,
+
+        [Parameter(ParameterSetName = 'ByID', ValueFromPipelineByPropertyName = $true)]
+        [uint64[]]$Id,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Name,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Label,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Device_Id,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Device,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Device_Type_Id,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Module_Id,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Site_Id,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Site,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Location_Id,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Rack_Id,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Type,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [decimal[]]$Diameter,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Diameter_Unit,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [decimal[]]$Max_Flow,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Max_Flow_Unit,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Cooling_Outflow_Id,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Description,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string]$Query,
+
+        [ValidateRange(1, 1000)]
+        [uint16]$Limit,
+
+        [ValidateRange(0, [int]::MaxValue)]
+        [uint32]$Offset,
+
+        [switch]$Raw
+    )
+    process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
+        Write-Verbose "Retrieving DCIM Cooling Intake"
+        switch ($PSCmdlet.ParameterSetName) {
+            'ByID' {
+                foreach ($i in $Id) {
+                    $Segments = [System.Collections.ArrayList]::new(@('dcim', 'cooling-intakes', $i))
+                    $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw', 'All', 'PageSize'
+                    $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
+                    InvokeNetboxRequest -URI $URI -Raw:$Raw
+                }
+            }
+            default {
+                $Segments = [System.Collections.ArrayList]::new(@('dcim', 'cooling-intakes'))
+                $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'All', 'PageSize'
+                $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
+                InvokeNetboxRequest -URI $URI -Raw:$Raw -All:$All -PageSize $PageSize
+            }
+        }
+    }
+}

--- a/Functions/DCIM/CoolingIntakes/New-NBDCIMCoolingIntake.ps1
+++ b/Functions/DCIM/CoolingIntakes/New-NBDCIMCoolingIntake.ps1
@@ -1,0 +1,115 @@
+<#
+.SYNOPSIS
+    Creates a new DCIM CoolingIntake in Netbox DCIM module.
+
+.DESCRIPTION
+    Creates a new Cooling Intake (NetBox 4.7+).
+    Supports pipeline input for bulk creation.
+
+.PARAMETER Raw
+    Return the raw API response instead of the results array.
+
+.PARAMETER Device
+    Device this component belongs to (database ID).
+
+.PARAMETER Module
+    Installed module this component belongs to (database ID).
+
+.PARAMETER Name
+    Name of the component.
+
+.PARAMETER Label
+    Physical label.
+
+.PARAMETER Type
+    Connector type: 'uqd', 'uqdb', 'qdc', 'camlock', 'npt', 'bsp'
+    or 'proprietary'.
+
+.PARAMETER Diameter
+    Connector diameter (number, 0.01 - 1000000).
+
+.PARAMETER Diameter_Unit
+    Unit for -Diameter: 'mm', 'cm' or 'in'.
+
+.PARAMETER Max_Flow
+    Maximum coolant flow rate (number, 0.01 - 1000000).
+
+.PARAMETER Max_Flow_Unit
+    Unit for -Max_Flow: 'lpm', 'm3ph' or 'gpm'.
+
+.PARAMETER Cooling_Outflow
+    Upstream cooling outflow that serves this intake (database ID).
+
+.PARAMETER Description
+    Brief description.
+
+.PARAMETER Owner
+    Owner for object ownership (database ID).
+
+.PARAMETER Tags
+    One or more tags to assign to this object (tag names or IDs).
+
+.PARAMETER Custom_Fields
+    Hashtable of custom field values to set.
+
+.EXAMPLE
+    New-NBDCIMCoolingIntake -Device 12 -Name 'Coolant In' -Type 'uqd' -Diameter 12.7 -Diameter_Unit 'mm' -Max_Flow 8 -Max_Flow_Unit 'lpm' -Cooling_Outflow 3
+
+    Creates a UQD coolant intake on device 12 fed by cooling outflow 3.
+
+.LINK
+    https://netbox.readthedocs.io/en/stable/rest-api/overview/
+.NOTES
+    AddedInVersion: v4.7.1.0
+#>
+function New-NBDCIMCoolingIntake {
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Low')]
+    [OutputType([PSCustomObject])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [uint64]$Device,
+
+        [uint64]$Module,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Name,
+
+        [string]$Label,
+
+        [ValidateSet('uqd', 'uqdb', 'qdc', 'camlock', 'npt', 'bsp', 'proprietary', IgnoreCase = $true)]
+        [string]$Type,
+
+        [ValidateRange(0.01, 1000000)]
+        [decimal]$Diameter,
+
+        [ValidateSet('mm', 'cm', 'in', IgnoreCase = $true)]
+        [string]$Diameter_Unit,
+
+        [ValidateRange(0.01, 1000000)]
+        [decimal]$Max_Flow,
+
+        [ValidateSet('lpm', 'm3ph', 'gpm', IgnoreCase = $true)]
+        [string]$Max_Flow_Unit,
+
+        [uint64]$Cooling_Outflow,
+
+        [string]$Description,
+
+        [uint64]$Owner,
+
+        [object[]]$Tags,
+
+        [hashtable]$Custom_Fields,
+
+        [switch]$Raw
+    )
+    process {
+        Write-Verbose "Creating DCIM Cooling Intake"
+        $Segments = [System.Collections.ArrayList]::new(@('dcim', 'cooling-intakes'))
+        $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw'
+        if ($PSCmdlet.ShouldProcess($Name, 'Create cooling intake')) {
+            InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments) -Method POST -Body $URIComponents.Parameters -Raw:$Raw
+        }
+    }
+}

--- a/Functions/DCIM/CoolingIntakes/Remove-NBDCIMCoolingIntake.ps1
+++ b/Functions/DCIM/CoolingIntakes/Remove-NBDCIMCoolingIntake.ps1
@@ -1,0 +1,45 @@
+<#
+.SYNOPSIS
+    Removes a DCIM CoolingIntake from Netbox DCIM module.
+
+.DESCRIPTION
+    Removes a Cooling Intake (NetBox 4.7+).
+    Supports pipeline input for the Id parameter.
+
+.PARAMETER Raw
+    Return the raw API response instead of the results array.
+
+.PARAMETER Id
+    Database ID of the object to delete.
+
+.EXAMPLE
+    Remove-NBDCIMCoolingIntake -Id 5
+
+    Deletes the cooling intake with ID 5.
+
+.EXAMPLE
+    Get-NBDCIMCoolingIntake -Device_Id 12 | Remove-NBDCIMCoolingIntake -Confirm:$false
+
+    Deletes every cooling intake of device 12 without prompting.
+
+.LINK
+    https://netbox.readthedocs.io/en/stable/rest-api/overview/
+.NOTES
+    AddedInVersion: v4.7.1.0
+#>
+function Remove-NBDCIMCoolingIntake {
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
+    [OutputType([void])]
+    param(
+        [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
+        [uint64]$Id,
+
+        [switch]$Raw
+    )
+    process {
+        Write-Verbose "Removing DCIM Cooling Intake ID $Id"
+        if ($PSCmdlet.ShouldProcess($Id, 'Delete cooling intake')) {
+            InvokeNetboxRequest -URI (BuildNewURI -Segments @('dcim', 'cooling-intakes', $Id)) -Method DELETE -Raw:$Raw
+        }
+    }
+}

--- a/Functions/DCIM/CoolingIntakes/Set-NBDCIMCoolingIntake.ps1
+++ b/Functions/DCIM/CoolingIntakes/Set-NBDCIMCoolingIntake.ps1
@@ -1,0 +1,137 @@
+<#
+.SYNOPSIS
+    Updates an existing DCIM CoolingIntake in Netbox DCIM module.
+
+.DESCRIPTION
+    Updates an existing Cooling Intake (NetBox 4.7+) via PATCH.
+    Supports pipeline input for the Id parameter.
+    Nullable numeric and FK parameters accept $null to clear the field;
+    clearable enum parameters accept '' (empty string) to clear the field.
+
+.PARAMETER Raw
+    Return the raw API response instead of the results array.
+
+.PARAMETER Id
+    Database ID of the object to update.
+
+.PARAMETER Device
+    Device this component belongs to (database ID).
+
+.PARAMETER Module
+    Installed module this component belongs to (database ID). Pass $null to clear.
+
+.PARAMETER Name
+    Name of the component.
+
+.PARAMETER Label
+    Physical label.
+
+.PARAMETER Type
+    Connector type: 'uqd', 'uqdb', 'qdc', 'camlock', 'npt', 'bsp'
+    or 'proprietary'.
+    Pass '' to clear the field server-side (sent as JSON null).
+
+.PARAMETER Diameter
+    Connector diameter (number, 0.01 - 1000000). Pass $null to clear.
+
+.PARAMETER Diameter_Unit
+    Unit for -Diameter: 'mm', 'cm' or 'in'.
+    Pass '' to clear the field server-side (sent as JSON null).
+    NetBox requires a unit whenever -Diameter is set, so clear both
+    together: -Diameter $null -Diameter_Unit ''.
+
+.PARAMETER Max_Flow
+    Maximum coolant flow rate (number, 0.01 - 1000000). Pass $null to clear.
+
+.PARAMETER Max_Flow_Unit
+    Unit for -Max_Flow: 'lpm', 'm3ph' or 'gpm'.
+    Pass '' to clear the field server-side (sent as JSON null).
+    NetBox requires a unit whenever -Max_Flow is set, so clear both
+    together: -Max_Flow $null -Max_Flow_Unit ''.
+
+.PARAMETER Cooling_Outflow
+    Upstream cooling outflow that serves this intake (database ID). Pass $null to clear.
+
+.PARAMETER Description
+    Brief description.
+
+.PARAMETER Owner
+    Owner for object ownership (database ID).
+
+.PARAMETER Tags
+    One or more tags to assign to this object (tag names or IDs).
+
+.PARAMETER Custom_Fields
+    Hashtable of custom field values to set.
+
+.EXAMPLE
+    Set-NBDCIMCoolingIntake -Id 5 -Label 'IN-1' -Type ''
+
+    Sets the label and clears the connector type of cooling intake 5.
+
+.LINK
+    https://netbox.readthedocs.io/en/stable/rest-api/overview/
+.NOTES
+    AddedInVersion: v4.7.1.0
+#>
+function Set-NBDCIMCoolingIntake {
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
+    [OutputType([PSCustomObject])]
+    param(
+        [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
+        [uint64]$Id,
+
+        [uint64]$Device,
+
+        [Nullable[uint64]]$Module,
+
+        [string]$Name,
+
+        [string]$Label,
+
+        [AllowEmptyString()]
+        [ValidateSet('uqd', 'uqdb', 'qdc', 'camlock', 'npt', 'bsp', 'proprietary', '', IgnoreCase = $true)]
+        [string]$Type,
+
+        [Nullable[decimal]]$Diameter,
+
+        [AllowEmptyString()]
+        [ValidateSet('mm', 'cm', 'in', '', IgnoreCase = $true)]
+        [string]$Diameter_Unit,
+
+        [Nullable[decimal]]$Max_Flow,
+
+        [AllowEmptyString()]
+        [ValidateSet('lpm', 'm3ph', 'gpm', '', IgnoreCase = $true)]
+        [string]$Max_Flow_Unit,
+
+        [Nullable[uint64]]$Cooling_Outflow,
+
+        [string]$Description,
+
+        [uint64]$Owner,
+
+        [object[]]$Tags,
+
+        [hashtable]$Custom_Fields,
+
+        [switch]$Raw
+    )
+    process {
+        # Translate '' -> $null for clearable enum params BEFORE
+        # BuildURIComponents, so the PATCH body carries JSON null
+        # (NetBox rejects "" for these nullable enum fields).
+        foreach ($p in @('Type', 'Diameter_Unit', 'Max_Flow_Unit')) {
+            if ($PSBoundParameters.ContainsKey($p) -and $PSBoundParameters[$p] -eq '') {
+                $PSBoundParameters[$p] = $null
+            }
+        }
+
+        Write-Verbose "Updating DCIM Cooling Intake ID $Id"
+        $Segments = [System.Collections.ArrayList]::new(@('dcim', 'cooling-intakes', $Id))
+        $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw'
+        if ($PSCmdlet.ShouldProcess($Id, 'Update cooling intake')) {
+            InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments) -Method PATCH -Body $URIComponents.Parameters -Raw:$Raw
+        }
+    }
+}

--- a/Functions/DCIM/CoolingOutflowTemplates/Get-NBDCIMCoolingOutflowTemplate.ps1
+++ b/Functions/DCIM/CoolingOutflowTemplates/Get-NBDCIMCoolingOutflowTemplate.ps1
@@ -1,0 +1,170 @@
+<#
+.SYNOPSIS
+    Retrieves Cooling Outflow Templates objects from Netbox DCIM module.
+
+.DESCRIPTION
+    Retrieves Cooling Outflow Templates objects from Netbox DCIM module (NetBox 4.7+).
+    Array-typed filters accept multiple values and are sent as repeated query keys.
+
+.PARAMETER Raw
+    Return the raw API response instead of the results array.
+
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'device.name', 'module.display').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+.PARAMETER Id
+    One or more database IDs to retrieve.
+
+.PARAMETER Name
+    Filter by name (one or more values).
+
+.PARAMETER Label
+    Filter by physical label (one or more values).
+
+.PARAMETER Device_Type_Id
+    Filter by device type database ID.
+
+.PARAMETER Module_Type_Id
+    Filter by module type database ID.
+
+.PARAMETER Type
+    Filter by connector type ('uqd', 'uqdb', 'qdc', 'camlock', 'npt', 'bsp', 'proprietary').
+
+.PARAMETER Diameter
+    Filter by connector diameter.
+
+.PARAMETER Diameter_Unit
+    Filter by diameter unit ('mm', 'cm', 'in').
+
+.PARAMETER Cooling_Intake_Id
+    Filter by the paired cooling intake template database ID.
+
+.PARAMETER Description
+    Filter by description (one or more values).
+
+.PARAMETER Query
+    Free-text search across the object (NetBox 'q' parameter).
+
+.PARAMETER Limit
+    Maximum number of results to return per request (1-1000).
+
+.PARAMETER Offset
+    Number of results to skip (pagination offset).
+
+.EXAMPLE
+    Get-NBDCIMCoolingOutflowTemplate
+
+    Retrieves all cooling outflow templates.
+
+.EXAMPLE
+    Get-NBDCIMCoolingOutflowTemplate -Device_Type_Id 4
+
+    Lists the cooling outflow templates of device type 4.
+
+.EXAMPLE
+    Get-NBDCIMCoolingOutflowTemplate -Id 5
+
+    Retrieves the cooling outflow template with ID 5.
+
+.LINK
+    https://netbox.readthedocs.io/en/stable/rest-api/overview/
+.NOTES
+    AddedInVersion: v4.7.1.0
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
+#>
+function Get-NBDCIMCoolingOutflowTemplate {
+    [CmdletBinding(DefaultParameterSetName = 'Query')]
+    [OutputType([PSCustomObject])]
+    param(
+        [switch]$All,
+
+        [ValidateRange(1, 1000)]
+        [int]$PageSize = 100,
+
+        [switch]$Brief,
+
+        [string[]]$Fields,
+
+        [string[]]$Omit,
+
+        [Parameter(ParameterSetName = 'ByID', ValueFromPipelineByPropertyName = $true)]
+        [uint64[]]$Id,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Name,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Label,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Device_Type_Id,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Module_Type_Id,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Type,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [decimal[]]$Diameter,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Diameter_Unit,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Cooling_Intake_Id,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Description,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string]$Query,
+
+        [ValidateRange(1, 1000)]
+        [uint16]$Limit,
+
+        [ValidateRange(0, [int]::MaxValue)]
+        [uint32]$Offset,
+
+        [switch]$Raw
+    )
+    process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
+        Write-Verbose "Retrieving DCIM Cooling Outflow Template"
+        switch ($PSCmdlet.ParameterSetName) {
+            'ByID' {
+                foreach ($i in $Id) {
+                    $Segments = [System.Collections.ArrayList]::new(@('dcim', 'cooling-outflow-templates', $i))
+                    $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw', 'All', 'PageSize'
+                    $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
+                    InvokeNetboxRequest -URI $URI -Raw:$Raw
+                }
+            }
+            default {
+                $Segments = [System.Collections.ArrayList]::new(@('dcim', 'cooling-outflow-templates'))
+                $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'All', 'PageSize'
+                $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
+                InvokeNetboxRequest -URI $URI -Raw:$Raw -All:$All -PageSize $PageSize
+            }
+        }
+    }
+}

--- a/Functions/DCIM/CoolingOutflowTemplates/New-NBDCIMCoolingOutflowTemplate.ps1
+++ b/Functions/DCIM/CoolingOutflowTemplates/New-NBDCIMCoolingOutflowTemplate.ps1
@@ -1,0 +1,87 @@
+<#
+.SYNOPSIS
+    Creates a new DCIM CoolingOutflowTemplate in Netbox DCIM module.
+
+.DESCRIPTION
+    Creates a new Cooling Outflow Template (NetBox 4.7+).
+    Supports pipeline input for bulk creation.
+
+.PARAMETER Raw
+    Return the raw API response instead of the results array.
+
+.PARAMETER Device_Type
+    Device type this template belongs to (database ID). Mutually exclusive with -Module_Type.
+
+.PARAMETER Module_Type
+    Module type this template belongs to (database ID). Mutually exclusive with -Device_Type.
+
+.PARAMETER Name
+    Name of the template. Use {module} as a placeholder for the module bay position on module type templates.
+
+.PARAMETER Label
+    Physical label.
+
+.PARAMETER Type
+    Connector type: 'uqd', 'uqdb', 'qdc', 'camlock', 'npt', 'bsp'
+    or 'proprietary'.
+
+.PARAMETER Diameter
+    Connector diameter (number, 0.01 - 1000000).
+
+.PARAMETER Diameter_Unit
+    Unit for -Diameter: 'mm', 'cm' or 'in'.
+
+.PARAMETER Cooling_Intake
+    Cooling intake template on the same device type that this outflow template is paired with (database ID).
+
+.PARAMETER Description
+    Brief description.
+
+.EXAMPLE
+    New-NBDCIMCoolingOutflowTemplate -Device_Type 4 -Name 'Coolant Out' -Type 'uqd' -Cooling_Intake 9
+
+    Creates a cooling outflow template on device type 4 paired with intake template 9.
+
+.LINK
+    https://netbox.readthedocs.io/en/stable/rest-api/overview/
+.NOTES
+    AddedInVersion: v4.7.1.0
+#>
+function New-NBDCIMCoolingOutflowTemplate {
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Low')]
+    [OutputType([PSCustomObject])]
+    param(
+        [uint64]$Device_Type,
+
+        [uint64]$Module_Type,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Name,
+
+        [string]$Label,
+
+        [ValidateSet('uqd', 'uqdb', 'qdc', 'camlock', 'npt', 'bsp', 'proprietary', IgnoreCase = $true)]
+        [string]$Type,
+
+        [ValidateRange(0.01, 1000000)]
+        [decimal]$Diameter,
+
+        [ValidateSet('mm', 'cm', 'in', IgnoreCase = $true)]
+        [string]$Diameter_Unit,
+
+        [uint64]$Cooling_Intake,
+
+        [string]$Description,
+
+        [switch]$Raw
+    )
+    process {
+        Write-Verbose "Creating DCIM Cooling Outflow Template"
+        $Segments = [System.Collections.ArrayList]::new(@('dcim', 'cooling-outflow-templates'))
+        $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw'
+        if ($PSCmdlet.ShouldProcess($Name, 'Create cooling outflow template')) {
+            InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments) -Method POST -Body $URIComponents.Parameters -Raw:$Raw
+        }
+    }
+}

--- a/Functions/DCIM/CoolingOutflowTemplates/Remove-NBDCIMCoolingOutflowTemplate.ps1
+++ b/Functions/DCIM/CoolingOutflowTemplates/Remove-NBDCIMCoolingOutflowTemplate.ps1
@@ -1,0 +1,45 @@
+<#
+.SYNOPSIS
+    Removes a DCIM CoolingOutflowTemplate from Netbox DCIM module.
+
+.DESCRIPTION
+    Removes a Cooling Outflow Template (NetBox 4.7+).
+    Supports pipeline input for the Id parameter.
+
+.PARAMETER Raw
+    Return the raw API response instead of the results array.
+
+.PARAMETER Id
+    Database ID of the object to delete.
+
+.EXAMPLE
+    Remove-NBDCIMCoolingOutflowTemplate -Id 5
+
+    Deletes the cooling outflow template with ID 5.
+
+.EXAMPLE
+    Get-NBDCIMCoolingOutflowTemplate -Device_Type_Id 12 | Remove-NBDCIMCoolingOutflowTemplate -Confirm:$false
+
+    Deletes every cooling outflow template of device type 12 without prompting.
+
+.LINK
+    https://netbox.readthedocs.io/en/stable/rest-api/overview/
+.NOTES
+    AddedInVersion: v4.7.1.0
+#>
+function Remove-NBDCIMCoolingOutflowTemplate {
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
+    [OutputType([void])]
+    param(
+        [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
+        [uint64]$Id,
+
+        [switch]$Raw
+    )
+    process {
+        Write-Verbose "Removing DCIM Cooling Outflow Template ID $Id"
+        if ($PSCmdlet.ShouldProcess($Id, 'Delete cooling outflow template')) {
+            InvokeNetboxRequest -URI (BuildNewURI -Segments @('dcim', 'cooling-outflow-templates', $Id)) -Method DELETE -Raw:$Raw
+        }
+    }
+}

--- a/Functions/DCIM/CoolingOutflowTemplates/Set-NBDCIMCoolingOutflowTemplate.ps1
+++ b/Functions/DCIM/CoolingOutflowTemplates/Set-NBDCIMCoolingOutflowTemplate.ps1
@@ -1,0 +1,107 @@
+<#
+.SYNOPSIS
+    Updates an existing DCIM CoolingOutflowTemplate in Netbox DCIM module.
+
+.DESCRIPTION
+    Updates an existing Cooling Outflow Template (NetBox 4.7+) via PATCH.
+    Supports pipeline input for the Id parameter.
+    Nullable numeric and FK parameters accept $null to clear the field;
+    clearable enum parameters accept '' (empty string) to clear the field.
+
+.PARAMETER Raw
+    Return the raw API response instead of the results array.
+
+.PARAMETER Id
+    Database ID of the object to update.
+
+.PARAMETER Device_Type
+    Device type this template belongs to (database ID). Mutually exclusive with -Module_Type. Pass $null to clear.
+
+.PARAMETER Module_Type
+    Module type this template belongs to (database ID). Mutually exclusive with -Device_Type. Pass $null to clear.
+
+.PARAMETER Name
+    Name of the template. Use {module} as a placeholder for the module bay position on module type templates.
+
+.PARAMETER Label
+    Physical label.
+
+.PARAMETER Type
+    Connector type: 'uqd', 'uqdb', 'qdc', 'camlock', 'npt', 'bsp'
+    or 'proprietary'.
+    Pass '' to clear the field server-side (sent as JSON null).
+
+.PARAMETER Diameter
+    Connector diameter (number, 0.01 - 1000000). Pass $null to clear.
+
+.PARAMETER Diameter_Unit
+    Unit for -Diameter: 'mm', 'cm' or 'in'.
+    Pass '' to clear the field server-side (sent as JSON null).
+    NetBox requires a unit whenever -Diameter is set, so clear both
+    together: -Diameter $null -Diameter_Unit ''.
+
+.PARAMETER Cooling_Intake
+    Cooling intake template on the same device type that this outflow template is paired with (database ID). Pass $null to clear.
+
+.PARAMETER Description
+    Brief description.
+
+.EXAMPLE
+    Set-NBDCIMCoolingOutflowTemplate -Id 5 -Label 'OUT-1'
+
+    Sets the label of cooling outflow template 5.
+
+.LINK
+    https://netbox.readthedocs.io/en/stable/rest-api/overview/
+.NOTES
+    AddedInVersion: v4.7.1.0
+#>
+function Set-NBDCIMCoolingOutflowTemplate {
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
+    [OutputType([PSCustomObject])]
+    param(
+        [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
+        [uint64]$Id,
+
+        [Nullable[uint64]]$Device_Type,
+
+        [Nullable[uint64]]$Module_Type,
+
+        [string]$Name,
+
+        [string]$Label,
+
+        [AllowEmptyString()]
+        [ValidateSet('uqd', 'uqdb', 'qdc', 'camlock', 'npt', 'bsp', 'proprietary', '', IgnoreCase = $true)]
+        [string]$Type,
+
+        [Nullable[decimal]]$Diameter,
+
+        [AllowEmptyString()]
+        [ValidateSet('mm', 'cm', 'in', '', IgnoreCase = $true)]
+        [string]$Diameter_Unit,
+
+        [Nullable[uint64]]$Cooling_Intake,
+
+        [string]$Description,
+
+        [switch]$Raw
+    )
+    process {
+        # Translate '' -> $null for clearable enum params BEFORE
+        # BuildURIComponents, so the PATCH body carries JSON null
+        # (NetBox rejects "" for these nullable enum fields).
+        foreach ($p in @('Type', 'Diameter_Unit')) {
+            if ($PSBoundParameters.ContainsKey($p) -and $PSBoundParameters[$p] -eq '') {
+                $PSBoundParameters[$p] = $null
+            }
+        }
+
+        Write-Verbose "Updating DCIM Cooling Outflow Template ID $Id"
+        $Segments = [System.Collections.ArrayList]::new(@('dcim', 'cooling-outflow-templates', $Id))
+        $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw'
+        if ($PSCmdlet.ShouldProcess($Id, 'Update cooling outflow template')) {
+            InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments) -Method PATCH -Body $URIComponents.Parameters -Raw:$Raw
+        }
+    }
+}

--- a/Functions/DCIM/CoolingOutflows/Get-NBDCIMCoolingOutflow.ps1
+++ b/Functions/DCIM/CoolingOutflows/Get-NBDCIMCoolingOutflow.ps1
@@ -79,6 +79,9 @@
 
 .PARAMETER Tag
     Filter by tag slug (one or more values).
+.PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
 
 .PARAMETER Query
     Free-text search across the object (NetBox 'q' parameter).
@@ -175,6 +178,11 @@ function Get-NBDCIMCoolingOutflow {
 
         [Parameter(ParameterSetName = 'Query')]
         [string[]]$Tag,
+
+
+        [Parameter(ParameterSetName = 'Query')]
+
+        [uint64[]]$Tag_Id,
 
         [Parameter(ParameterSetName = 'Query')]
         [string]$Query,

--- a/Functions/DCIM/CoolingOutflows/Get-NBDCIMCoolingOutflow.ps1
+++ b/Functions/DCIM/CoolingOutflows/Get-NBDCIMCoolingOutflow.ps1
@@ -1,0 +1,212 @@
+<#
+.SYNOPSIS
+    Retrieves Cooling Outflows objects from Netbox DCIM module.
+
+.DESCRIPTION
+    Retrieves Cooling Outflows objects from Netbox DCIM module (NetBox 4.7+).
+    Array-typed filters accept multiple values and are sent as repeated query keys.
+
+.PARAMETER Raw
+    Return the raw API response instead of the results array.
+
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'device.name', 'module.display').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+.PARAMETER Id
+    One or more database IDs to retrieve.
+
+.PARAMETER Name
+    Filter by name (one or more values).
+
+.PARAMETER Label
+    Filter by physical label (one or more values).
+
+.PARAMETER Device_Id
+    Filter by device database ID.
+
+.PARAMETER Device
+    Filter by device name.
+
+.PARAMETER Device_Type_Id
+    Filter by the device type database ID of the parent device.
+
+.PARAMETER Module_Id
+    Filter by module database ID.
+
+.PARAMETER Site_Id
+    Filter by site database ID.
+
+.PARAMETER Site
+    Filter by site slug.
+
+.PARAMETER Location_Id
+    Filter by location database ID.
+
+.PARAMETER Rack_Id
+    Filter by rack database ID.
+
+.PARAMETER Type
+    Filter by connector type ('uqd', 'uqdb', 'qdc', 'camlock', 'npt', 'bsp', 'proprietary').
+
+.PARAMETER Diameter
+    Filter by connector diameter.
+
+.PARAMETER Diameter_Unit
+    Filter by diameter unit ('mm', 'cm', 'in').
+
+.PARAMETER Cooling_Intake_Id
+    Filter by the paired cooling intake database ID.
+
+.PARAMETER Description
+    Filter by description (one or more values).
+
+.PARAMETER Tag
+    Filter by tag slug (one or more values).
+
+.PARAMETER Query
+    Free-text search across the object (NetBox 'q' parameter).
+
+.PARAMETER Limit
+    Maximum number of results to return per request (1-1000).
+
+.PARAMETER Offset
+    Number of results to skip (pagination offset).
+
+.EXAMPLE
+    Get-NBDCIMCoolingOutflow
+
+    Retrieves all cooling outflows.
+
+.EXAMPLE
+    Get-NBDCIMCoolingOutflow -Device_Id 12
+
+    Lists the cooling outflows on device 12.
+
+.EXAMPLE
+    Get-NBDCIMCoolingOutflow -Id 5
+
+    Retrieves the cooling outflow with ID 5.
+
+.LINK
+    https://netbox.readthedocs.io/en/stable/rest-api/overview/
+.NOTES
+    AddedInVersion: v4.7.1.0
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
+#>
+function Get-NBDCIMCoolingOutflow {
+    [CmdletBinding(DefaultParameterSetName = 'Query')]
+    [OutputType([PSCustomObject])]
+    param(
+        [switch]$All,
+
+        [ValidateRange(1, 1000)]
+        [int]$PageSize = 100,
+
+        [switch]$Brief,
+
+        [string[]]$Fields,
+
+        [string[]]$Omit,
+
+        [Parameter(ParameterSetName = 'ByID', ValueFromPipelineByPropertyName = $true)]
+        [uint64[]]$Id,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Name,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Label,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Device_Id,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Device,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Device_Type_Id,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Module_Id,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Site_Id,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Site,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Location_Id,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Rack_Id,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Type,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [decimal[]]$Diameter,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Diameter_Unit,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Cooling_Intake_Id,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Description,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string]$Query,
+
+        [ValidateRange(1, 1000)]
+        [uint16]$Limit,
+
+        [ValidateRange(0, [int]::MaxValue)]
+        [uint32]$Offset,
+
+        [switch]$Raw
+    )
+    process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
+        Write-Verbose "Retrieving DCIM Cooling Outflow"
+        switch ($PSCmdlet.ParameterSetName) {
+            'ByID' {
+                foreach ($i in $Id) {
+                    $Segments = [System.Collections.ArrayList]::new(@('dcim', 'cooling-outflows', $i))
+                    $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw', 'All', 'PageSize'
+                    $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
+                    InvokeNetboxRequest -URI $URI -Raw:$Raw
+                }
+            }
+            default {
+                $Segments = [System.Collections.ArrayList]::new(@('dcim', 'cooling-outflows'))
+                $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'All', 'PageSize'
+                $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
+                InvokeNetboxRequest -URI $URI -Raw:$Raw -All:$All -PageSize $PageSize
+            }
+        }
+    }
+}

--- a/Functions/DCIM/CoolingOutflows/New-NBDCIMCoolingOutflow.ps1
+++ b/Functions/DCIM/CoolingOutflows/New-NBDCIMCoolingOutflow.ps1
@@ -1,0 +1,103 @@
+<#
+.SYNOPSIS
+    Creates a new DCIM CoolingOutflow in Netbox DCIM module.
+
+.DESCRIPTION
+    Creates a new Cooling Outflow (NetBox 4.7+).
+    Supports pipeline input for bulk creation.
+
+.PARAMETER Raw
+    Return the raw API response instead of the results array.
+
+.PARAMETER Device
+    Device this component belongs to (database ID).
+
+.PARAMETER Module
+    Installed module this component belongs to (database ID).
+
+.PARAMETER Name
+    Name of the component.
+
+.PARAMETER Label
+    Physical label.
+
+.PARAMETER Type
+    Connector type: 'uqd', 'uqdb', 'qdc', 'camlock', 'npt', 'bsp'
+    or 'proprietary'.
+
+.PARAMETER Diameter
+    Connector diameter (number, 0.01 - 1000000).
+
+.PARAMETER Diameter_Unit
+    Unit for -Diameter: 'mm', 'cm' or 'in'.
+
+.PARAMETER Cooling_Intake
+    Cooling intake on the same device that this outflow is paired with (database ID).
+
+.PARAMETER Description
+    Brief description.
+
+.PARAMETER Owner
+    Owner for object ownership (database ID).
+
+.PARAMETER Tags
+    One or more tags to assign to this object (tag names or IDs).
+
+.PARAMETER Custom_Fields
+    Hashtable of custom field values to set.
+
+.EXAMPLE
+    New-NBDCIMCoolingOutflow -Device 12 -Name 'Coolant Out' -Type 'uqd' -Diameter 12.7 -Diameter_Unit 'mm'
+
+    Creates a UQD coolant outflow on device 12.
+
+.LINK
+    https://netbox.readthedocs.io/en/stable/rest-api/overview/
+.NOTES
+    AddedInVersion: v4.7.1.0
+#>
+function New-NBDCIMCoolingOutflow {
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Low')]
+    [OutputType([PSCustomObject])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [uint64]$Device,
+
+        [uint64]$Module,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [string]$Name,
+
+        [string]$Label,
+
+        [ValidateSet('uqd', 'uqdb', 'qdc', 'camlock', 'npt', 'bsp', 'proprietary', IgnoreCase = $true)]
+        [string]$Type,
+
+        [ValidateRange(0.01, 1000000)]
+        [decimal]$Diameter,
+
+        [ValidateSet('mm', 'cm', 'in', IgnoreCase = $true)]
+        [string]$Diameter_Unit,
+
+        [uint64]$Cooling_Intake,
+
+        [string]$Description,
+
+        [uint64]$Owner,
+
+        [object[]]$Tags,
+
+        [hashtable]$Custom_Fields,
+
+        [switch]$Raw
+    )
+    process {
+        Write-Verbose "Creating DCIM Cooling Outflow"
+        $Segments = [System.Collections.ArrayList]::new(@('dcim', 'cooling-outflows'))
+        $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw'
+        if ($PSCmdlet.ShouldProcess($Name, 'Create cooling outflow')) {
+            InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments) -Method POST -Body $URIComponents.Parameters -Raw:$Raw
+        }
+    }
+}

--- a/Functions/DCIM/CoolingOutflows/Remove-NBDCIMCoolingOutflow.ps1
+++ b/Functions/DCIM/CoolingOutflows/Remove-NBDCIMCoolingOutflow.ps1
@@ -1,0 +1,45 @@
+<#
+.SYNOPSIS
+    Removes a DCIM CoolingOutflow from Netbox DCIM module.
+
+.DESCRIPTION
+    Removes a Cooling Outflow (NetBox 4.7+).
+    Supports pipeline input for the Id parameter.
+
+.PARAMETER Raw
+    Return the raw API response instead of the results array.
+
+.PARAMETER Id
+    Database ID of the object to delete.
+
+.EXAMPLE
+    Remove-NBDCIMCoolingOutflow -Id 5
+
+    Deletes the cooling outflow with ID 5.
+
+.EXAMPLE
+    Get-NBDCIMCoolingOutflow -Device_Id 12 | Remove-NBDCIMCoolingOutflow -Confirm:$false
+
+    Deletes every cooling outflow of device 12 without prompting.
+
+.LINK
+    https://netbox.readthedocs.io/en/stable/rest-api/overview/
+.NOTES
+    AddedInVersion: v4.7.1.0
+#>
+function Remove-NBDCIMCoolingOutflow {
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
+    [OutputType([void])]
+    param(
+        [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
+        [uint64]$Id,
+
+        [switch]$Raw
+    )
+    process {
+        Write-Verbose "Removing DCIM Cooling Outflow ID $Id"
+        if ($PSCmdlet.ShouldProcess($Id, 'Delete cooling outflow')) {
+            InvokeNetboxRequest -URI (BuildNewURI -Segments @('dcim', 'cooling-outflows', $Id)) -Method DELETE -Raw:$Raw
+        }
+    }
+}

--- a/Functions/DCIM/CoolingOutflows/Set-NBDCIMCoolingOutflow.ps1
+++ b/Functions/DCIM/CoolingOutflows/Set-NBDCIMCoolingOutflow.ps1
@@ -1,0 +1,122 @@
+<#
+.SYNOPSIS
+    Updates an existing DCIM CoolingOutflow in Netbox DCIM module.
+
+.DESCRIPTION
+    Updates an existing Cooling Outflow (NetBox 4.7+) via PATCH.
+    Supports pipeline input for the Id parameter.
+    Nullable numeric and FK parameters accept $null to clear the field;
+    clearable enum parameters accept '' (empty string) to clear the field.
+
+.PARAMETER Raw
+    Return the raw API response instead of the results array.
+
+.PARAMETER Id
+    Database ID of the object to update.
+
+.PARAMETER Device
+    Device this component belongs to (database ID).
+
+.PARAMETER Module
+    Installed module this component belongs to (database ID). Pass $null to clear.
+
+.PARAMETER Name
+    Name of the component.
+
+.PARAMETER Label
+    Physical label.
+
+.PARAMETER Type
+    Connector type: 'uqd', 'uqdb', 'qdc', 'camlock', 'npt', 'bsp'
+    or 'proprietary'.
+    Pass '' to clear the field server-side (sent as JSON null).
+
+.PARAMETER Diameter
+    Connector diameter (number, 0.01 - 1000000). Pass $null to clear.
+
+.PARAMETER Diameter_Unit
+    Unit for -Diameter: 'mm', 'cm' or 'in'.
+    Pass '' to clear the field server-side (sent as JSON null).
+    NetBox requires a unit whenever -Diameter is set, so clear both
+    together: -Diameter $null -Diameter_Unit ''.
+
+.PARAMETER Cooling_Intake
+    Cooling intake on the same device that this outflow is paired with (database ID). Pass $null to clear.
+
+.PARAMETER Description
+    Brief description.
+
+.PARAMETER Owner
+    Owner for object ownership (database ID).
+
+.PARAMETER Tags
+    One or more tags to assign to this object (tag names or IDs).
+
+.PARAMETER Custom_Fields
+    Hashtable of custom field values to set.
+
+.EXAMPLE
+    Set-NBDCIMCoolingOutflow -Id 5 -Label 'OUT-1' -Cooling_Intake 7
+
+    Sets the label and pairs cooling outflow 5 with intake 7.
+
+.LINK
+    https://netbox.readthedocs.io/en/stable/rest-api/overview/
+.NOTES
+    AddedInVersion: v4.7.1.0
+#>
+function Set-NBDCIMCoolingOutflow {
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
+    [OutputType([PSCustomObject])]
+    param(
+        [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
+        [uint64]$Id,
+
+        [uint64]$Device,
+
+        [Nullable[uint64]]$Module,
+
+        [string]$Name,
+
+        [string]$Label,
+
+        [AllowEmptyString()]
+        [ValidateSet('uqd', 'uqdb', 'qdc', 'camlock', 'npt', 'bsp', 'proprietary', '', IgnoreCase = $true)]
+        [string]$Type,
+
+        [Nullable[decimal]]$Diameter,
+
+        [AllowEmptyString()]
+        [ValidateSet('mm', 'cm', 'in', '', IgnoreCase = $true)]
+        [string]$Diameter_Unit,
+
+        [Nullable[uint64]]$Cooling_Intake,
+
+        [string]$Description,
+
+        [uint64]$Owner,
+
+        [object[]]$Tags,
+
+        [hashtable]$Custom_Fields,
+
+        [switch]$Raw
+    )
+    process {
+        # Translate '' -> $null for clearable enum params BEFORE
+        # BuildURIComponents, so the PATCH body carries JSON null
+        # (NetBox rejects "" for these nullable enum fields).
+        foreach ($p in @('Type', 'Diameter_Unit')) {
+            if ($PSBoundParameters.ContainsKey($p) -and $PSBoundParameters[$p] -eq '') {
+                $PSBoundParameters[$p] = $null
+            }
+        }
+
+        Write-Verbose "Updating DCIM Cooling Outflow ID $Id"
+        $Segments = [System.Collections.ArrayList]::new(@('dcim', 'cooling-outflows', $Id))
+        $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw'
+        if ($PSCmdlet.ShouldProcess($Id, 'Update cooling outflow')) {
+            InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments) -Method PATCH -Body $URIComponents.Parameters -Raw:$Raw
+        }
+    }
+}

--- a/Functions/DCIM/CoolingSources/Get-NBDCIMCoolingSource.ps1
+++ b/Functions/DCIM/CoolingSources/Get-NBDCIMCoolingSource.ps1
@@ -1,0 +1,215 @@
+<#
+.SYNOPSIS
+    Retrieves Cooling Source objects from Netbox DCIM module.
+
+.DESCRIPTION
+    Retrieves Cooling Source objects from Netbox DCIM module (NetBox 4.7+).
+    A cooling source is a facility-level piece of cooling equipment (chiller,
+    cooling tower, dry cooler, CRAC or CRAH) installed at a site, analogous
+    to a power panel for the power distribution model.
+
+.PARAMETER Raw
+    Return the raw API response instead of the results array.
+
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'site.name', 'location.name').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+.PARAMETER Id
+    One or more database IDs to retrieve.
+
+.PARAMETER Name
+    Filter by name. Accepts multiple values.
+
+.PARAMETER Site_Id
+    Filter by site database ID. Accepts multiple values.
+
+.PARAMETER Site
+    Filter by site slug. Accepts multiple values.
+
+.PARAMETER Location_Id
+    Filter by location database ID. Accepts multiple values.
+
+.PARAMETER Location
+    Filter by location slug. Accepts multiple values.
+
+.PARAMETER Region_Id
+    Filter by region database ID. Accepts multiple values.
+
+.PARAMETER Region
+    Filter by region slug. Accepts multiple values.
+
+.PARAMETER Site_Group_Id
+    Filter by site group database ID. Accepts multiple values.
+
+.PARAMETER Type
+    Filter by cooling source type (chiller, cooling-tower, dry-cooler, crac, crah).
+    Accepts multiple values.
+
+.PARAMETER Status
+    Filter by operational status (offline, active, planned, failed).
+    Accepts multiple values.
+
+.PARAMETER Fluid_Type
+    Filter by cooling fluid type (water, water-glycol, dielectric, refrigerant).
+    Accepts multiple values.
+
+.PARAMETER Cooling_Capacity
+    Filter by total rated cooling capacity in kW. Accepts multiple values.
+
+.PARAMETER Description
+    Filter by description. Accepts multiple values.
+
+.PARAMETER Owner_Id
+    Filter by owner database ID. Accepts multiple values.
+
+.PARAMETER Tag
+    Filter by tag slug. Accepts multiple values.
+
+.PARAMETER Query
+    Free-text search across the object (NetBox 'q' parameter).
+
+.PARAMETER Limit
+    Maximum number of results to return per request (1-1000).
+
+.PARAMETER Offset
+    Number of results to skip (pagination offset).
+
+.EXAMPLE
+    Get-NBDCIMCoolingSource
+
+    Returns all cooling sources.
+
+.EXAMPLE
+    Get-NBDCIMCoolingSource -Site_Id 1 -Type chiller
+
+    Returns all chillers at site ID 1.
+
+.EXAMPLE
+    Get-NBDCIMCoolingSource -Id 5 -Brief
+
+    Returns the brief representation of cooling source ID 5.
+
+.NOTES
+    AddedInVersion: v4.7.1.0
+    Requires NetBox 4.7.0 or later.
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
+.LINK
+    https://netbox.readthedocs.io/en/stable/rest-api/overview/
+#>
+function Get-NBDCIMCoolingSource {
+    [CmdletBinding(DefaultParameterSetName = 'Query')]
+    [OutputType([PSCustomObject])]
+    param(
+        [switch]$All,
+
+        [ValidateRange(1, 1000)]
+        [int]$PageSize = 100,
+
+        [switch]$Brief,
+
+        [string[]]$Fields,
+
+        [string[]]$Omit,
+
+        [Parameter(ParameterSetName = 'ByID', ValueFromPipelineByPropertyName = $true)]
+        [uint64[]]$Id,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Name,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Site_Id,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Site,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Location_Id,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Location,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Region_Id,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Region,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Site_Group_Id,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [ValidateSet('chiller', 'cooling-tower', 'dry-cooler', 'crac', 'crah')]
+        [string[]]$Type,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [ValidateSet('offline', 'active', 'planned', 'failed')]
+        [string[]]$Status,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [ValidateSet('water', 'water-glycol', 'dielectric', 'refrigerant')]
+        [string[]]$Fluid_Type,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [decimal[]]$Cooling_Capacity,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Description,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Owner_Id,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string]$Query,
+
+        [ValidateRange(1, 1000)]
+        [uint16]$Limit,
+
+        [ValidateRange(0, [int]::MaxValue)]
+        [uint32]$Offset,
+
+        [switch]$Raw
+    )
+    process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
+        Write-Verbose "Retrieving DCIM Cooling Source"
+        switch ($PSCmdlet.ParameterSetName) {
+            'ByID' {
+                foreach ($i in $Id) {
+                    $Segments = [System.Collections.ArrayList]::new(@('dcim', 'cooling-sources', $i))
+                    $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw', 'All', 'PageSize'
+                    $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
+                    InvokeNetboxRequest -URI $URI -Raw:$Raw
+                }
+            }
+            default {
+                $Segments = [System.Collections.ArrayList]::new(@('dcim', 'cooling-sources'))
+                $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'All', 'PageSize'
+                $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
+                InvokeNetboxRequest -URI $URI -Raw:$Raw -All:$All -PageSize $PageSize
+            }
+        }
+    }
+}

--- a/Functions/DCIM/CoolingSources/Get-NBDCIMCoolingSource.ps1
+++ b/Functions/DCIM/CoolingSources/Get-NBDCIMCoolingSource.ps1
@@ -81,6 +81,9 @@
 
 .PARAMETER Tag
     Filter by tag slug. Accepts multiple values.
+.PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
 
 .PARAMETER Query
     Free-text search across the object (NetBox 'q' parameter).
@@ -178,6 +181,11 @@ function Get-NBDCIMCoolingSource {
 
         [Parameter(ParameterSetName = 'Query')]
         [string[]]$Tag,
+
+
+        [Parameter(ParameterSetName = 'Query')]
+
+        [uint64[]]$Tag_Id,
 
         [Parameter(ParameterSetName = 'Query')]
         [string]$Query,

--- a/Functions/DCIM/CoolingSources/New-NBDCIMCoolingSource.ps1
+++ b/Functions/DCIM/CoolingSources/New-NBDCIMCoolingSource.ps1
@@ -1,0 +1,106 @@
+<#
+.SYNOPSIS
+    Creates a new Cooling Source in Netbox DCIM module.
+
+.DESCRIPTION
+    Creates a new Cooling Source in Netbox DCIM module (NetBox 4.7+).
+    A cooling source is a facility-level piece of cooling equipment
+    (chiller, cooling tower, dry cooler, CRAC or CRAH) installed at a site.
+    Cooling feeds are then provisioned from a cooling source to racks.
+
+.PARAMETER Raw
+    Return the raw API response instead of the results array.
+
+.PARAMETER Site
+    Site this cooling source is installed at (database ID). Required.
+
+.PARAMETER Location
+    Location within the site (database ID).
+
+.PARAMETER Name
+    Name of the cooling source. Required.
+
+.PARAMETER Type
+    Type of cooling equipment: chiller, cooling-tower, dry-cooler, crac or crah. Required.
+
+.PARAMETER Status
+    Operational status: offline, active, planned or failed. Defaults to active server-side.
+
+.PARAMETER Fluid_Type
+    Cooling fluid type: water, water-glycol, dielectric or refrigerant.
+
+.PARAMETER Cooling_Capacity
+    Total rated cooling capacity in kW.
+
+.PARAMETER Description
+    Brief description.
+
+.PARAMETER Owner
+    Owner of this object (database ID).
+
+.PARAMETER Comments
+    Detailed comments (Markdown is supported).
+
+.PARAMETER Tags
+    One or more tags to assign to this object (tag names or IDs).
+
+.PARAMETER Custom_Fields
+    Hashtable of custom field values to set (cf_<name>).
+
+.EXAMPLE
+    New-NBDCIMCoolingSource -Site 1 -Name 'CH-01' -Type chiller -Fluid_Type water -Cooling_Capacity 500
+
+    Creates a 500 kW water chiller at site ID 1.
+
+.LINK
+    https://netbox.readthedocs.io/en/stable/rest-api/overview/
+.NOTES
+    AddedInVersion: v4.7.1.0
+    Requires NetBox 4.7.0 or later.
+
+#>
+function New-NBDCIMCoolingSource {
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Low')]
+    [OutputType([PSCustomObject])]
+    param(
+        [Parameter(Mandatory = $true)]
+        [uint64]$Site,
+
+        [uint64]$Location,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Name,
+
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('chiller', 'cooling-tower', 'dry-cooler', 'crac', 'crah')]
+        [string]$Type,
+
+        [ValidateSet('offline', 'active', 'planned', 'failed')]
+        [string]$Status,
+
+        [ValidateSet('water', 'water-glycol', 'dielectric', 'refrigerant')]
+        [string]$Fluid_Type,
+
+        [decimal]$Cooling_Capacity,
+
+        [string]$Description,
+
+        [uint64]$Owner,
+
+        [string]$Comments,
+
+        [object[]]$Tags,
+
+        [hashtable]$Custom_Fields,
+
+        [switch]$Raw
+    )
+    process {
+        Write-Verbose "Creating DCIM Cooling Source"
+        $Segments = [System.Collections.ArrayList]::new(@('dcim', 'cooling-sources'))
+        $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw'
+        if ($PSCmdlet.ShouldProcess($Name, 'Create cooling source')) {
+            InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments) -Method POST -Body $URIComponents.Parameters -Raw:$Raw
+        }
+    }
+}

--- a/Functions/DCIM/CoolingSources/Remove-NBDCIMCoolingSource.ps1
+++ b/Functions/DCIM/CoolingSources/Remove-NBDCIMCoolingSource.ps1
@@ -1,0 +1,48 @@
+<#
+.SYNOPSIS
+    Removes a Cooling Source from Netbox DCIM module.
+
+.DESCRIPTION
+    Removes a Cooling Source from Netbox DCIM module (NetBox 4.7+).
+    Any cooling feeds attached to the source are deleted by NetBox as well.
+    Supports pipeline input for the Id parameter.
+
+.PARAMETER Raw
+    Return the raw API response instead of the results array.
+
+.PARAMETER Id
+    Database ID of the cooling source to delete.
+
+.EXAMPLE
+    Remove-NBDCIMCoolingSource -Id 5
+
+    Deletes cooling source ID 5 after confirmation.
+
+.EXAMPLE
+    Get-NBDCIMCoolingSource -Status planned | Remove-NBDCIMCoolingSource -Confirm:$false
+
+    Deletes every planned cooling source without prompting.
+
+.LINK
+    https://netbox.readthedocs.io/en/stable/rest-api/overview/
+.NOTES
+    AddedInVersion: v4.7.1.0
+    Requires NetBox 4.7.0 or later.
+
+#>
+function Remove-NBDCIMCoolingSource {
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
+    [OutputType([void])]
+    param(
+        [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
+        [uint64]$Id,
+
+        [switch]$Raw
+    )
+    process {
+        Write-Verbose "Removing DCIM Cooling Source"
+        if ($PSCmdlet.ShouldProcess($Id, 'Delete cooling source')) {
+            InvokeNetboxRequest -URI (BuildNewURI -Segments @('dcim', 'cooling-sources', $Id)) -Method DELETE -Raw:$Raw
+        }
+    }
+}

--- a/Functions/DCIM/CoolingSources/Set-NBDCIMCoolingSource.ps1
+++ b/Functions/DCIM/CoolingSources/Set-NBDCIMCoolingSource.ps1
@@ -1,0 +1,129 @@
+<#
+.SYNOPSIS
+    Updates an existing Cooling Source in Netbox DCIM module.
+
+.DESCRIPTION
+    Updates an existing Cooling Source in Netbox DCIM module (NetBox 4.7+)
+    via a PATCH request. Only the parameters you supply are sent.
+    Supports pipeline input for the Id parameter.
+
+    Nullable fields can be cleared server-side:
+    - Pass $null to -Location or -Cooling_Capacity.
+    - Pass '' (empty string) to -Fluid_Type.
+
+.PARAMETER Raw
+    Return the raw API response instead of the results array.
+
+.PARAMETER Id
+    Database ID of the cooling source to update.
+
+.PARAMETER Site
+    Site this cooling source is installed at (database ID).
+
+.PARAMETER Location
+    Location within the site (database ID). Pass $null to clear.
+
+.PARAMETER Name
+    Name of the cooling source.
+
+.PARAMETER Type
+    Type of cooling equipment: chiller, cooling-tower, dry-cooler, crac or crah.
+
+.PARAMETER Status
+    Operational status: offline, active, planned or failed.
+
+.PARAMETER Fluid_Type
+    Cooling fluid type: water, water-glycol, dielectric or refrigerant.
+    Pass '' (empty string) to clear the field server-side.
+
+.PARAMETER Cooling_Capacity
+    Total rated cooling capacity in kW. Pass $null to clear.
+
+.PARAMETER Description
+    Brief description.
+
+.PARAMETER Owner
+    Owner of this object (database ID).
+
+.PARAMETER Comments
+    Detailed comments (Markdown is supported).
+
+.PARAMETER Tags
+    One or more tags to assign to this object (tag names or IDs).
+
+.PARAMETER Custom_Fields
+    Hashtable of custom field values to set (cf_<name>).
+
+.EXAMPLE
+    Set-NBDCIMCoolingSource -Id 5 -Status offline
+
+    Marks cooling source ID 5 as offline.
+
+.EXAMPLE
+    Set-NBDCIMCoolingSource -Id 5 -Fluid_Type '' -Cooling_Capacity $null
+
+    Clears the fluid type and cooling capacity of cooling source ID 5.
+
+.LINK
+    https://netbox.readthedocs.io/en/stable/rest-api/overview/
+.NOTES
+    AddedInVersion: v4.7.1.0
+    Requires NetBox 4.7.0 or later.
+
+#>
+function Set-NBDCIMCoolingSource {
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
+    [OutputType([PSCustomObject])]
+    param(
+        [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)]
+        [uint64]$Id,
+
+        [uint64]$Site,
+
+        [Nullable[uint64]]$Location,
+
+        [string]$Name,
+
+        [ValidateSet('chiller', 'cooling-tower', 'dry-cooler', 'crac', 'crah')]
+        [string]$Type,
+
+        [ValidateSet('offline', 'active', 'planned', 'failed')]
+        [string]$Status,
+
+        [AllowEmptyString()]
+        [ValidateSet('water', 'water-glycol', 'dielectric', 'refrigerant', '')]
+        [string]$Fluid_Type,
+
+        [Nullable[decimal]]$Cooling_Capacity,
+
+        [string]$Description,
+
+        [uint64]$Owner,
+
+        [string]$Comments,
+
+        [object[]]$Tags,
+
+        [hashtable]$Custom_Fields,
+
+        [switch]$Raw
+    )
+    process {
+        Write-Verbose "Updating DCIM Cooling Source"
+
+        # Translate '' -> $null for clearable enum params BEFORE
+        # BuildURIComponents, so the PATCH body carries JSON null
+        # (NetBox rejects "" for these nullable enum fields).
+        foreach ($p in @('Fluid_Type')) {
+            if ($PSBoundParameters.ContainsKey($p) -and $PSBoundParameters[$p] -eq '') {
+                $PSBoundParameters[$p] = $null
+            }
+        }
+
+        $Segments = [System.Collections.ArrayList]::new(@('dcim', 'cooling-sources', $Id))
+        $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw'
+        if ($PSCmdlet.ShouldProcess($Id, 'Update cooling source')) {
+            InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments) -Method PATCH -Body $URIComponents.Parameters -Raw:$Raw
+        }
+    }
+}

--- a/Functions/DCIM/DeviceBays/Get-NBDCIMDeviceBay.ps1
+++ b/Functions/DCIM/DeviceBays/Get-NBDCIMDeviceBay.ps1
@@ -40,7 +40,14 @@
 .PARAMETER Query
     Free-text search across the object (NetBox 'q' parameter).
 
-.PARAMETER Limit
+.PARAMETER Tag
+        Filter by tag slug(s). Several values are combined with AND (object must carry all of them);
+        use Set-NBQueryOption -TagMatch Any (Netbox 4.6.6+) for OR semantics.
+
+    .PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
+    .PARAMETER Limit
     Maximum number of results to return per request (1-1000).
 
 .PARAMETER Offset
@@ -74,6 +81,12 @@ function Get-NBDCIMDeviceBay {
         [Parameter(ParameterSetName = 'Query')][string]$Name,
         [Parameter(ParameterSetName = 'Query')][uint64]$Device_Id,
         [Parameter(ParameterSetName = 'Query')][string]$Query,
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tag_Id,
+
         [ValidateRange(1, 1000)]
         [uint16]$Limit,
         [ValidateRange(0, [int]::MaxValue)]

--- a/Functions/DCIM/Devices/Get-NBDCIMDevice.ps1
+++ b/Functions/DCIM/Devices/Get-NBDCIMDevice.ps1
@@ -131,6 +131,11 @@
 .PARAMETER Serial
     Filter by serial number.
 
+.PARAMETER Cooling_Method
+    Filter by cooling method: 'air', 'liquid', 'hybrid' or 'immersion'
+    (scalar filter). Requires NetBox 4.7.0 or later; ignored with a warning
+    on older servers.
+
 .EXAMPLE
     Get-NBDCIMDevice
     Returns the first page of devices (config_context excluded by default).
@@ -279,6 +284,10 @@ function Get-NBDCIMDevice {
         [Parameter(ParameterSetName = 'Query')]
         [string]$Serial,
 
+        [Parameter(ParameterSetName = 'Query')]
+        [ValidateSet('air', 'liquid', 'hybrid', 'immersion', IgnoreCase = $true)]
+        [string]$Cooling_Method,
+
         [switch]$Raw
     )
 
@@ -328,7 +337,16 @@ function Get-NBDCIMDevice {
                     $paramsToPass['Omit'] = $omitFields | Select-Object -Unique
                 }
                 [void]$paramsToPass.Remove('IncludeConfigContext')
-                $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $paramsToPass -SkipParameterByName 'Raw', 'All', 'PageSize'
+
+                # NetBox 4.7+ only fields: drop them with a warning on older servers.
+                $skipParams = @('Raw', 'All', 'PageSize')
+                foreach ($p in @('Cooling_Method')) {
+                    if (Test-NBMinimumVersion -ParameterName $p -MinimumVersion '4.7.0' -BoundParameters $PSBoundParameters -FeatureName "The -$p filter") {
+                        $skipParams += $p
+                    }
+                }
+
+                $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $paramsToPass -SkipParameterByName $skipParams
                 $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
                 InvokeNetboxRequest -URI $URI -Raw:$Raw -All:$All -PageSize $PageSize
             }

--- a/Functions/DCIM/Devices/Get-NBDCIMDevice.ps1
+++ b/Functions/DCIM/Devices/Get-NBDCIMDevice.ps1
@@ -41,7 +41,14 @@
 .PARAMETER Raw
     Return the raw API response instead of the results array.
 
-.PARAMETER Limit
+.PARAMETER Tag
+        Filter by tag slug(s). Several values are combined with AND (object must carry all of them);
+        use Set-NBQueryOption -TagMatch Any (Netbox 4.6.6+) for OR semantics.
+
+    .PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
+    .PARAMETER Limit
     Maximum number of results to return per request (1-1000).
 
 .PARAMETER Offset
@@ -183,6 +190,12 @@ function Get-NBDCIMDevice {
         [string[]]$Omit,
 
         [switch]$IncludeConfigContext,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tag_Id,
 
         [ValidateRange(1, 1000)]
         [uint16]$Limit,

--- a/Functions/DCIM/Devices/Get-NBDCIMDeviceRole.ps1
+++ b/Functions/DCIM/Devices/Get-NBDCIMDeviceRole.ps1
@@ -28,7 +28,14 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-.PARAMETER Limit
+.PARAMETER Tag
+        Filter by tag slug(s). Several values are combined with AND (object must carry all of them);
+        use Set-NBQueryOption -TagMatch Any (Netbox 4.6.6+) for OR semantics.
+
+    .PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
+    .PARAMETER Limit
     Maximum number of results to return per request (1-1000).
 
 .PARAMETER Offset
@@ -73,6 +80,12 @@ function Get-NBDCIMDeviceRole {
         [string[]]$Fields,
 
         [string[]]$Omit,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tag_Id,
 
         [ValidateRange(1, 1000)]
         [uint16]$Limit,

--- a/Functions/DCIM/Devices/Get-NBDCIMDeviceType.ps1
+++ b/Functions/DCIM/Devices/Get-NBDCIMDeviceType.ps1
@@ -73,6 +73,15 @@
 .PARAMETER Subdevice_Role
     Filter by subdevice role.
 
+.PARAMETER Cooling_Method
+    Filter by cooling method: 'air', 'liquid', 'hybrid' or 'immersion'
+    (scalar filter). Requires NetBox 4.7.0 or later; ignored with a warning
+    on older servers.
+
+.PARAMETER End_Of_Life
+    Filter by end-of-life date (one or more dates, sent as yyyy-MM-dd).
+    Requires NetBox 4.7.0 or later; ignored with a warning on older servers.
+
 .EXAMPLE
     Get-NBDCIMDeviceType
 
@@ -144,6 +153,13 @@ function Get-NBDCIMDeviceType {
         [Parameter(ParameterSetName = 'Query')]
         [uint16]$Subdevice_Role,
 
+        [Parameter(ParameterSetName = 'Query')]
+        [ValidateSet('air', 'liquid', 'hybrid', 'immersion', IgnoreCase = $true)]
+        [string]$Cooling_Method,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [datetime[]]$End_Of_Life,
+
         [switch]$Raw
     )
 
@@ -158,7 +174,20 @@ function Get-NBDCIMDeviceType {
             'ByID' { foreach ($i in $Id) { InvokeNetboxRequest -URI (BuildNewURI -Segments @('dcim', 'device-types', $i)) -Raw:$Raw } }
             default {
                 $Segments = [System.Collections.ArrayList]::new(@('dcim', 'device-types'))
-                $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'All', 'PageSize'
+
+                if ($PSBoundParameters.ContainsKey('End_Of_Life')) {
+                    $PSBoundParameters['End_Of_Life'] = @($End_Of_Life | ForEach-Object { $_.ToString('yyyy-MM-dd') })
+                }
+
+                # NetBox 4.7+ only fields: drop them with a warning on older servers.
+                $skipParams = @('Raw', 'All', 'PageSize')
+                foreach ($p in @('Cooling_Method', 'End_Of_Life')) {
+                    if (Test-NBMinimumVersion -ParameterName $p -MinimumVersion '4.7.0' -BoundParameters $PSBoundParameters -FeatureName "The -$p filter") {
+                        $skipParams += $p
+                    }
+                }
+
+                $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName $skipParams
                 $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
                 InvokeNetboxRequest -URI $URI -Raw:$Raw -All:$All -PageSize $PageSize
             }

--- a/Functions/DCIM/Devices/Get-NBDCIMDeviceType.ps1
+++ b/Functions/DCIM/Devices/Get-NBDCIMDeviceType.ps1
@@ -31,7 +31,14 @@
 .PARAMETER Offset
     Number of results to skip (pagination offset).
 
-.PARAMETER Limit
+.PARAMETER Tag
+        Filter by tag slug(s). Several values are combined with AND (object must carry all of them);
+        use Set-NBQueryOption -TagMatch Any (Netbox 4.6.6+) for OR semantics.
+
+    .PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
+    .PARAMETER Limit
     Maximum number of results to return per request (1-1000).
 
 .PARAMETER Id
@@ -101,6 +108,12 @@ function Get-NBDCIMDeviceType {
 
         [ValidateRange(0, [int]::MaxValue)]
         [uint16]$Offset,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tag_Id,
 
         [ValidateRange(1, 1000)]
         [uint16]$Limit,

--- a/Functions/DCIM/Devices/New-NBDCIMDevice.ps1
+++ b/Functions/DCIM/Devices/New-NBDCIMDevice.ps1
@@ -35,6 +35,10 @@
     Default: 0 (no batching - backwards compatible single-item mode)
     Range: 1-1000
 
+.PARAMETER Background
+    Netbox 4.7+: queue each bulk batch as a background job (?background=true) instead of processing it
+    synchronously; the returned items are the job objects (check them with Get-NBJob). Ignored with a
+    warning on older Netbox versions. Only meaningful together with -BatchSize pipeline input.
 .PARAMETER Force
     Skip confirmation prompts for bulk operations.
 
@@ -263,6 +267,8 @@ function New-NBDCIMDevice {
         [ValidateRange(1, 1000)]
         [int]$BatchSize = 100,
 
+        [switch]$Background,
+
         [Parameter(ParameterSetName = 'Bulk')]
         [switch]$Force,
 
@@ -318,6 +324,7 @@ function New-NBDCIMDevice {
             if ($Force -or $PSCmdlet.ShouldProcess($target, 'Create devices (bulk)')) {
                 Write-Verbose "Processing $($bulkItems.Count) devices in bulk mode with batch size $BatchSize"
 
+                $useBackground = $Background -and -not (Test-NBMinimumVersion -ParameterName 'Background' -MinimumVersion '4.7.0' -BoundParameters $PSBoundParameters -FeatureName 'Background bulk processing (-Background)')
                 $bulkParams = @{
                     URI          = $URI
                     Items        = $bulkItems.ToArray()
@@ -325,6 +332,7 @@ function New-NBDCIMDevice {
                     BatchSize    = $BatchSize
                     ShowProgress = $true
                     ActivityName = 'Creating devices'
+                    Background   = $useBackground
                 }
                 $result = Send-NBBulkRequest @bulkParams
 

--- a/Functions/DCIM/Devices/New-NBDCIMDevice.ps1
+++ b/Functions/DCIM/Devices/New-NBDCIMDevice.ps1
@@ -68,6 +68,10 @@
     Local config context data (free-form JSON; hashtable or object). Takes
     precedence over source contexts in the rendered config context.
 
+.PARAMETER Cooling_Method
+    Cooling method. One of: 'air', 'liquid', 'hybrid', 'immersion'.
+    Requires NetBox 4.7.0 or later; ignored with a warning on older servers.
+
 .PARAMETER Status
     Operational status.
 
@@ -255,6 +259,10 @@ function New-NBDCIMDevice {
         [Parameter(ParameterSetName = 'Single')]
         [object]$Local_Context_Data,
 
+        [Parameter(ParameterSetName = 'Single')]
+        [ValidateSet('air', 'liquid', 'hybrid', 'immersion', IgnoreCase = $true)]
+        [string]$Cooling_Method,
+
         # Bulk mode parameters
         [Parameter(ParameterSetName = 'Bulk', Mandatory = $true, ValueFromPipeline = $true)]
         [PSCustomObject]$InputObject,
@@ -287,7 +295,15 @@ function New-NBDCIMDevice {
     process {
         if ($PSCmdlet.ParameterSetName -eq 'Single') {
             # Original single-item behavior
-            $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw'
+            # NetBox 4.7+ only fields: drop them with a warning on older servers.
+            $skipParams = @('Raw')
+            foreach ($p in @('Cooling_Method')) {
+                if (Test-NBMinimumVersion -ParameterName $p -MinimumVersion '4.7.0' -BoundParameters $PSBoundParameters -FeatureName "The -$p parameter") {
+                    $skipParams += $p
+                }
+            }
+
+            $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName $skipParams
 
             if ($PSCmdlet.ShouldProcess($Name, 'Create new Device')) {
                 InvokeNetboxRequest -URI $URI -Body $URIComponents.Parameters -Method POST -Raw:$Raw

--- a/Functions/DCIM/Devices/New-NBDCIMDeviceType.ps1
+++ b/Functions/DCIM/Devices/New-NBDCIMDeviceType.ps1
@@ -45,6 +45,15 @@
 .PARAMETER Comments
     Detailed comments (Markdown is supported).
 
+.PARAMETER Cooling_Method
+    Cooling method. One of: 'air', 'liquid', 'hybrid', 'immersion'.
+    Requires NetBox 4.7.0 or later; ignored with a warning on older servers.
+
+.PARAMETER End_Of_Life
+    Date after which this device type is no longer supported by the manufacturer.
+    Sent as yyyy-MM-dd. Requires NetBox 4.7.0 or later; ignored with a
+    warning on older servers.
+
 .PARAMETER Tags
     One or more tags to assign to this object (tag names or IDs).
 
@@ -78,6 +87,9 @@ function New-NBDCIMDeviceType {
         [string]$Weight_Unit,
         [string]$Description,
         [string]$Comments,
+        [ValidateSet('air', 'liquid', 'hybrid', 'immersion', IgnoreCase = $true)]
+        [string]$Cooling_Method,
+        [datetime]$End_Of_Life,
         [string[]]$Tags,
         [hashtable]$Custom_Fields,
         [switch]$Raw
@@ -85,7 +97,21 @@ function New-NBDCIMDeviceType {
     process {
         Write-Verbose "Creating DCIM Device Type"
         $Segments = [System.Collections.ArrayList]::new(@('dcim','device-types'))
-        $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw'
+
+        # NetBox DateField wants yyyy-MM-dd, not the ISO datetime ConvertTo-Json emits.
+        if ($PSBoundParameters.ContainsKey('End_Of_Life') -and $null -ne $PSBoundParameters['End_Of_Life']) {
+            $PSBoundParameters['End_Of_Life'] = ([datetime]$PSBoundParameters['End_Of_Life']).ToString('yyyy-MM-dd')
+        }
+
+        # NetBox 4.7+ only fields: drop them with a warning on older servers.
+        $skipParams = @('Raw')
+        foreach ($p in @('Cooling_Method', 'End_Of_Life')) {
+            if (Test-NBMinimumVersion -ParameterName $p -MinimumVersion '4.7.0' -BoundParameters $PSBoundParameters -FeatureName "The -$p parameter") {
+                $skipParams += $p
+            }
+        }
+
+        $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName $skipParams
         if ($PSCmdlet.ShouldProcess($Model, 'Create device type')) {
             InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments) -Method POST -Body $URIComponents.Parameters -Raw:$Raw
         }

--- a/Functions/DCIM/Devices/Remove-NBDCIMDevice.ps1
+++ b/Functions/DCIM/Devices/Remove-NBDCIMDevice.ps1
@@ -22,6 +22,10 @@
     Number of devices to delete per API request in bulk mode.
     Default: 50, Range: 1-1000
 
+.PARAMETER Background
+    Netbox 4.7+: queue each bulk batch as a background job (?background=true) instead of processing it
+    synchronously; the returned items are the job objects (check them with Get-NBJob). Ignored with a
+    warning on older Netbox versions. Only meaningful together with -BatchSize pipeline input.
 .PARAMETER Force
     Skip confirmation prompts. Use with caution!
 
@@ -72,6 +76,8 @@ function Remove-NBDCIMDevice {
         [Parameter(ParameterSetName = 'Bulk')]
         [ValidateRange(1, 1000)]
         [int]$BatchSize = 100,
+
+        [switch]$Background,
 
         # Common parameters
         [Parameter()]
@@ -127,6 +133,7 @@ function Remove-NBDCIMDevice {
             if ($Force -or $PSCmdlet.ShouldProcess($target, 'Delete devices (bulk)')) {
                 Write-Verbose "Processing $($bulkItems.Count) devices in bulk DELETE mode with batch size $BatchSize"
 
+                $useBackground = $Background -and -not (Test-NBMinimumVersion -ParameterName 'Background' -MinimumVersion '4.7.0' -BoundParameters $PSBoundParameters -FeatureName 'Background bulk processing (-Background)')
                 $bulkParams = @{
                     URI          = $URI
                     Items        = $bulkItems.ToArray()
@@ -134,6 +141,7 @@ function Remove-NBDCIMDevice {
                     BatchSize    = $BatchSize
                     ShowProgress = $true
                     ActivityName = 'Deleting devices'
+                    Background   = $useBackground
                 }
                 $result = Send-NBBulkRequest @bulkParams
 

--- a/Functions/DCIM/Devices/Set-NBDCIMDevice.ps1
+++ b/Functions/DCIM/Devices/Set-NBDCIMDevice.ps1
@@ -135,6 +135,10 @@
     Number of devices to update per API request in bulk mode.
     Default: 50, Range: 1-1000
 
+.PARAMETER Background
+    Netbox 4.7+: queue each bulk batch as a background job (?background=true) instead of processing it
+    synchronously; the returned items are the job objects (check them with Get-NBJob). Ignored with a
+    warning on older Netbox versions. Only meaningful together with -BatchSize pipeline input.
 .PARAMETER Force
     Skip confirmation prompts.
 
@@ -293,6 +297,8 @@ function Set-NBDCIMDevice {
         [ValidateRange(1, 1000)]
         [int]$BatchSize = 100,
 
+        [switch]$Background,
+
         # Common parameters
         [Parameter()]
         [switch]$Force,
@@ -371,6 +377,7 @@ function Set-NBDCIMDevice {
             if ($Force -or $PSCmdlet.ShouldProcess($target, 'Update devices (bulk)')) {
                 Write-Verbose "Processing $($bulkItems.Count) devices in bulk PATCH mode with batch size $BatchSize"
 
+                $useBackground = $Background -and -not (Test-NBMinimumVersion -ParameterName 'Background' -MinimumVersion '4.7.0' -BoundParameters $PSBoundParameters -FeatureName 'Background bulk processing (-Background)')
                 $bulkParams = @{
                     URI          = $URI
                     Items        = $bulkItems.ToArray()
@@ -378,6 +385,7 @@ function Set-NBDCIMDevice {
                     BatchSize    = $BatchSize
                     ShowProgress = $true
                     ActivityName = 'Updating devices'
+                    Background   = $useBackground
                 }
                 $result = Send-NBBulkRequest @bulkParams
 

--- a/Functions/DCIM/Devices/Set-NBDCIMDevice.ps1
+++ b/Functions/DCIM/Devices/Set-NBDCIMDevice.ps1
@@ -91,6 +91,11 @@
     Local config context data (free-form JSON; hashtable or object). Takes
     precedence over source contexts. Pass $null to clear.
 
+.PARAMETER Cooling_Method
+    Cooling method. One of: 'air', 'liquid', 'hybrid', 'immersion'.
+    Pass '' to clear the field server-side (sent as JSON null).
+    Requires NetBox 4.7.0 or later; ignored with a warning on older servers.
+
 .PARAMETER Virtual_Chassis
     Virtual Chassis.
 
@@ -285,6 +290,11 @@ function Set-NBDCIMDevice {
         [Parameter(ParameterSetName = 'Single')]
         [object]$Local_Context_Data,
 
+        [Parameter(ParameterSetName = 'Single')]
+        [AllowEmptyString()]
+        [ValidateSet('air', 'liquid', 'hybrid', 'immersion', '', IgnoreCase = $true)]
+        [string]$Cooling_Method,
+
         # Bulk mode parameters
         [Parameter(ParameterSetName = 'Bulk', Mandatory = $true, ValueFromPipeline = $true)]
         [PSCustomObject]$InputObject,
@@ -318,8 +328,10 @@ function Set-NBDCIMDevice {
         # the field server-side: BuildURIComponents + ConvertTo-Json emit
         # "airflow": null on the wire, which NetBox PATCH accepts (airflow is
         # enum-nullable). Same idiom as Set-NBDCIMInterface -Duplex '' (#401).
-        if ($PSBoundParameters.ContainsKey('Airflow') -and $PSBoundParameters['Airflow'] -eq '') {
-            $PSBoundParameters['Airflow'] = $null
+        foreach ($p in @('Airflow', 'Cooling_Method')) {
+            if ($PSBoundParameters.ContainsKey($p) -and $PSBoundParameters[$p] -eq '') {
+                $PSBoundParameters[$p] = $null
+            }
         }
 
         if ($PSCmdlet.ParameterSetName -eq 'Single') {
@@ -327,7 +339,15 @@ function Set-NBDCIMDevice {
             if ($Force -or $PSCmdlet.ShouldProcess("Device ID $Id", "Update device")) {
                 $DeviceSegments = [System.Collections.ArrayList]::new(@('dcim', 'devices', $Id))
 
-                $URIComponents = BuildURIComponents -URISegments $DeviceSegments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Force', 'Raw'
+                # NetBox 4.7+ only fields: drop them with a warning on older servers.
+                $skipParams = @('Id', 'Force', 'Raw')
+                foreach ($p in @('Cooling_Method')) {
+                    if (Test-NBMinimumVersion -ParameterName $p -MinimumVersion '4.7.0' -BoundParameters $PSBoundParameters -FeatureName "The -$p parameter") {
+                        $skipParams += $p
+                    }
+                }
+
+                $URIComponents = BuildURIComponents -URISegments $DeviceSegments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName $skipParams
 
                 $DeviceURI = BuildNewURI -Segments $URIComponents.Segments
 

--- a/Functions/DCIM/Devices/Set-NBDCIMDeviceType.ps1
+++ b/Functions/DCIM/Devices/Set-NBDCIMDeviceType.ps1
@@ -48,6 +48,16 @@
 .PARAMETER Comments
     Detailed comments (Markdown is supported).
 
+.PARAMETER Cooling_Method
+    Cooling method. One of: 'air', 'liquid', 'hybrid', 'immersion'.
+    Pass '' to clear the field server-side (sent as JSON null).
+    Requires NetBox 4.7.0 or later; ignored with a warning on older servers.
+
+.PARAMETER End_Of_Life
+    Date after which this device type is no longer supported by the manufacturer.
+    Sent as yyyy-MM-dd. Pass $null to clear. Requires NetBox 4.7.0 or later;
+    ignored with a warning on older servers.
+
 .PARAMETER Tags
     One or more tags to assign to this object (tag names or IDs).
 
@@ -82,6 +92,10 @@ function Set-NBDCIMDeviceType {
         [string]$Weight_Unit,
         [string]$Description,
         [string]$Comments,
+        [AllowEmptyString()]
+        [ValidateSet('air', 'liquid', 'hybrid', 'immersion', '', IgnoreCase = $true)]
+        [string]$Cooling_Method,
+        [Nullable[datetime]]$End_Of_Life,
         [string[]]$Tags,
         [hashtable]$Custom_Fields,
         [switch]$Raw
@@ -89,7 +103,29 @@ function Set-NBDCIMDeviceType {
     process {
         Write-Verbose "Updating DCIM Device Type"
         $Segments = [System.Collections.ArrayList]::new(@('dcim','device-types',$Id))
-        $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id','Raw'
+
+        # Translate '' -> $null for clearable enum params BEFORE BuildURIComponents,
+        # so the PATCH body carries JSON null (NetBox rejects "" for nullable enums).
+        foreach ($p in @('Cooling_Method')) {
+            if ($PSBoundParameters.ContainsKey($p) -and $PSBoundParameters[$p] -eq '') {
+                $PSBoundParameters[$p] = $null
+            }
+        }
+
+        # NetBox DateField wants yyyy-MM-dd, not the ISO datetime ConvertTo-Json emits.
+        if ($PSBoundParameters.ContainsKey('End_Of_Life') -and $null -ne $PSBoundParameters['End_Of_Life']) {
+            $PSBoundParameters['End_Of_Life'] = ([datetime]$PSBoundParameters['End_Of_Life']).ToString('yyyy-MM-dd')
+        }
+
+        # NetBox 4.7+ only fields: drop them with a warning on older servers.
+        $skipParams = @('Id', 'Raw')
+        foreach ($p in @('Cooling_Method', 'End_Of_Life')) {
+            if (Test-NBMinimumVersion -ParameterName $p -MinimumVersion '4.7.0' -BoundParameters $PSBoundParameters -FeatureName "The -$p parameter") {
+                $skipParams += $p
+            }
+        }
+
+        $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName $skipParams
         if ($PSCmdlet.ShouldProcess($Id, 'Update device type')) {
             InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments) -Method PATCH -Body $URIComponents.Parameters -Raw:$Raw
         }

--- a/Functions/DCIM/FrontPorts/Get-NBDCIMFrontPort.ps1
+++ b/Functions/DCIM/FrontPorts/Get-NBDCIMFrontPort.ps1
@@ -28,7 +28,14 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-.PARAMETER Limit
+.PARAMETER Tag
+        Filter by tag slug(s). Several values are combined with AND (object must carry all of them);
+        use Set-NBQueryOption -TagMatch Any (Netbox 4.6.6+) for OR semantics.
+
+    .PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
+    .PARAMETER Limit
     Maximum number of results to return per request (1-1000).
 
 .PARAMETER Offset
@@ -73,6 +80,12 @@ function Get-NBDCIMFrontPort {
         [string[]]$Fields,
 
         [string[]]$Omit,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tag_Id,
 
         [ValidateRange(1, 1000)]
         [uint16]$Limit,

--- a/Functions/DCIM/InterfaceTemplates/Get-NBDCIMInterfaceTemplate.ps1
+++ b/Functions/DCIM/InterfaceTemplates/Get-NBDCIMInterfaceTemplate.ps1
@@ -46,6 +46,15 @@
 .PARAMETER Query
     Free-text search across the object (NetBox 'q' parameter).
 
+.PARAMETER Channels
+    Filter by number of channels (one or more values). Requires NetBox 4.7.0
+    or later; ignored with a warning on older servers.
+
+.PARAMETER Channel_Id
+    Filter by channel number on the parent interface template (one or more
+    values). Requires NetBox 4.7.0 or later; ignored with a warning on older
+    servers.
+
 .PARAMETER Limit
     Maximum number of results to return per request (1-1000).
 
@@ -82,6 +91,8 @@ function Get-NBDCIMInterfaceTemplate {
         [Parameter(ParameterSetName = 'Query')][uint64]$Module_Type_Id,
         [Parameter(ParameterSetName = 'Query')][string]$Type,
         [Parameter(ParameterSetName = 'Query')][string]$Query,
+        [Parameter(ParameterSetName = 'Query')][uint16[]]$Channels,
+        [Parameter(ParameterSetName = 'Query')][uint16[]]$Channel_Id,
         [ValidateRange(1, 1000)]
         [uint16]$Limit,
         [ValidateRange(0, [int]::MaxValue)]
@@ -97,7 +108,16 @@ function Get-NBDCIMInterfaceTemplate {
             'ByID' { foreach ($i in $Id) { InvokeNetboxRequest -URI (BuildNewURI -Segments @('dcim','interface-templates',$i)) -Raw:$Raw } }
             default {
                 $Segments = [System.Collections.ArrayList]::new(@('dcim','interface-templates'))
-                $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'All', 'PageSize'
+
+                # NetBox 4.7+ only filters: drop them with a warning on older servers.
+                $skipParams = @('Raw', 'All', 'PageSize')
+                foreach ($p in @('Channels', 'Channel_Id')) {
+                    if (Test-NBMinimumVersion -ParameterName $p -MinimumVersion '4.7.0' -BoundParameters $PSBoundParameters -FeatureName "The -$p filter") {
+                        $skipParams += $p
+                    }
+                }
+
+                $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName $skipParams
                 InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters) -Raw:$Raw -All:$All -PageSize $PageSize
             }
         }

--- a/Functions/DCIM/InterfaceTemplates/New-NBDCIMInterfaceTemplate.ps1
+++ b/Functions/DCIM/InterfaceTemplates/New-NBDCIMInterfaceTemplate.ps1
@@ -42,6 +42,16 @@
 .PARAMETER Rf_Role
     Rf Role.
 
+.PARAMETER Channels
+    Number of channels this (breakout) interface template is channelized into
+    (1-1024). Requires NetBox 4.7.0 or later; ignored with a warning on
+    older servers.
+
+.PARAMETER Channel_Id
+    For a template of type 'channel': the channel number (1-1024) on the
+    parent interface template that this template is bound to. Requires
+    NetBox 4.7.0 or later; ignored with a warning on older servers.
+
 .PARAMETER Tags
     One or more tags to assign to this object (tag names or IDs).
 
@@ -72,6 +82,12 @@ function New-NBDCIMInterfaceTemplate {
         [string]$Poe_Type,
         [string]$Rf_Role,
 
+        [ValidateRange(1, 1024)]
+        [uint16]$Channels,
+
+        [ValidateRange(1, 1024)]
+        [uint16]$Channel_Id,
+
         [object[]]$Tags,
 
         [switch]$Raw
@@ -79,7 +95,16 @@ function New-NBDCIMInterfaceTemplate {
     process {
         Write-Verbose "Creating DCIM Interface Template"
         $Segments = [System.Collections.ArrayList]::new(@('dcim','interface-templates'))
-        $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw'
+
+        # NetBox 4.7+ only fields: drop them with a warning on older servers.
+        $skipParams = @('Raw')
+        foreach ($p in @('Channels', 'Channel_Id')) {
+            if (Test-NBMinimumVersion -ParameterName $p -MinimumVersion '4.7.0' -BoundParameters $PSBoundParameters -FeatureName "The -$p parameter") {
+                $skipParams += $p
+            }
+        }
+
+        $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName $skipParams
         if ($PSCmdlet.ShouldProcess($Name, 'Create interface template')) {
             InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments) -Method POST -Body $URIComponents.Parameters -Raw:$Raw
         }

--- a/Functions/DCIM/InterfaceTemplates/Set-NBDCIMInterfaceTemplate.ps1
+++ b/Functions/DCIM/InterfaceTemplates/Set-NBDCIMInterfaceTemplate.ps1
@@ -45,6 +45,17 @@
 .PARAMETER Rf_Role
     Rf Role.
 
+.PARAMETER Channels
+    Number of channels this (breakout) interface template is channelized into
+    (1-1024). Pass $null to clear. Requires NetBox 4.7.0 or later; ignored
+    with a warning on older servers.
+
+.PARAMETER Channel_Id
+    For a template of type 'channel': the channel number (1-1024) on the
+    parent interface template that this template is bound to. Pass $null to
+    clear. Requires NetBox 4.7.0 or later; ignored with a warning on older
+    servers.
+
 .PARAMETER Tags
     One or more tags to assign to this object (tag names or IDs).
 
@@ -76,6 +87,11 @@ function Set-NBDCIMInterfaceTemplate {
         [string]$Poe_Type,
         [string]$Rf_Role,
 
+        # No [ValidateRange]: it fires before [Nullable[T]] binding (#398).
+        [Nullable[uint16]]$Channels,
+
+        [Nullable[uint16]]$Channel_Id,
+
         [object[]]$Tags,
 
         [switch]$Raw
@@ -83,7 +99,16 @@ function Set-NBDCIMInterfaceTemplate {
     process {
         Write-Verbose "Updating DCIM Interface Template"
         $Segments = [System.Collections.ArrayList]::new(@('dcim','interface-templates',$Id))
-        $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id','Raw'
+
+        # NetBox 4.7+ only fields: drop them with a warning on older servers.
+        $skipParams = @('Id', 'Raw')
+        foreach ($p in @('Channels', 'Channel_Id')) {
+            if (Test-NBMinimumVersion -ParameterName $p -MinimumVersion '4.7.0' -BoundParameters $PSBoundParameters -FeatureName "The -$p parameter") {
+                $skipParams += $p
+            }
+        }
+
+        $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName $skipParams
         if ($PSCmdlet.ShouldProcess($Id, 'Update interface template')) {
             InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments) -Method PATCH -Body $URIComponents.Parameters -Raw:$Raw
         }

--- a/Functions/DCIM/Interfaces/Get-NBDCIMInterface.ps1
+++ b/Functions/DCIM/Interfaces/Get-NBDCIMInterface.ps1
@@ -28,7 +28,14 @@
     Specify which fields to include in the response.
     Supports nested field selection (e.g., 'site.name', 'device_type.model').
 
-.PARAMETER Limit
+.PARAMETER Tag
+        Filter by tag slug(s). Several values are combined with AND (object must carry all of them);
+        use Set-NBQueryOption -TagMatch Any (Netbox 4.6.6+) for OR semantics.
+
+    .PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
+    .PARAMETER Limit
     Maximum number of results to return per request (1-1000).
 
 .PARAMETER Offset
@@ -95,6 +102,12 @@ function Get-NBDCIMInterface {
         [string[]]$Fields,
 
         [string[]]$Omit,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tag_Id,
 
         [ValidateRange(1, 1000)]
         [uint16]$Limit,

--- a/Functions/DCIM/Interfaces/Get-NBDCIMInterface.ps1
+++ b/Functions/DCIM/Interfaces/Get-NBDCIMInterface.ps1
@@ -62,10 +62,18 @@
     Filter by lag database ID.
 
 .PARAMETER MAC_Address
-    Filter by MAC address.
+    Filter by one or more MAC addresses (repeat-key filter).
 
 .PARAMETER Label
     Filter by physical label.
+
+.PARAMETER Channels
+    Filter by number of channels (one or more values). Requires NetBox 4.7.0
+    or later; ignored with a warning on older servers.
+
+.PARAMETER Channel_Id
+    Filter by channel number on the parent interface (one or more values).
+    Requires NetBox 4.7.0 or later; ignored with a warning on older servers.
 
 .EXAMPLE
     Get-NBDCIMInterface
@@ -131,10 +139,16 @@ function Get-NBDCIMInterface {
         [uint64]$LAG_Id,
 
         [Parameter(ParameterSetName = 'Query')]
-        [string]$MAC_Address,
+        [string[]]$MAC_Address,
 
         [Parameter(ParameterSetName = 'Query')]
         [string]$Label,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint16[]]$Channels,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint16[]]$Channel_Id,
 
         [switch]$Raw
     )
@@ -148,7 +162,17 @@ function Get-NBDCIMInterface {
             'ByID' { foreach ($i in $Id) { InvokeNetboxRequest -URI (BuildNewURI -Segments @('dcim', 'interfaces', $i)) -Raw:$Raw } }
             default {
                 $Segments = [System.Collections.ArrayList]::new(@('dcim', 'interfaces'))
-                $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'All', 'PageSize'
+
+                # NetBox 4.7+ only filters: older servers silently ignore unknown
+                # query keys (returning the full list), so drop them with a warning.
+                $skipParams = @('Raw', 'All', 'PageSize')
+                foreach ($p in @('Channels', 'Channel_Id')) {
+                    if (Test-NBMinimumVersion -ParameterName $p -MinimumVersion '4.7.0' -BoundParameters $PSBoundParameters -FeatureName "The -$p filter") {
+                        $skipParams += $p
+                    }
+                }
+
+                $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName $skipParams
                 $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
                 InvokeNetboxRequest -URI $URI -Raw:$Raw -All:$All -PageSize $PageSize
             }

--- a/Functions/DCIM/Interfaces/New-NBDCIMInterface.ps1
+++ b/Functions/DCIM/Interfaces/New-NBDCIMInterface.ps1
@@ -125,6 +125,10 @@
     Number of interfaces to create per API request in bulk mode.
     Default: 50, Range: 1-1000
 
+.PARAMETER Background
+    Netbox 4.7+: queue each bulk batch as a background job (?background=true) instead of processing it
+    synchronously; the returned items are the job objects (check them with Get-NBJob). Ignored with a
+    warning on older Netbox versions. Only meaningful together with -BatchSize pipeline input.
 .PARAMETER Force
     Skip confirmation prompts for bulk operations.
 
@@ -286,6 +290,8 @@ function New-NBDCIMInterface {
         [ValidateRange(1, 1000)]
         [int]$BatchSize = 100,
 
+        [switch]$Background,
+
         [Parameter(ParameterSetName = 'Bulk')]
         [switch]$Force,
 
@@ -361,6 +367,7 @@ function New-NBDCIMInterface {
             if ($Force -or $PSCmdlet.ShouldProcess($target, 'Create interfaces (bulk)')) {
                 Write-Verbose "Processing $($bulkItems.Count) interfaces in bulk mode with batch size $BatchSize"
 
+                $useBackground = $Background -and -not (Test-NBMinimumVersion -ParameterName 'Background' -MinimumVersion '4.7.0' -BoundParameters $PSBoundParameters -FeatureName 'Background bulk processing (-Background)')
                 $bulkParams = @{
                     URI          = $URI
                     Items        = $bulkItems.ToArray()
@@ -368,6 +375,7 @@ function New-NBDCIMInterface {
                     BatchSize    = $BatchSize
                     ShowProgress = $true
                     ActivityName = 'Creating interfaces'
+                    Background   = $useBackground
                 }
                 $result = Send-NBBulkRequest @bulkParams
 

--- a/Functions/DCIM/Interfaces/New-NBDCIMInterface.ps1
+++ b/Functions/DCIM/Interfaces/New-NBDCIMInterface.ps1
@@ -27,7 +27,11 @@
     Maximum Transmission Unit size (typically 1500 for Ethernet).
 
 .PARAMETER MAC_Address
-    The MAC address of the interface in format XX:XX:XX:XX:XX:XX.
+    The MAC address of the interface in format XX:XX:XX:XX:XX:XX. On NetBox
+    4.7+ this creates the MAC address record and sets it as the interface's
+    primary MAC in a single call (NetBox #18821). To reference an existing
+    MAC address record by its database ID use -Primary_MAC_Address instead.
+    Requires NetBox 4.7.0 or later; ignored with a warning on older servers.
 
 .PARAMETER MGMT_Only
     If true, this interface is used for management traffic only.
@@ -106,7 +110,19 @@
 
 .PARAMETER Primary_MAC_Address
     Numeric ID of the primary MAC address record. Use New-NBDCIMMACAddress to
-    create a MAC address record, then pass its id here.
+    create a MAC address record, then pass its id here. See -MAC_Address to
+    set the MAC by value instead (NetBox 4.7+).
+
+.PARAMETER Channels
+    Number of channels this (breakout) parent interface is channelized into
+    (1-1024). Requires NetBox 4.7.0 or later; ignored with a warning on
+    older servers.
+
+.PARAMETER Channel_Id
+    For a subinterface of type 'channel': the channel number (1-1024) on the
+    parent interface that this subinterface is bound to. Set the parent via
+    -Parent. Requires NetBox 4.7.0 or later; ignored with a warning on older
+    servers.
 
 .PARAMETER Owner
     Numeric ID of the owning user or team.
@@ -243,6 +259,14 @@ function New-NBDCIMInterface {
         [uint64]$Primary_MAC_Address,
 
         [Parameter(ParameterSetName = 'Single')]
+        [ValidateRange(1, 1024)]
+        [uint16]$Channels,
+
+        [Parameter(ParameterSetName = 'Single')]
+        [ValidateRange(1, 1024)]
+        [uint16]$Channel_Id,
+
+        [Parameter(ParameterSetName = 'Single')]
         [uint64]$Owner,
 
         [Parameter(ParameterSetName = 'Single')]
@@ -323,7 +347,16 @@ function New-NBDCIMInterface {
                 }
             }
 
-            $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw'
+            # NetBox 4.7+ only fields (channelized interfaces, writable MAC):
+            # drop them with a warning when connected to an older server.
+            $skipParams = @('Raw')
+            foreach ($p in @('Channels', 'Channel_Id', 'MAC_Address')) {
+                if (Test-NBMinimumVersion -ParameterName $p -MinimumVersion '4.7.0' -BoundParameters $PSBoundParameters -FeatureName "The -$p parameter") {
+                    $skipParams += $p
+                }
+            }
+
+            $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName $skipParams
 
             if ($PSCmdlet.ShouldProcess("Device $Device", "Create interface '$Name'")) {
                 InvokeNetboxRequest -URI $URI -Body $URIComponents.Parameters -Method POST -Raw:$Raw

--- a/Functions/DCIM/Interfaces/Set-NBDCIMInterface.ps1
+++ b/Functions/DCIM/Interfaces/Set-NBDCIMInterface.ps1
@@ -26,7 +26,13 @@
     Maximum Transmission Unit size (typically 1500 for Ethernet).
 
 .PARAMETER MAC_Address
-    The MAC address of the interface in format XX:XX:XX:XX:XX:XX.
+    The MAC address of the interface in format XX:XX:XX:XX:XX:XX. On NetBox
+    4.7+ this creates/updates the MAC address record and sets it as the
+    interface's primary MAC in a single call (NetBox #18821). To point the
+    primary MAC at an existing MAC address record by its database ID use
+    -Primary_MAC_Address instead. Pass '' to clear the primary MAC (sent as
+    JSON null). Requires NetBox 4.7.0 or later; ignored with a warning on
+    older servers.
 
 .PARAMETER MGMT_Only
     If true, this interface is used for management traffic only.
@@ -105,6 +111,17 @@
 
 .PARAMETER Primary_MAC_Address
     Numeric ID of the primary MAC address record. Pass $null to clear.
+    See -MAC_Address to set the MAC by value instead (NetBox 4.7+).
+
+.PARAMETER Channels
+    Number of channels this (breakout) parent interface is channelized into
+    (1-1024). Pass $null to clear. Requires NetBox 4.7.0 or later; ignored
+    with a warning on older servers.
+
+.PARAMETER Channel_Id
+    For a subinterface of type 'channel': the channel number (1-1024) on the
+    parent interface that this subinterface is bound to. Pass $null to clear.
+    Requires NetBox 4.7.0 or later; ignored with a warning on older servers.
 
 .PARAMETER Owner
     Numeric ID of the owning user or team. Pass $null to clear.
@@ -203,12 +220,19 @@ function Set-NBDCIMInterface {
 
         [Nullable[uint64]]$Primary_MAC_Address,
 
+        # No [ValidateRange]: it fires before [Nullable[T]] binding, so
+        # -Channels $null (clear) would throw (see #398). Server enforces 1-1024.
+        [Nullable[uint16]]$Channels,
+
+        [Nullable[uint16]]$Channel_Id,
+
         [Nullable[uint64]]$Owner,
 
         [string]$Changelog_Message,
 
         [uint16]$MTU,
 
+        [AllowEmptyString()]
         [string]$MAC_Address,
 
         [bool]$MGMT_Only,
@@ -296,11 +320,26 @@ function Set-NBDCIMInterface {
             }
         }
 
+        # -MAC_Address '' clears the primary MAC server-side (mac_address is
+        # nullable with minLength 1, so JSON null is the only way to clear it).
+        if ($PSBoundParameters.ContainsKey('MAC_Address') -and $PSBoundParameters['MAC_Address'] -eq '') {
+            $PSBoundParameters['MAC_Address'] = $null
+        }
+
+        # NetBox 4.7+ only fields (channelized interfaces, writable MAC):
+        # drop them with a warning when connected to an older server.
+        $skipParams = @('Id', 'Raw')
+        foreach ($p in @('Channels', 'Channel_Id', 'MAC_Address')) {
+            if (Test-NBMinimumVersion -ParameterName $p -MinimumVersion '4.7.0' -BoundParameters $PSBoundParameters -FeatureName "The -$p parameter") {
+                $skipParams += $p
+            }
+        }
+
         foreach ($InterfaceId in $Id) {
 
             $Segments = [System.Collections.ArrayList]::new(@('dcim', 'interfaces', $InterfaceId))
 
-            $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw'
+            $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName $skipParams
 
             $URI = BuildNewURI -Segments $Segments
 

--- a/Functions/DCIM/InventoryItemRoles/Get-NBDCIMInventoryItemRole.ps1
+++ b/Functions/DCIM/InventoryItemRoles/Get-NBDCIMInventoryItemRole.ps1
@@ -40,7 +40,14 @@
 .PARAMETER Query
     Free-text search across the object (NetBox 'q' parameter).
 
-.PARAMETER Limit
+.PARAMETER Tag
+        Filter by tag slug(s). Several values are combined with AND (object must carry all of them);
+        use Set-NBQueryOption -TagMatch Any (Netbox 4.6.6+) for OR semantics.
+
+    .PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
+    .PARAMETER Limit
     Maximum number of results to return per request (1-1000).
 
 .PARAMETER Offset
@@ -74,6 +81,12 @@ function Get-NBDCIMInventoryItemRole {
         [Parameter(ParameterSetName = 'Query')][string]$Name,
         [Parameter(ParameterSetName = 'Query')][string]$Slug,
         [Parameter(ParameterSetName = 'Query')][string]$Query,
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tag_Id,
+
         [ValidateRange(1, 1000)]
         [uint16]$Limit,
         [ValidateRange(0, [int]::MaxValue)]

--- a/Functions/DCIM/InventoryItems/Get-NBDCIMInventoryItem.ps1
+++ b/Functions/DCIM/InventoryItems/Get-NBDCIMInventoryItem.ps1
@@ -52,7 +52,14 @@
 .PARAMETER Query
     Free-text search across the object (NetBox 'q' parameter).
 
-.PARAMETER Limit
+.PARAMETER Tag
+        Filter by tag slug(s). Several values are combined with AND (object must carry all of them);
+        use Set-NBQueryOption -TagMatch Any (Netbox 4.6.6+) for OR semantics.
+
+    .PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
+    .PARAMETER Limit
     Maximum number of results to return per request (1-1000).
 
 .PARAMETER Offset
@@ -90,6 +97,12 @@ function Get-NBDCIMInventoryItem {
         [Parameter(ParameterSetName = 'Query')][string]$Serial,
         [Parameter(ParameterSetName = 'Query')][string]$Asset_Tag,
         [Parameter(ParameterSetName = 'Query')][string]$Query,
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tag_Id,
+
         [ValidateRange(1, 1000)]
         [uint16]$Limit,
         [ValidateRange(0, [int]::MaxValue)]

--- a/Functions/DCIM/Locations/Get-NBDCIMLocation.ps1
+++ b/Functions/DCIM/Locations/Get-NBDCIMLocation.ps1
@@ -34,6 +34,13 @@ function Get-NBDCIMLocation {
     .PARAMETER Tenant_Id
         Filter by tenant ID
 
+    .PARAMETER Tag
+        Filter by tag slug(s). Several values are combined with AND (object must carry all of them);
+        use Set-NBQueryOption -TagMatch Any (Netbox 4.6.6+) for OR semantics.
+
+    .PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
     .PARAMETER Limit
         Limit the number of results
 
@@ -125,6 +132,12 @@ function Get-NBDCIMLocation {
 
         [Parameter(ParameterSetName = 'Query')]
         [uint64]$Tenant_Id,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tag_Id,
 
         [ValidateRange(1, 1000)]
         [uint16]$Limit,

--- a/Functions/DCIM/MACAddresses/Get-NBDCIMMACAddress.ps1
+++ b/Functions/DCIM/MACAddresses/Get-NBDCIMMACAddress.ps1
@@ -49,7 +49,14 @@
 .PARAMETER Query
     Free-text search across the object (NetBox 'q' parameter).
 
-.PARAMETER Limit
+.PARAMETER Tag
+        Filter by tag slug(s). Several values are combined with AND (object must carry all of them);
+        use Set-NBQueryOption -TagMatch Any (Netbox 4.6.6+) for OR semantics.
+
+    .PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
+    .PARAMETER Limit
     Maximum number of results to return per request (1-1000).
 
 .PARAMETER Offset
@@ -86,6 +93,12 @@ function Get-NBDCIMMACAddress {
         [Parameter(ParameterSetName = 'Query')][uint64]$Device_Id,
         [Parameter(ParameterSetName = 'Query')][uint64]$Virtual_Machine_Id,
         [Parameter(ParameterSetName = 'Query')][string]$Query,
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tag_Id,
+
         [ValidateRange(1, 1000)]
         [uint16]$Limit,
         [ValidateRange(0, [int]::MaxValue)]

--- a/Functions/DCIM/Manufacturers/Get-NBDCIMManufacturer.ps1
+++ b/Functions/DCIM/Manufacturers/Get-NBDCIMManufacturer.ps1
@@ -18,6 +18,13 @@ function Get-NBDCIMManufacturer {
     .PARAMETER Query
         A general search query
 
+    .PARAMETER Tag
+        Filter by tag slug(s). Several values are combined with AND (object must carry all of them);
+        use Set-NBQueryOption -TagMatch Any (Netbox 4.6.6+) for OR semantics.
+
+    .PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
     .PARAMETER Limit
         Limit the number of results
 
@@ -88,6 +95,12 @@ function Get-NBDCIMManufacturer {
 
         [Parameter(ParameterSetName = 'Query')]
         [string]$Query,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tag_Id,
 
         [ValidateRange(1, 1000)]
         [uint16]$Limit,

--- a/Functions/DCIM/ModuleBayTemplates/New-NBDCIMModuleBayTemplate.ps1
+++ b/Functions/DCIM/ModuleBayTemplates/New-NBDCIMModuleBayTemplate.ps1
@@ -27,6 +27,11 @@
 .PARAMETER Tags
     One or more tags to assign to this object (tag names or IDs).
 
+.PARAMETER Module_Bay_Types
+    One or more module bay type database IDs describing which kinds of modules
+    bays created from this template accept (NetBox 4.7+). Ignored with a warning
+    on older versions.
+
 .EXAMPLE
     New-NBDCIMModuleBayTemplate
 
@@ -50,12 +55,19 @@ function New-NBDCIMModuleBayTemplate {
 
         [object[]]$Tags,
 
+        [uint64[]]$Module_Bay_Types,
+
         [switch]$Raw
     )
     process {
         Write-Verbose "Creating DCIM Module Bay Template"
         $Segments = [System.Collections.ArrayList]::new(@('dcim','module-bay-templates'))
-        $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw'
+        # Module_Bay_Types only exists on NetBox 4.7+; drop it (with a warning) on older versions
+        $skipParams = @('Raw')
+        if (Test-NBMinimumVersion -ParameterName 'Module_Bay_Types' -MinimumVersion '4.7.0' -BoundParameters $PSBoundParameters -FeatureName 'Module bay types') {
+            $skipParams += 'Module_Bay_Types'
+        }
+        $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName $skipParams
         if ($PSCmdlet.ShouldProcess($Name, 'Create module bay template')) {
             InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments) -Method POST -Body $URIComponents.Parameters -Raw:$Raw
         }

--- a/Functions/DCIM/ModuleBayTemplates/Set-NBDCIMModuleBayTemplate.ps1
+++ b/Functions/DCIM/ModuleBayTemplates/Set-NBDCIMModuleBayTemplate.ps1
@@ -30,6 +30,11 @@
 .PARAMETER Tags
     One or more tags to assign to this object (tag names or IDs).
 
+.PARAMETER Module_Bay_Types
+    One or more module bay type database IDs describing which kinds of modules
+    bays created from this template accept (NetBox 4.7+). Pass an empty array
+    (@()) to clear the assignment. Ignored with a warning on older versions.
+
 .EXAMPLE
     Set-NBDCIMModuleBayTemplate
 
@@ -54,12 +59,19 @@ function Set-NBDCIMModuleBayTemplate {
 
         [object[]]$Tags,
 
+        [uint64[]]$Module_Bay_Types,
+
         [switch]$Raw
     )
     process {
         Write-Verbose "Updating DCIM Module Bay Template"
         $Segments = [System.Collections.ArrayList]::new(@('dcim','module-bay-templates',$Id))
-        $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id','Raw'
+        # Module_Bay_Types only exists on NetBox 4.7+; drop it (with a warning) on older versions
+        $skipParams = @('Id', 'Raw')
+        if (Test-NBMinimumVersion -ParameterName 'Module_Bay_Types' -MinimumVersion '4.7.0' -BoundParameters $PSBoundParameters -FeatureName 'Module bay types') {
+            $skipParams += 'Module_Bay_Types'
+        }
+        $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName $skipParams
         if ($PSCmdlet.ShouldProcess($Id, 'Update module bay template')) {
             InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments) -Method PATCH -Body $URIComponents.Parameters -Raw:$Raw
         }

--- a/Functions/DCIM/ModuleBayTypes/Get-NBDCIMModuleBayType.ps1
+++ b/Functions/DCIM/ModuleBayTypes/Get-NBDCIMModuleBayType.ps1
@@ -68,6 +68,9 @@
 
 .PARAMETER Tag
     Filter by tag slug. Accepts multiple values.
+.PARAMETER Tag_Id
+    Filter by tag ID(s); combines like -Tag.
+
 
 .PARAMETER Query
     Free-text search across the object (NetBox 'q' parameter).
@@ -122,6 +125,7 @@ function Get-NBDCIMModuleBayType {
         [Parameter(ParameterSetName = 'Query')][string[]]$Description,
         [Parameter(ParameterSetName = 'Query')][uint64[]]$Owner_Id,
         [Parameter(ParameterSetName = 'Query')][string[]]$Tag,
+        [Parameter(ParameterSetName = 'Query')][uint64[]]$Tag_Id,
         [Parameter(ParameterSetName = 'Query')][string]$Query,
         [ValidateRange(1, 1000)]
         [uint16]$Limit,

--- a/Functions/DCIM/ModuleBayTypes/Get-NBDCIMModuleBayType.ps1
+++ b/Functions/DCIM/ModuleBayTypes/Get-NBDCIMModuleBayType.ps1
@@ -1,0 +1,151 @@
+<#
+.SYNOPSIS
+    Retrieves Module Bay Type objects from Netbox DCIM module.
+
+.DESCRIPTION
+    Retrieves Module Bay Type objects from Netbox DCIM module.
+    A module bay type describes which kinds of modules a module bay accepts
+    (NetBox 4.7+). Module bays, module bay templates and module types reference
+    one or more module bay types.
+
+.PARAMETER Raw
+    Return the raw API response instead of the results array.
+
+.PARAMETER All
+    Automatically fetch all pages of results. Uses the API's pagination
+    to retrieve all items across multiple requests.
+
+.PARAMETER PageSize
+    Number of items per page when using -All. Default: 100.
+    Range: 1-1000.
+
+.PARAMETER Brief
+    Return a minimal representation of objects (id, url, display, name only).
+    Reduces response size by ~90%. Ideal for dropdowns and reference lists.
+
+.PARAMETER Fields
+    Specify which fields to include in the response.
+    Supports nested field selection (e.g., 'manufacturer.name').
+
+.PARAMETER Omit
+    Specify which fields to exclude from the response.
+    Requires Netbox 4.5.0 or later.
+
+.PARAMETER Id
+    One or more database IDs to retrieve.
+
+.PARAMETER Name
+    Filter by name. Accepts multiple values.
+
+.PARAMETER Slug
+    Filter by URL slug. Accepts multiple values.
+
+.PARAMETER Color
+    Filter by color (6-digit hex code, e.g. 'ff0000'). Accepts multiple values.
+
+.PARAMETER Manufacturer_Id
+    Filter by manufacturer database ID. Accepts multiple values.
+
+.PARAMETER Manufacturer
+    Filter by manufacturer slug. Accepts multiple values.
+
+.PARAMETER Module_Bay_Id
+    Filter by module bay database ID (module bay types assigned to that bay).
+    Accepts multiple values.
+
+.PARAMETER Module_Bay_Template_Id
+    Filter by module bay template database ID. Accepts multiple values.
+
+.PARAMETER Module_Type_Id
+    Filter by module type database ID (module bay types accepted by that module type).
+    Accepts multiple values.
+
+.PARAMETER Description
+    Filter by description. Accepts multiple values.
+
+.PARAMETER Owner_Id
+    Filter by owner database ID. Accepts multiple values.
+
+.PARAMETER Tag
+    Filter by tag slug. Accepts multiple values.
+
+.PARAMETER Query
+    Free-text search across the object (NetBox 'q' parameter).
+
+.PARAMETER Limit
+    Maximum number of results to return per request (1-1000).
+
+.PARAMETER Offset
+    Number of results to skip (pagination offset).
+
+.EXAMPLE
+    Get-NBDCIMModuleBayType
+
+    Retrieves all module bay types.
+
+.EXAMPLE
+    Get-NBDCIMModuleBayType -Module_Type_Id 12
+
+    Retrieves the module bay types accepted by module type 12.
+
+.NOTES
+    AddedInVersion: v4.7.1.0
+    Requires NetBox 4.7.0 or later (the /api/dcim/module-bay-types/ endpoint).
+    The -Brief, -Fields, and -Omit parameters are mutually exclusive.
+.LINK
+    https://netbox.readthedocs.io/en/stable/rest-api/overview/
+#>
+function Get-NBDCIMModuleBayType {
+    [CmdletBinding(DefaultParameterSetName = 'Query')]
+    [OutputType([PSCustomObject])]
+    param(
+        [switch]$All,
+
+        [ValidateRange(1, 1000)]
+        [int]$PageSize = 100,
+
+        [switch]$Brief,
+
+        [string[]]$Fields,
+
+        [string[]]$Omit,
+
+        [Parameter(ParameterSetName = 'ByID', ValueFromPipelineByPropertyName = $true)][uint64[]]$Id,
+        [Parameter(ParameterSetName = 'Query')][string[]]$Name,
+        [Parameter(ParameterSetName = 'Query')][string[]]$Slug,
+        [Parameter(ParameterSetName = 'Query')][string[]]$Color,
+        [Parameter(ParameterSetName = 'Query')][uint64[]]$Manufacturer_Id,
+        [Parameter(ParameterSetName = 'Query')][string[]]$Manufacturer,
+        [Parameter(ParameterSetName = 'Query')][uint64[]]$Module_Bay_Id,
+        [Parameter(ParameterSetName = 'Query')][uint64[]]$Module_Bay_Template_Id,
+        [Parameter(ParameterSetName = 'Query')][uint64[]]$Module_Type_Id,
+        [Parameter(ParameterSetName = 'Query')][string[]]$Description,
+        [Parameter(ParameterSetName = 'Query')][uint64[]]$Owner_Id,
+        [Parameter(ParameterSetName = 'Query')][string[]]$Tag,
+        [Parameter(ParameterSetName = 'Query')][string]$Query,
+        [ValidateRange(1, 1000)]
+        [uint16]$Limit,
+        [uint32]$Offset,
+        [switch]$Raw
+    )
+    process {
+        AssertNBMutualExclusiveParam `
+            -BoundParameters $PSBoundParameters `
+            -Parameters 'Brief', 'Fields', 'Omit'
+        Write-Verbose "Retrieving DCIM Module Bay Type"
+        switch ($PSCmdlet.ParameterSetName) {
+            'ByID' {
+                foreach ($i in $Id) {
+                    $Segments = [System.Collections.ArrayList]::new(@('dcim', 'module-bay-types', $i))
+                    $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw', 'All', 'PageSize'
+                    InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters) -Raw:$Raw
+                }
+            }
+            default {
+                $Segments = [System.Collections.ArrayList]::new(@('dcim', 'module-bay-types'))
+                $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'All', 'PageSize'
+                InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters) -Raw:$Raw -All:$All -PageSize $PageSize
+            }
+        }
+    }
+}

--- a/Functions/DCIM/ModuleBayTypes/New-NBDCIMModuleBayType.ps1
+++ b/Functions/DCIM/ModuleBayTypes/New-NBDCIMModuleBayType.ps1
@@ -1,0 +1,90 @@
+<#
+.SYNOPSIS
+    Creates a new Module Bay Type in Netbox DCIM module.
+
+.DESCRIPTION
+    Creates a new Module Bay Type in Netbox DCIM module (NetBox 4.7+).
+    A module bay type describes which kinds of modules a module bay accepts.
+    Assign it to module bays, module bay templates and module types via their
+    -Module_Bay_Types parameter.
+
+.PARAMETER Raw
+    Return the raw API response instead of the results array.
+
+.PARAMETER Name
+    Name of the module bay type.
+
+.PARAMETER Slug
+    URL-friendly unique identifier (slug). Derived from -Name when omitted
+    (whitespace replaced by '-', lowercased).
+
+.PARAMETER Manufacturer
+    Manufacturer assigned to this object (database ID).
+
+.PARAMETER Color
+    Color as a 6-digit hex code (RRGGBB), e.g. 'ff0000'.
+
+.PARAMETER Description
+    Brief description.
+
+.PARAMETER Owner
+    Owner assigned to this object (database ID).
+
+.PARAMETER Comments
+    Detailed comments (Markdown is supported).
+
+.PARAMETER Tags
+    One or more tags to assign to this object (tag names or IDs).
+
+.PARAMETER Custom_Fields
+    Hashtable of custom field values to set (cf_<name>).
+
+.EXAMPLE
+    New-NBDCIMModuleBayType -Name 'SFP Cage' -Color '00ff00'
+
+    Creates a module bay type named 'SFP Cage' with slug 'sfp-cage'.
+
+.EXAMPLE
+    New-NBDCIMModuleBayType -Name 'Line Card Slot' -Slug 'lc-slot' -Manufacturer 3
+
+    Creates a manufacturer-specific module bay type with an explicit slug.
+
+.LINK
+    https://netbox.readthedocs.io/en/stable/rest-api/overview/
+.NOTES
+    AddedInVersion: v4.7.1.0
+    Requires NetBox 4.7.0 or later.
+#>
+function New-NBDCIMModuleBayType {
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Low')]
+    [OutputType([PSCustomObject])]
+    param(
+        [Parameter(Mandatory = $true)][string]$Name,
+        [string]$Slug,
+        [uint64]$Manufacturer,
+        [ValidatePattern('^[0-9a-fA-F]{6}$')]
+        [string]$Color,
+        [string]$Description,
+        [uint64]$Owner,
+        [string]$Comments,
+        [object[]]$Tags,
+        [hashtable]$Custom_Fields,
+        [switch]$Raw
+    )
+    process {
+        Write-Verbose "Creating DCIM Module Bay Type"
+        # Auto-generate slug from name if not provided (NetBox REST does not auto-slug)
+        if (-not $PSBoundParameters.ContainsKey('Slug')) {
+            $PSBoundParameters['Slug'] = ($Name -replace '\s+', '-').ToLower()
+        }
+        # NetBox validates color against ^[0-9a-f]{6}$ (lowercase only)
+        if ($PSBoundParameters.ContainsKey('Color')) {
+            $PSBoundParameters['Color'] = $Color.ToLower()
+        }
+        $Segments = [System.Collections.ArrayList]::new(@('dcim', 'module-bay-types'))
+        $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw'
+        if ($PSCmdlet.ShouldProcess($Name, 'Create module bay type')) {
+            InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments) -Method POST -Body $URIComponents.Parameters -Raw:$Raw
+        }
+    }
+}

--- a/Functions/DCIM/ModuleBayTypes/Remove-NBDCIMModuleBayType.ps1
+++ b/Functions/DCIM/ModuleBayTypes/Remove-NBDCIMModuleBayType.ps1
@@ -1,0 +1,44 @@
+<#
+.SYNOPSIS
+    Removes a Module Bay Type from Netbox DCIM module.
+
+.DESCRIPTION
+    Removes a Module Bay Type from Netbox DCIM module (NetBox 4.7+).
+    Supports pipeline input for Id parameter.
+
+.PARAMETER Raw
+    Return the raw API response instead of the results array.
+
+.PARAMETER Id
+    Database ID of the object to delete.
+
+.EXAMPLE
+    Remove-NBDCIMModuleBayType -Id 4
+
+    Deletes module bay type 4.
+
+.EXAMPLE
+    Get-NBDCIMModuleBayType -Name 'SFP Cage' | Remove-NBDCIMModuleBayType -Confirm:$false
+
+    Deletes the module bay type named 'SFP Cage' via the pipeline.
+
+.LINK
+    https://netbox.readthedocs.io/en/stable/rest-api/overview/
+.NOTES
+    AddedInVersion: v4.7.1.0
+    Requires NetBox 4.7.0 or later.
+#>
+function Remove-NBDCIMModuleBayType {
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'High')]
+    [OutputType([void])]
+    param(
+        [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)][uint64]$Id,
+        [switch]$Raw
+    )
+    process {
+        Write-Verbose "Removing DCIM Module Bay Type"
+        if ($PSCmdlet.ShouldProcess($Id, 'Delete module bay type')) {
+            InvokeNetboxRequest -URI (BuildNewURI -Segments @('dcim', 'module-bay-types', $Id)) -Method DELETE -Raw:$Raw
+        }
+    }
+}

--- a/Functions/DCIM/ModuleBayTypes/Set-NBDCIMModuleBayType.ps1
+++ b/Functions/DCIM/ModuleBayTypes/Set-NBDCIMModuleBayType.ps1
@@ -1,0 +1,88 @@
+<#
+.SYNOPSIS
+    Updates an existing Module Bay Type in Netbox DCIM module.
+
+.DESCRIPTION
+    Updates an existing Module Bay Type in Netbox DCIM module (NetBox 4.7+).
+    Supports pipeline input for Id parameter.
+
+.PARAMETER Raw
+    Return the raw API response instead of the results array.
+
+.PARAMETER Id
+    Database ID of the object to update.
+
+.PARAMETER Name
+    Name of the module bay type.
+
+.PARAMETER Slug
+    URL-friendly unique identifier (slug).
+
+.PARAMETER Manufacturer
+    Manufacturer assigned to this object (database ID). Pass $null to clear.
+
+.PARAMETER Color
+    Color as a 6-digit hex code (RRGGBB), e.g. 'ff0000'. Pass '' to clear.
+
+.PARAMETER Description
+    Brief description.
+
+.PARAMETER Owner
+    Owner assigned to this object (database ID).
+
+.PARAMETER Comments
+    Detailed comments (Markdown is supported).
+
+.PARAMETER Tags
+    One or more tags to assign to this object (tag names or IDs).
+
+.PARAMETER Custom_Fields
+    Hashtable of custom field values to set (cf_<name>).
+
+.EXAMPLE
+    Set-NBDCIMModuleBayType -Id 4 -Color 'ff0000' -Description 'Hot-swappable'
+
+    Updates the color and description of module bay type 4.
+
+.EXAMPLE
+    Set-NBDCIMModuleBayType -Id 4 -Manufacturer $null
+
+    Clears the manufacturer assignment of module bay type 4.
+
+.LINK
+    https://netbox.readthedocs.io/en/stable/rest-api/overview/
+.NOTES
+    AddedInVersion: v4.7.1.0
+    Requires NetBox 4.7.0 or later.
+#>
+function Set-NBDCIMModuleBayType {
+    [CmdletBinding(SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
+    [OutputType([PSCustomObject])]
+    param(
+        [Parameter(Mandatory = $true, ValueFromPipelineByPropertyName = $true)][uint64]$Id,
+        [string]$Name,
+        [string]$Slug,
+        [Nullable[uint64]]$Manufacturer,
+        [AllowEmptyString()]
+        [ValidatePattern('^([0-9a-fA-F]{6})?$')]
+        [string]$Color,
+        [string]$Description,
+        [uint64]$Owner,
+        [string]$Comments,
+        [object[]]$Tags,
+        [hashtable]$Custom_Fields,
+        [switch]$Raw
+    )
+    process {
+        Write-Verbose "Updating DCIM Module Bay Type"
+        # NetBox validates color against ^[0-9a-f]{6}$ (lowercase only); '' clears it
+        if ($PSBoundParameters.ContainsKey('Color')) {
+            $PSBoundParameters['Color'] = $Color.ToLower()
+        }
+        $Segments = [System.Collections.ArrayList]::new(@('dcim', 'module-bay-types', $Id))
+        $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw'
+        if ($PSCmdlet.ShouldProcess($Id, 'Update module bay type')) {
+            InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments) -Method PATCH -Body $URIComponents.Parameters -Raw:$Raw
+        }
+    }
+}

--- a/Functions/DCIM/ModuleBays/Get-NBDCIMModuleBay.ps1
+++ b/Functions/DCIM/ModuleBays/Get-NBDCIMModuleBay.ps1
@@ -40,7 +40,14 @@
 .PARAMETER Query
     Free-text search across the object (NetBox 'q' parameter).
 
-.PARAMETER Limit
+.PARAMETER Tag
+        Filter by tag slug(s). Several values are combined with AND (object must carry all of them);
+        use Set-NBQueryOption -TagMatch Any (Netbox 4.6.6+) for OR semantics.
+
+    .PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
+    .PARAMETER Limit
     Maximum number of results to return per request (1-1000).
 
 .PARAMETER Offset
@@ -74,6 +81,12 @@ function Get-NBDCIMModuleBay {
         [Parameter(ParameterSetName = 'Query')][string]$Name,
         [Parameter(ParameterSetName = 'Query')][uint64]$Device_Id,
         [Parameter(ParameterSetName = 'Query')][string]$Query,
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tag_Id,
+
         [ValidateRange(1, 1000)]
         [uint16]$Limit,
         [ValidateRange(0, [int]::MaxValue)]

--- a/Functions/DCIM/ModuleBays/New-NBDCIMModuleBay.ps1
+++ b/Functions/DCIM/ModuleBays/New-NBDCIMModuleBay.ps1
@@ -33,6 +33,10 @@
 .PARAMETER Custom_Fields
     Hashtable of custom field values to set (cf_<name>).
 
+.PARAMETER Module_Bay_Types
+    One or more module bay type database IDs describing which kinds of modules
+    this bay accepts (NetBox 4.7+). Ignored with a warning on older versions.
+
 .EXAMPLE
     New-NBDCIMModuleBay
 
@@ -56,12 +60,18 @@ function New-NBDCIMModuleBay {
         [string]$Description,
         [string[]]$Tags,
         [hashtable]$Custom_Fields,
+        [uint64[]]$Module_Bay_Types,
         [switch]$Raw
     )
     process {
         Write-Verbose "Creating DCIM Module Bay"
         $Segments = [System.Collections.ArrayList]::new(@('dcim','module-bays'))
-        $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw'
+        # Module_Bay_Types only exists on NetBox 4.7+; drop it (with a warning) on older versions
+        $skipParams = @('Raw')
+        if (Test-NBMinimumVersion -ParameterName 'Module_Bay_Types' -MinimumVersion '4.7.0' -BoundParameters $PSBoundParameters -FeatureName 'Module bay types') {
+            $skipParams += 'Module_Bay_Types'
+        }
+        $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName $skipParams
         if ($PSCmdlet.ShouldProcess($Name, 'Create module bay')) {
             InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments) -Method POST -Body $URIComponents.Parameters -Raw:$Raw
         }

--- a/Functions/DCIM/ModuleBays/Set-NBDCIMModuleBay.ps1
+++ b/Functions/DCIM/ModuleBays/Set-NBDCIMModuleBay.ps1
@@ -36,6 +36,11 @@
 .PARAMETER Custom_Fields
     Hashtable of custom field values to set (cf_<name>).
 
+.PARAMETER Module_Bay_Types
+    One or more module bay type database IDs describing which kinds of modules
+    this bay accepts (NetBox 4.7+). Pass an empty array (@()) to clear the
+    assignment. Ignored with a warning on older versions.
+
 .EXAMPLE
     Set-NBDCIMModuleBay
 
@@ -60,12 +65,18 @@ function Set-NBDCIMModuleBay {
         [string]$Description,
         [string[]]$Tags,
         [hashtable]$Custom_Fields,
+        [uint64[]]$Module_Bay_Types,
         [switch]$Raw
     )
     process {
         Write-Verbose "Updating DCIM Module Bay"
         $Segments = [System.Collections.ArrayList]::new(@('dcim','module-bays',$Id))
-        $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id','Raw'
+        # Module_Bay_Types only exists on NetBox 4.7+; drop it (with a warning) on older versions
+        $skipParams = @('Id', 'Raw')
+        if (Test-NBMinimumVersion -ParameterName 'Module_Bay_Types' -MinimumVersion '4.7.0' -BoundParameters $PSBoundParameters -FeatureName 'Module bay types') {
+            $skipParams += 'Module_Bay_Types'
+        }
+        $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName $skipParams
         if ($PSCmdlet.ShouldProcess($Id, 'Update module bay')) {
             InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments) -Method PATCH -Body $URIComponents.Parameters -Raw:$Raw
         }

--- a/Functions/DCIM/ModuleTypeProfiles/Get-NBDCIMModuleTypeProfile.ps1
+++ b/Functions/DCIM/ModuleTypeProfiles/Get-NBDCIMModuleTypeProfile.ps1
@@ -37,7 +37,14 @@
 .PARAMETER Query
     Free-text search across the object (NetBox 'q' parameter).
 
-.PARAMETER Limit
+.PARAMETER Tag
+        Filter by tag slug(s). Several values are combined with AND (object must carry all of them);
+        use Set-NBQueryOption -TagMatch Any (Netbox 4.6.6+) for OR semantics.
+
+    .PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
+    .PARAMETER Limit
     Maximum number of results to return per request (1-1000).
 
 .PARAMETER Offset
@@ -70,6 +77,12 @@ function Get-NBDCIMModuleTypeProfile {
         [Parameter(ParameterSetName = 'ByID', ValueFromPipelineByPropertyName = $true)][uint64[]]$Id,
         [Parameter(ParameterSetName = 'Query')][string]$Name,
         [Parameter(ParameterSetName = 'Query')][string]$Query,
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tag_Id,
+
         [ValidateRange(1, 1000)]
         [uint16]$Limit,
         [ValidateRange(0, [int]::MaxValue)]

--- a/Functions/DCIM/ModuleTypes/Get-NBDCIMModuleType.ps1
+++ b/Functions/DCIM/ModuleTypes/Get-NBDCIMModuleType.ps1
@@ -1,4 +1,4 @@
-﻿<#
+<#
 .SYNOPSIS
     Retrieves Module Types objects from Netbox DCIM module.
 

--- a/Functions/DCIM/ModuleTypes/Get-NBDCIMModuleType.ps1
+++ b/Functions/DCIM/ModuleTypes/Get-NBDCIMModuleType.ps1
@@ -43,7 +43,14 @@
 .PARAMETER Query
     Free-text search across the object (NetBox 'q' parameter).
 
-.PARAMETER Limit
+.PARAMETER Tag
+        Filter by tag slug(s). Several values are combined with AND (object must carry all of them);
+        use Set-NBQueryOption -TagMatch Any (Netbox 4.6.6+) for OR semantics.
+
+    .PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
+    .PARAMETER Limit
     Maximum number of results to return per request (1-1000).
 
 .PARAMETER Offset
@@ -78,6 +85,12 @@ function Get-NBDCIMModuleType {
         [Parameter(ParameterSetName = 'Query')][uint64]$Manufacturer_Id,
         [Parameter(ParameterSetName = 'Query')][string]$Part_Number,
         [Parameter(ParameterSetName = 'Query')][string]$Query,
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tag_Id,
+
         [ValidateRange(1, 1000)]
         [uint16]$Limit,
         [ValidateRange(0, [int]::MaxValue)]

--- a/Functions/DCIM/ModuleTypes/Get-NBDCIMModuleType.ps1
+++ b/Functions/DCIM/ModuleTypes/Get-NBDCIMModuleType.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Retrieves Module Types objects from Netbox DCIM module.
 
@@ -50,7 +50,7 @@
     .PARAMETER Tag_Id
         Filter by tag ID(s); combines like -Tag.
 
-    
+
 
 .PARAMETER Cooling_Method
     Filter by cooling method: 'air', 'liquid', 'hybrid' or 'immersion'

--- a/Functions/DCIM/ModuleTypes/Get-NBDCIMModuleType.ps1
+++ b/Functions/DCIM/ModuleTypes/Get-NBDCIMModuleType.ps1
@@ -43,6 +43,15 @@
 .PARAMETER Query
     Free-text search across the object (NetBox 'q' parameter).
 
+.PARAMETER Cooling_Method
+    Filter by cooling method: 'air', 'liquid', 'hybrid' or 'immersion'
+    (scalar filter). Requires NetBox 4.7.0 or later; ignored with a warning
+    on older servers.
+
+.PARAMETER End_Of_Life
+    Filter by end-of-life date (one or more dates, sent as yyyy-MM-dd).
+    Requires NetBox 4.7.0 or later; ignored with a warning on older servers.
+
 .PARAMETER Limit
     Maximum number of results to return per request (1-1000).
 
@@ -78,6 +87,10 @@ function Get-NBDCIMModuleType {
         [Parameter(ParameterSetName = 'Query')][uint64]$Manufacturer_Id,
         [Parameter(ParameterSetName = 'Query')][string]$Part_Number,
         [Parameter(ParameterSetName = 'Query')][string]$Query,
+        [Parameter(ParameterSetName = 'Query')]
+        [ValidateSet('air', 'liquid', 'hybrid', 'immersion', IgnoreCase = $true)]
+        [string]$Cooling_Method,
+        [Parameter(ParameterSetName = 'Query')][datetime[]]$End_Of_Life,
         [ValidateRange(1, 1000)]
         [uint16]$Limit,
         [ValidateRange(0, [int]::MaxValue)]
@@ -93,7 +106,20 @@ function Get-NBDCIMModuleType {
             'ByID' { foreach ($i in $Id) { InvokeNetboxRequest -URI (BuildNewURI -Segments @('dcim','module-types',$i)) -Raw:$Raw } }
             default {
                 $Segments = [System.Collections.ArrayList]::new(@('dcim','module-types'))
-                $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'All', 'PageSize'
+
+                if ($PSBoundParameters.ContainsKey('End_Of_Life')) {
+                    $PSBoundParameters['End_Of_Life'] = @($End_Of_Life | ForEach-Object { $_.ToString('yyyy-MM-dd') })
+                }
+
+                # NetBox 4.7+ only fields: drop them with a warning on older servers.
+                $skipParams = @('Raw', 'All', 'PageSize')
+                foreach ($p in @('Cooling_Method', 'End_Of_Life')) {
+                    if (Test-NBMinimumVersion -ParameterName $p -MinimumVersion '4.7.0' -BoundParameters $PSBoundParameters -FeatureName "The -$p filter") {
+                        $skipParams += $p
+                    }
+                }
+
+                $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName $skipParams
                 InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters) -Raw:$Raw -All:$All -PageSize $PageSize
             }
         }

--- a/Functions/DCIM/ModuleTypes/New-NBDCIMModuleType.ps1
+++ b/Functions/DCIM/ModuleTypes/New-NBDCIMModuleType.ps1
@@ -36,6 +36,10 @@
 .PARAMETER Custom_Fields
     Hashtable of custom field values to set (cf_<name>).
 
+.PARAMETER Module_Bay_Types
+    One or more module bay type database IDs this module type can be installed
+    into (NetBox 4.7+). Ignored with a warning on older versions.
+
 .EXAMPLE
     New-NBDCIMModuleType
 
@@ -60,12 +64,18 @@ function New-NBDCIMModuleType {
         [string]$Comments,
         [string[]]$Tags,
         [hashtable]$Custom_Fields,
+        [uint64[]]$Module_Bay_Types,
         [switch]$Raw
     )
     process {
         Write-Verbose "Creating DCIM Module Type"
         $Segments = [System.Collections.ArrayList]::new(@('dcim','module-types'))
-        $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw'
+        # Module_Bay_Types only exists on NetBox 4.7+; drop it (with a warning) on older versions
+        $skipParams = @('Raw')
+        if (Test-NBMinimumVersion -ParameterName 'Module_Bay_Types' -MinimumVersion '4.7.0' -BoundParameters $PSBoundParameters -FeatureName 'Module bay types') {
+            $skipParams += 'Module_Bay_Types'
+        }
+        $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName $skipParams
         if ($PSCmdlet.ShouldProcess($Model, 'Create module type')) {
             InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments) -Method POST -Body $URIComponents.Parameters -Raw:$Raw
         }

--- a/Functions/DCIM/ModuleTypes/New-NBDCIMModuleType.ps1
+++ b/Functions/DCIM/ModuleTypes/New-NBDCIMModuleType.ps1
@@ -30,6 +30,15 @@
 .PARAMETER Comments
     Detailed comments (Markdown is supported).
 
+.PARAMETER Cooling_Method
+    Cooling method. One of: 'air', 'liquid', 'hybrid', 'immersion'.
+    Requires NetBox 4.7.0 or later; ignored with a warning on older servers.
+
+.PARAMETER End_Of_Life
+    Date after which this module type is no longer supported by the manufacturer.
+    Sent as yyyy-MM-dd. Requires NetBox 4.7.0 or later; ignored with a
+    warning on older servers.
+
 .PARAMETER Tags
     One or more tags to assign to this object (tag names or IDs).
 
@@ -58,6 +67,9 @@ function New-NBDCIMModuleType {
         [string]$Weight_Unit,
         [string]$Description,
         [string]$Comments,
+        [ValidateSet('air', 'liquid', 'hybrid', 'immersion', IgnoreCase = $true)]
+        [string]$Cooling_Method,
+        [datetime]$End_Of_Life,
         [string[]]$Tags,
         [hashtable]$Custom_Fields,
         [switch]$Raw
@@ -65,7 +77,21 @@ function New-NBDCIMModuleType {
     process {
         Write-Verbose "Creating DCIM Module Type"
         $Segments = [System.Collections.ArrayList]::new(@('dcim','module-types'))
-        $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw'
+
+        # NetBox DateField wants yyyy-MM-dd, not the ISO datetime ConvertTo-Json emits.
+        if ($PSBoundParameters.ContainsKey('End_Of_Life') -and $null -ne $PSBoundParameters['End_Of_Life']) {
+            $PSBoundParameters['End_Of_Life'] = ([datetime]$PSBoundParameters['End_Of_Life']).ToString('yyyy-MM-dd')
+        }
+
+        # NetBox 4.7+ only fields: drop them with a warning on older servers.
+        $skipParams = @('Raw')
+        foreach ($p in @('Cooling_Method', 'End_Of_Life')) {
+            if (Test-NBMinimumVersion -ParameterName $p -MinimumVersion '4.7.0' -BoundParameters $PSBoundParameters -FeatureName "The -$p parameter") {
+                $skipParams += $p
+            }
+        }
+
+        $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName $skipParams
         if ($PSCmdlet.ShouldProcess($Model, 'Create module type')) {
             InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments) -Method POST -Body $URIComponents.Parameters -Raw:$Raw
         }

--- a/Functions/DCIM/ModuleTypes/Set-NBDCIMModuleType.ps1
+++ b/Functions/DCIM/ModuleTypes/Set-NBDCIMModuleType.ps1
@@ -39,6 +39,11 @@
 .PARAMETER Custom_Fields
     Hashtable of custom field values to set (cf_<name>).
 
+.PARAMETER Module_Bay_Types
+    One or more module bay type database IDs this module type can be installed
+    into (NetBox 4.7+). Pass an empty array (@()) to clear the assignment.
+    Ignored with a warning on older versions.
+
 .EXAMPLE
     Set-NBDCIMModuleType
 
@@ -64,12 +69,18 @@ function Set-NBDCIMModuleType {
         [string]$Comments,
         [string[]]$Tags,
         [hashtable]$Custom_Fields,
+        [uint64[]]$Module_Bay_Types,
         [switch]$Raw
     )
     process {
         Write-Verbose "Updating DCIM Module Type"
         $Segments = [System.Collections.ArrayList]::new(@('dcim','module-types',$Id))
-        $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id','Raw'
+        # Module_Bay_Types only exists on NetBox 4.7+; drop it (with a warning) on older versions
+        $skipParams = @('Id', 'Raw')
+        if (Test-NBMinimumVersion -ParameterName 'Module_Bay_Types' -MinimumVersion '4.7.0' -BoundParameters $PSBoundParameters -FeatureName 'Module bay types') {
+            $skipParams += 'Module_Bay_Types'
+        }
+        $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName $skipParams
         if ($PSCmdlet.ShouldProcess($Id, 'Update module type')) {
             InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments) -Method PATCH -Body $URIComponents.Parameters -Raw:$Raw
         }

--- a/Functions/DCIM/ModuleTypes/Set-NBDCIMModuleType.ps1
+++ b/Functions/DCIM/ModuleTypes/Set-NBDCIMModuleType.ps1
@@ -33,6 +33,16 @@
 .PARAMETER Comments
     Detailed comments (Markdown is supported).
 
+.PARAMETER Cooling_Method
+    Cooling method. One of: 'air', 'liquid', 'hybrid', 'immersion'.
+    Pass '' to clear the field server-side (sent as JSON null).
+    Requires NetBox 4.7.0 or later; ignored with a warning on older servers.
+
+.PARAMETER End_Of_Life
+    Date after which this module type is no longer supported by the manufacturer.
+    Sent as yyyy-MM-dd. Pass $null to clear. Requires NetBox 4.7.0 or later;
+    ignored with a warning on older servers.
+
 .PARAMETER Tags
     One or more tags to assign to this object (tag names or IDs).
 
@@ -62,6 +72,10 @@ function Set-NBDCIMModuleType {
         [string]$Weight_Unit,
         [string]$Description,
         [string]$Comments,
+        [AllowEmptyString()]
+        [ValidateSet('air', 'liquid', 'hybrid', 'immersion', '', IgnoreCase = $true)]
+        [string]$Cooling_Method,
+        [Nullable[datetime]]$End_Of_Life,
         [string[]]$Tags,
         [hashtable]$Custom_Fields,
         [switch]$Raw
@@ -69,7 +83,29 @@ function Set-NBDCIMModuleType {
     process {
         Write-Verbose "Updating DCIM Module Type"
         $Segments = [System.Collections.ArrayList]::new(@('dcim','module-types',$Id))
-        $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id','Raw'
+
+        # Translate '' -> $null for clearable enum params BEFORE BuildURIComponents,
+        # so the PATCH body carries JSON null (NetBox rejects "" for nullable enums).
+        foreach ($p in @('Cooling_Method')) {
+            if ($PSBoundParameters.ContainsKey($p) -and $PSBoundParameters[$p] -eq '') {
+                $PSBoundParameters[$p] = $null
+            }
+        }
+
+        # NetBox DateField wants yyyy-MM-dd, not the ISO datetime ConvertTo-Json emits.
+        if ($PSBoundParameters.ContainsKey('End_Of_Life') -and $null -ne $PSBoundParameters['End_Of_Life']) {
+            $PSBoundParameters['End_Of_Life'] = ([datetime]$PSBoundParameters['End_Of_Life']).ToString('yyyy-MM-dd')
+        }
+
+        # NetBox 4.7+ only fields: drop them with a warning on older servers.
+        $skipParams = @('Id', 'Raw')
+        foreach ($p in @('Cooling_Method', 'End_Of_Life')) {
+            if (Test-NBMinimumVersion -ParameterName $p -MinimumVersion '4.7.0' -BoundParameters $PSBoundParameters -FeatureName "The -$p parameter") {
+                $skipParams += $p
+            }
+        }
+
+        $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName $skipParams
         if ($PSCmdlet.ShouldProcess($Id, 'Update module type')) {
             InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments) -Method PATCH -Body $URIComponents.Parameters -Raw:$Raw
         }

--- a/Functions/DCIM/Modules/Get-NBDCIMModule.ps1
+++ b/Functions/DCIM/Modules/Get-NBDCIMModule.ps1
@@ -52,7 +52,14 @@
 .PARAMETER Query
     Free-text search across the object (NetBox 'q' parameter).
 
-.PARAMETER Limit
+.PARAMETER Tag
+        Filter by tag slug(s). Several values are combined with AND (object must carry all of them);
+        use Set-NBQueryOption -TagMatch Any (Netbox 4.6.6+) for OR semantics.
+
+    .PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
+    .PARAMETER Limit
     Maximum number of results to return per request (1-1000).
 
 .PARAMETER Offset
@@ -90,6 +97,12 @@ function Get-NBDCIMModule {
         [Parameter(ParameterSetName = 'Query')][string]$Asset_Tag,
         [Parameter(ParameterSetName = 'Query')][string]$Status,
         [Parameter(ParameterSetName = 'Query')][string]$Query,
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tag_Id,
+
         [ValidateRange(1, 1000)]
         [uint16]$Limit,
         [ValidateRange(0, [int]::MaxValue)]

--- a/Functions/DCIM/Modules/Set-NBDCIMModule.ps1
+++ b/Functions/DCIM/Modules/Set-NBDCIMModule.ps1
@@ -6,6 +6,12 @@
     Updates an existing DCIM Module in Netbox DCIM module.
     Supports pipeline input for Id parameter where applicable.
 
+    To relocate an installed module (NetBox 4.7+), pass -Module_Bay with the
+    target bay ID; to move it to a bay on another device, pass -Device and
+    -Module_Bay together. The source bay is vacated automatically. NetBox
+    rejects the move (400) when the target bay is already occupied or when the
+    module type is not compatible with the target bay's module bay types.
+
 .PARAMETER Raw
     Return the raw API response instead of the results array.
 
@@ -13,10 +19,12 @@
     Database ID of the object to update.
 
 .PARAMETER Device
-    Device assigned to this object (database ID).
+    Device assigned to this object (database ID). Combine with -Module_Bay to
+    move the module to a bay on a different device.
 
 .PARAMETER Module_Bay
-    Module Bay.
+    Module bay the module is installed in (database ID). Passing a different
+    bay relocates the module into that bay.
 
 .PARAMETER Module_Type
     Module type assigned to this object (database ID).
@@ -43,9 +51,19 @@
     Hashtable of custom field values to set (cf_<name>).
 
 .EXAMPLE
-    Set-NBDCIMModule
+    Set-NBDCIMModule -Id 1 -Serial 'SN12345'
 
-    Updates an existing DCIM Module object.
+    Updates the serial number of module 1.
+
+.EXAMPLE
+    Set-NBDCIMModule -Id 1 -Module_Bay 12
+
+    Moves module 1 into module bay 12 on the same device.
+
+.EXAMPLE
+    Set-NBDCIMModule -Id 1 -Device 7 -Module_Bay 30
+
+    Moves module 1 into module bay 30 on device 7.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/

--- a/Functions/DCIM/Platforms/Get-NBDCIMPlatform.ps1
+++ b/Functions/DCIM/Platforms/Get-NBDCIMPlatform.ps1
@@ -28,7 +28,14 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-.PARAMETER Limit
+.PARAMETER Tag
+        Filter by tag slug(s). Several values are combined with AND (object must carry all of them);
+        use Set-NBQueryOption -TagMatch Any (Netbox 4.6.6+) for OR semantics.
+
+    .PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
+    .PARAMETER Limit
     Maximum number of results to return per request (1-1000).
 
 .PARAMETER Offset
@@ -73,6 +80,12 @@ function Get-NBDCIMPlatform {
         [string[]]$Fields,
 
         [string[]]$Omit,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tag_Id,
 
         [ValidateRange(1, 1000)]
         [uint16]$Limit,

--- a/Functions/DCIM/PowerFeeds/Get-NBDCIMPowerFeed.ps1
+++ b/Functions/DCIM/PowerFeeds/Get-NBDCIMPowerFeed.ps1
@@ -49,7 +49,14 @@
 .PARAMETER Query
     Free-text search across the object (NetBox 'q' parameter).
 
-.PARAMETER Limit
+.PARAMETER Tag
+        Filter by tag slug(s). Several values are combined with AND (object must carry all of them);
+        use Set-NBQueryOption -TagMatch Any (Netbox 4.6.6+) for OR semantics.
+
+    .PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
+    .PARAMETER Limit
     Maximum number of results to return per request (1-1000).
 
 .PARAMETER Offset
@@ -86,6 +93,12 @@ function Get-NBDCIMPowerFeed {
         [Parameter(ParameterSetName = 'Query')][string]$Status,
         [Parameter(ParameterSetName = 'Query')][string]$Type,
         [Parameter(ParameterSetName = 'Query')][string]$Query,
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tag_Id,
+
         [ValidateRange(1, 1000)]
         [uint16]$Limit,
         [ValidateRange(0, [int]::MaxValue)]

--- a/Functions/DCIM/PowerOutlets/Get-NBDCIMPowerOutlet.ps1
+++ b/Functions/DCIM/PowerOutlets/Get-NBDCIMPowerOutlet.ps1
@@ -46,7 +46,14 @@
 .PARAMETER Query
     Free-text search across the object (NetBox 'q' parameter).
 
-.PARAMETER Limit
+.PARAMETER Tag
+        Filter by tag slug(s). Several values are combined with AND (object must carry all of them);
+        use Set-NBQueryOption -TagMatch Any (Netbox 4.6.6+) for OR semantics.
+
+    .PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
+    .PARAMETER Limit
     Maximum number of results to return per request (1-1000).
 
 .PARAMETER Offset
@@ -82,6 +89,12 @@ function Get-NBDCIMPowerOutlet {
         [Parameter(ParameterSetName = 'Query')][uint64]$Module_Id,
         [Parameter(ParameterSetName = 'Query')][string]$Type,
         [Parameter(ParameterSetName = 'Query')][string]$Query,
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tag_Id,
+
         [ValidateRange(1, 1000)]
         [uint16]$Limit,
         [ValidateRange(0, [int]::MaxValue)]

--- a/Functions/DCIM/PowerPanels/Get-NBDCIMPowerPanel.ps1
+++ b/Functions/DCIM/PowerPanels/Get-NBDCIMPowerPanel.ps1
@@ -43,7 +43,14 @@
 .PARAMETER Query
     Free-text search across the object (NetBox 'q' parameter).
 
-.PARAMETER Limit
+.PARAMETER Tag
+        Filter by tag slug(s). Several values are combined with AND (object must carry all of them);
+        use Set-NBQueryOption -TagMatch Any (Netbox 4.6.6+) for OR semantics.
+
+    .PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
+    .PARAMETER Limit
     Maximum number of results to return per request (1-1000).
 
 .PARAMETER Offset
@@ -78,6 +85,12 @@ function Get-NBDCIMPowerPanel {
         [Parameter(ParameterSetName = 'Query')][uint64]$Site_Id,
         [Parameter(ParameterSetName = 'Query')][uint64]$Location_Id,
         [Parameter(ParameterSetName = 'Query')][string]$Query,
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tag_Id,
+
         [ValidateRange(1, 1000)]
         [uint16]$Limit,
         [ValidateRange(0, [int]::MaxValue)]

--- a/Functions/DCIM/PowerPorts/Get-NBDCIMPowerPort.ps1
+++ b/Functions/DCIM/PowerPorts/Get-NBDCIMPowerPort.ps1
@@ -46,7 +46,14 @@
 .PARAMETER Query
     Free-text search across the object (NetBox 'q' parameter).
 
-.PARAMETER Limit
+.PARAMETER Tag
+        Filter by tag slug(s). Several values are combined with AND (object must carry all of them);
+        use Set-NBQueryOption -TagMatch Any (Netbox 4.6.6+) for OR semantics.
+
+    .PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
+    .PARAMETER Limit
     Maximum number of results to return per request (1-1000).
 
 .PARAMETER Offset
@@ -82,6 +89,12 @@ function Get-NBDCIMPowerPort {
         [Parameter(ParameterSetName = 'Query')][uint64]$Module_Id,
         [Parameter(ParameterSetName = 'Query')][string]$Type,
         [Parameter(ParameterSetName = 'Query')][string]$Query,
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tag_Id,
+
         [ValidateRange(1, 1000)]
         [uint16]$Limit,
         [ValidateRange(0, [int]::MaxValue)]

--- a/Functions/DCIM/RackGroups/Get-NBDCIMRackGroup.ps1
+++ b/Functions/DCIM/RackGroups/Get-NBDCIMRackGroup.ps1
@@ -36,7 +36,14 @@
 .PARAMETER PageSize
     Page size to request while -All follows pagination.
 
-.PARAMETER Limit
+.PARAMETER Tag
+        Filter by tag slug(s). Several values are combined with AND (object must carry all of them);
+        use Set-NBQueryOption -TagMatch Any (Netbox 4.6.6+) for OR semantics.
+
+    .PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
+    .PARAMETER Limit
     Maximum number of results to return per request (1-1000).
 
 .PARAMETER Offset
@@ -73,6 +80,12 @@ function Get-NBDCIMRackGroup {
 
         [Parameter(ParameterSetName = 'Query')]
         [string]$Query,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tag_Id,
 
         [ValidateRange(1, 1000)]
         [uint16]$Limit,

--- a/Functions/DCIM/RackReservations/Get-NBDCIMRackReservation.ps1
+++ b/Functions/DCIM/RackReservations/Get-NBDCIMRackReservation.ps1
@@ -46,7 +46,14 @@
 .PARAMETER Query
     Free-text search across the object (NetBox 'q' parameter).
 
-.PARAMETER Limit
+.PARAMETER Tag
+        Filter by tag slug(s). Several values are combined with AND (object must carry all of them);
+        use Set-NBQueryOption -TagMatch Any (Netbox 4.6.6+) for OR semantics.
+
+    .PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
+    .PARAMETER Limit
     Maximum number of results to return per request (1-1000).
 
 .PARAMETER Offset
@@ -82,6 +89,12 @@ function Get-NBDCIMRackReservation {
         [Parameter(ParameterSetName = 'Query')][uint64]$User_Id,
         [Parameter(ParameterSetName = 'Query')][uint64]$Tenant_Id,
         [Parameter(ParameterSetName = 'Query')][string]$Query,
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tag_Id,
+
         [ValidateRange(1, 1000)]
         [uint16]$Limit,
         [ValidateRange(0, [int]::MaxValue)]

--- a/Functions/DCIM/RackRoles/Get-NBDCIMRackRole.ps1
+++ b/Functions/DCIM/RackRoles/Get-NBDCIMRackRole.ps1
@@ -40,7 +40,14 @@
 .PARAMETER Query
     Free-text search across the object (NetBox 'q' parameter).
 
-.PARAMETER Limit
+.PARAMETER Tag
+        Filter by tag slug(s). Several values are combined with AND (object must carry all of them);
+        use Set-NBQueryOption -TagMatch Any (Netbox 4.6.6+) for OR semantics.
+
+    .PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
+    .PARAMETER Limit
     Maximum number of results to return per request (1-1000).
 
 .PARAMETER Offset
@@ -74,6 +81,12 @@ function Get-NBDCIMRackRole {
         [Parameter(ParameterSetName = 'Query')][string]$Name,
         [Parameter(ParameterSetName = 'Query')][string]$Slug,
         [Parameter(ParameterSetName = 'Query')][string]$Query,
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tag_Id,
+
         [ValidateRange(1, 1000)]
         [uint16]$Limit,
         [ValidateRange(0, [int]::MaxValue)]

--- a/Functions/DCIM/RackTypes/Get-NBDCIMRackType.ps1
+++ b/Functions/DCIM/RackTypes/Get-NBDCIMRackType.ps1
@@ -43,6 +43,15 @@
 .PARAMETER Query
     Free-text search across the object (NetBox 'q' parameter).
 
+.PARAMETER Cooling_Capability
+    Filter by cooling capability (one or more of 'air-only', 'hybrid',
+    'liquid-only'). Requires NetBox 4.7.0 or later; ignored with a warning
+    on older servers.
+
+.PARAMETER Cooling_Capacity
+    Filter by cooling capacity in kW (one or more values). Requires NetBox
+    4.7.0 or later; ignored with a warning on older servers.
+
 .PARAMETER Limit
     Maximum number of results to return per request (1-1000).
 
@@ -78,6 +87,10 @@ function Get-NBDCIMRackType {
         [Parameter(ParameterSetName = 'Query')][string]$Slug,
         [Parameter(ParameterSetName = 'Query')][uint64]$Manufacturer_Id,
         [Parameter(ParameterSetName = 'Query')][string]$Query,
+        [Parameter(ParameterSetName = 'Query')]
+        [ValidateSet('air-only', 'hybrid', 'liquid-only', IgnoreCase = $true)]
+        [string[]]$Cooling_Capability,
+        [Parameter(ParameterSetName = 'Query')][decimal[]]$Cooling_Capacity,
         [ValidateRange(1, 1000)]
         [uint16]$Limit,
         [ValidateRange(0, [int]::MaxValue)]
@@ -93,7 +106,16 @@ function Get-NBDCIMRackType {
             'ByID' { foreach ($i in $Id) { InvokeNetboxRequest -URI (BuildNewURI -Segments @('dcim','rack-types',$i)) -Raw:$Raw } }
             default {
                 $Segments = [System.Collections.ArrayList]::new(@('dcim','rack-types'))
-                $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'All', 'PageSize'
+
+                # NetBox 4.7+ only fields: drop them with a warning on older servers.
+                $skipParams = @('Raw', 'All', 'PageSize')
+                foreach ($p in @('Cooling_Capability', 'Cooling_Capacity')) {
+                    if (Test-NBMinimumVersion -ParameterName $p -MinimumVersion '4.7.0' -BoundParameters $PSBoundParameters -FeatureName "The -$p filter") {
+                        $skipParams += $p
+                    }
+                }
+
+                $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName $skipParams
                 InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters) -Raw:$Raw -All:$All -PageSize $PageSize
             }
         }

--- a/Functions/DCIM/RackTypes/Get-NBDCIMRackType.ps1
+++ b/Functions/DCIM/RackTypes/Get-NBDCIMRackType.ps1
@@ -1,4 +1,4 @@
-﻿<#
+<#
 .SYNOPSIS
     Retrieves Rack Types objects from Netbox DCIM module.
 

--- a/Functions/DCIM/RackTypes/Get-NBDCIMRackType.ps1
+++ b/Functions/DCIM/RackTypes/Get-NBDCIMRackType.ps1
@@ -43,7 +43,14 @@
 .PARAMETER Query
     Free-text search across the object (NetBox 'q' parameter).
 
-.PARAMETER Limit
+.PARAMETER Tag
+        Filter by tag slug(s). Several values are combined with AND (object must carry all of them);
+        use Set-NBQueryOption -TagMatch Any (Netbox 4.6.6+) for OR semantics.
+
+    .PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
+    .PARAMETER Limit
     Maximum number of results to return per request (1-1000).
 
 .PARAMETER Offset
@@ -78,6 +85,12 @@ function Get-NBDCIMRackType {
         [Parameter(ParameterSetName = 'Query')][string]$Slug,
         [Parameter(ParameterSetName = 'Query')][uint64]$Manufacturer_Id,
         [Parameter(ParameterSetName = 'Query')][string]$Query,
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tag_Id,
+
         [ValidateRange(1, 1000)]
         [uint16]$Limit,
         [ValidateRange(0, [int]::MaxValue)]

--- a/Functions/DCIM/RackTypes/Get-NBDCIMRackType.ps1
+++ b/Functions/DCIM/RackTypes/Get-NBDCIMRackType.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
     Retrieves Rack Types objects from Netbox DCIM module.
 
@@ -50,7 +50,7 @@
     .PARAMETER Tag_Id
         Filter by tag ID(s); combines like -Tag.
 
-    
+
 
 .PARAMETER Cooling_Capability
     Filter by cooling capability (one or more of 'air-only', 'hybrid',

--- a/Functions/DCIM/RackTypes/New-NBDCIMRackType.ps1
+++ b/Functions/DCIM/RackTypes/New-NBDCIMRackType.ps1
@@ -57,6 +57,14 @@
 .PARAMETER Comments
     Detailed comments (Markdown is supported).
 
+.PARAMETER Cooling_Capability
+    Cooling capability. One of: 'air-only', 'hybrid', 'liquid-only'.
+    Requires NetBox 4.7.0 or later; ignored with a warning on older servers.
+
+.PARAMETER Cooling_Capacity
+    Cooling capacity in kW. Requires NetBox 4.7.0 or later; ignored with a
+    warning on older servers.
+
 .PARAMETER Tags
     One or more tags to assign to this object (tag names or IDs).
 
@@ -94,6 +102,9 @@ function New-NBDCIMRackType {
         [string]$Mounting_Depth,
         [string]$Description,
         [string]$Comments,
+        [ValidateSet('air-only', 'hybrid', 'liquid-only', IgnoreCase = $true)]
+        [string]$Cooling_Capability,
+        [decimal]$Cooling_Capacity,
         [string[]]$Tags,
         [hashtable]$Custom_Fields,
         [switch]$Raw
@@ -101,7 +112,16 @@ function New-NBDCIMRackType {
     process {
         Write-Verbose "Creating DCIM Rack Type"
         $Segments = [System.Collections.ArrayList]::new(@('dcim','rack-types'))
-        $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw'
+
+        # NetBox 4.7+ only fields: drop them with a warning on older servers.
+        $skipParams = @('Raw')
+        foreach ($p in @('Cooling_Capability', 'Cooling_Capacity')) {
+            if (Test-NBMinimumVersion -ParameterName $p -MinimumVersion '4.7.0' -BoundParameters $PSBoundParameters -FeatureName "The -$p parameter") {
+                $skipParams += $p
+            }
+        }
+
+        $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName $skipParams
         if ($PSCmdlet.ShouldProcess($Model, 'Create rack type')) {
             InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments) -Method POST -Body $URIComponents.Parameters -Raw:$Raw
         }

--- a/Functions/DCIM/RackTypes/Set-NBDCIMRackType.ps1
+++ b/Functions/DCIM/RackTypes/Set-NBDCIMRackType.ps1
@@ -60,6 +60,15 @@
 .PARAMETER Comments
     Detailed comments (Markdown is supported).
 
+.PARAMETER Cooling_Capability
+    Cooling capability. One of: 'air-only', 'hybrid', 'liquid-only'.
+    Pass '' to clear the field server-side (sent as JSON null).
+    Requires NetBox 4.7.0 or later; ignored with a warning on older servers.
+
+.PARAMETER Cooling_Capacity
+    Cooling capacity in kW. Pass $null to clear. Requires NetBox 4.7.0 or
+    later; ignored with a warning on older servers.
+
 .PARAMETER Tags
     One or more tags to assign to this object (tag names or IDs).
 
@@ -98,6 +107,10 @@ function Set-NBDCIMRackType {
         [string]$Mounting_Depth,
         [string]$Description,
         [string]$Comments,
+        [AllowEmptyString()]
+        [ValidateSet('air-only', 'hybrid', 'liquid-only', '', IgnoreCase = $true)]
+        [string]$Cooling_Capability,
+        [Nullable[decimal]]$Cooling_Capacity,
         [string[]]$Tags,
         [hashtable]$Custom_Fields,
         [switch]$Raw
@@ -105,7 +118,24 @@ function Set-NBDCIMRackType {
     process {
         Write-Verbose "Updating DCIM Rack Type"
         $Segments = [System.Collections.ArrayList]::new(@('dcim','rack-types',$Id))
-        $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id','Raw'
+
+        # Translate '' -> $null for clearable enum params BEFORE BuildURIComponents,
+        # so the PATCH body carries JSON null (NetBox rejects "" for nullable enums).
+        foreach ($p in @('Cooling_Capability')) {
+            if ($PSBoundParameters.ContainsKey($p) -and $PSBoundParameters[$p] -eq '') {
+                $PSBoundParameters[$p] = $null
+            }
+        }
+
+        # NetBox 4.7+ only fields: drop them with a warning on older servers.
+        $skipParams = @('Id', 'Raw')
+        foreach ($p in @('Cooling_Capability', 'Cooling_Capacity')) {
+            if (Test-NBMinimumVersion -ParameterName $p -MinimumVersion '4.7.0' -BoundParameters $PSBoundParameters -FeatureName "The -$p parameter") {
+                $skipParams += $p
+            }
+        }
+
+        $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName $skipParams
         if ($PSCmdlet.ShouldProcess($Id, 'Update rack type')) {
             InvokeNetboxRequest -URI (BuildNewURI -Segments $URIComponents.Segments) -Method PATCH -Body $URIComponents.Parameters -Raw:$Raw
         }

--- a/Functions/DCIM/Racks/Get-NBDCIMRack.ps1
+++ b/Functions/DCIM/Racks/Get-NBDCIMRack.ps1
@@ -42,6 +42,13 @@ function Get-NBDCIMRack {
     .PARAMETER Facility_Id
         Filter by facility ID
 
+    .PARAMETER Tag
+        Filter by tag slug(s). Several values are combined with AND (object must carry all of them);
+        use Set-NBQueryOption -TagMatch Any (Netbox 4.6.6+) for OR semantics.
+
+    .PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
     .PARAMETER Limit
         Limit the number of results
 
@@ -142,6 +149,12 @@ function Get-NBDCIMRack {
 
         [Parameter(ParameterSetName = 'Query')]
         [string]$Facility_Id,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tag_Id,
 
         [ValidateRange(1, 1000)]
         [uint16]$Limit,

--- a/Functions/DCIM/Racks/Get-NBDCIMRack.ps1
+++ b/Functions/DCIM/Racks/Get-NBDCIMRack.ps1
@@ -42,6 +42,15 @@ function Get-NBDCIMRack {
     .PARAMETER Facility_Id
         Filter by facility ID
 
+    .PARAMETER Cooling_Capability
+        Filter by cooling capability (one or more of 'air-only', 'hybrid',
+        'liquid-only'). Requires NetBox 4.7.0 or later; ignored with a warning
+        on older servers.
+
+    .PARAMETER Cooling_Capacity
+        Filter by cooling capacity in kW (one or more values). Requires NetBox
+        4.7.0 or later; ignored with a warning on older servers.
+
     .PARAMETER Limit
         Limit the number of results
 
@@ -143,6 +152,13 @@ function Get-NBDCIMRack {
         [Parameter(ParameterSetName = 'Query')]
         [string]$Facility_Id,
 
+        [Parameter(ParameterSetName = 'Query')]
+        [ValidateSet('air-only', 'hybrid', 'liquid-only', IgnoreCase = $true)]
+        [string[]]$Cooling_Capability,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [decimal[]]$Cooling_Capacity,
+
         [ValidateRange(1, 1000)]
         [uint16]$Limit,
 
@@ -171,7 +187,15 @@ function Get-NBDCIMRack {
             default {
                 $Segments = [System.Collections.ArrayList]::new(@('dcim', 'racks'))
 
-                $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw', 'All', 'PageSize'
+                # NetBox 4.7+ only fields: drop them with a warning on older servers.
+                $skipParams = @('Raw', 'All', 'PageSize')
+                foreach ($p in @('Cooling_Capability', 'Cooling_Capacity')) {
+                    if (Test-NBMinimumVersion -ParameterName $p -MinimumVersion '4.7.0' -BoundParameters $PSBoundParameters -FeatureName "The -$p filter") {
+                        $skipParams += $p
+                    }
+                }
+
+                $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName $skipParams
 
                 $URI = BuildNewURI -Segments $URIComponents.Segments -Parameters $URIComponents.Parameters
 

--- a/Functions/DCIM/Racks/New-NBDCIMRack.ps1
+++ b/Functions/DCIM/Racks/New-NBDCIMRack.ps1
@@ -38,9 +38,11 @@ function New-NBDCIMRack {
 
     .PARAMETER Form_Factor
         The rack form factor (NetBox 4.6+), e.g. '2-post-frame', '4-post-cabinet', 'wall-cabinet'.
+        Deprecated in NetBox 4.7 in favour of the rack type; removed in NetBox 5.0.
 
     .PARAMETER Width
         The rack width (10 or 19 inches)
+        Deprecated in NetBox 4.7 in favour of the rack type; removed in NetBox 5.0.
 
     .PARAMETER U_Height
         The height in rack units (default: 42)
@@ -53,12 +55,15 @@ function New-NBDCIMRack {
 
     .PARAMETER Outer_Width
         The outer width in millimeters
+        Deprecated in NetBox 4.7 in favour of the rack type; removed in NetBox 5.0.
 
     .PARAMETER Outer_Depth
         The outer depth in millimeters
+        Deprecated in NetBox 4.7 in favour of the rack type; removed in NetBox 5.0.
 
     .PARAMETER Outer_Height
         The outer height in millimeters
+        Deprecated in NetBox 4.7 in favour of the rack type; removed in NetBox 5.0.
 
     .PARAMETER Mounting_Depth
         The mounting depth in millimeters
@@ -83,6 +88,18 @@ function New-NBDCIMRack {
 
     .PARAMETER Owner
         The owner ID for object ownership (Netbox 4.5+ only).
+
+    .PARAMETER Cooling_Capability
+        Cooling capability. One of: 'air-only', 'hybrid', 'liquid-only'.
+        When -Rack_Type is set, NetBox derives this value from the rack type
+        and ignores the rack-level value.
+        Requires NetBox 4.7.0 or later; ignored with a warning on older servers.
+
+    .PARAMETER Cooling_Capacity
+        Cooling capacity in kW. Requires NetBox 4.7.0 or later; ignored with a
+        warning on older servers.
+        When -Rack_Type is set, NetBox derives this value from the rack type
+        and ignores the rack-level value.
 
     .PARAMETER Raw
         Return the raw API response
@@ -170,6 +187,10 @@ function New-NBDCIMRack {
 
         [uint64]$Owner,
 
+        [ValidateSet('air-only', 'hybrid', 'liquid-only', IgnoreCase = $true)]
+        [string]$Cooling_Capability,
+
+        [decimal]$Cooling_Capacity,
 
         [object[]]$Tags,
 
@@ -180,7 +201,23 @@ function New-NBDCIMRack {
         Write-Verbose "Creating DCIM Rack"
         $Segments = [System.Collections.ArrayList]::new(@('dcim', 'racks'))
 
-        $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Raw'
+        # Rack-level geometry is now inferred from the rack type (NetBox 4.7);
+        # these params still work but go away in NetBox 5.0.
+        foreach ($p in @('Form_Factor', 'Width', 'Outer_Width', 'Outer_Depth', 'Outer_Height')) {
+            if ($PSBoundParameters.ContainsKey($p)) {
+                Write-Verbose "-$p is deprecated in NetBox 4.7 in favour of the rack type and will be removed in NetBox 5.0."
+            }
+        }
+
+        # NetBox 4.7+ only fields: drop them with a warning on older servers.
+        $skipParams = @('Raw')
+        foreach ($p in @('Cooling_Capability', 'Cooling_Capacity')) {
+            if (Test-NBMinimumVersion -ParameterName $p -MinimumVersion '4.7.0' -BoundParameters $PSBoundParameters -FeatureName "The -$p parameter") {
+                $skipParams += $p
+            }
+        }
+
+        $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName $skipParams
 
         $URI = BuildNewURI -Segments $URIComponents.Segments
 

--- a/Functions/DCIM/Racks/Set-NBDCIMRack.ps1
+++ b/Functions/DCIM/Racks/Set-NBDCIMRack.ps1
@@ -43,9 +43,11 @@ function Set-NBDCIMRack {
     .PARAMETER Form_Factor
         The rack form factor (NetBox 4.6+), e.g. '2-post-frame', '4-post-cabinet'.
         Pass '' to clear the field server-side (sent as JSON null).
+        Deprecated in NetBox 4.7 in favour of the rack type; removed in NetBox 5.0.
 
     .PARAMETER Width
         The rack width (10 or 19 inches)
+        Deprecated in NetBox 4.7 in favour of the rack type; removed in NetBox 5.0.
 
     .PARAMETER U_Height
         The height in rack units
@@ -58,12 +60,15 @@ function Set-NBDCIMRack {
 
     .PARAMETER Outer_Width
         The outer width in millimeters
+        Deprecated in NetBox 4.7 in favour of the rack type; removed in NetBox 5.0.
 
     .PARAMETER Outer_Depth
         The outer depth in millimeters
+        Deprecated in NetBox 4.7 in favour of the rack type; removed in NetBox 5.0.
 
     .PARAMETER Outer_Height
         The outer height in millimeters
+        Deprecated in NetBox 4.7 in favour of the rack type; removed in NetBox 5.0.
 
     .PARAMETER Mounting_Depth
         The mounting depth in millimeters
@@ -88,6 +93,19 @@ function Set-NBDCIMRack {
 
     .PARAMETER Owner
         The owner ID for object ownership (Netbox 4.5+ only).
+
+    .PARAMETER Cooling_Capability
+        Cooling capability. One of: 'air-only', 'hybrid', 'liquid-only'.
+        When -Rack_Type is set, NetBox derives this value from the rack type
+        and ignores the rack-level value.
+        Pass '' to clear the field server-side (sent as JSON null).
+        Requires NetBox 4.7.0 or later; ignored with a warning on older servers.
+
+    .PARAMETER Cooling_Capacity
+        Cooling capacity in kW. Pass $null to clear. Requires NetBox 4.7.0 or
+        later; ignored with a warning on older servers.
+        When -Rack_Type is set, NetBox derives this value from the rack type
+        and ignores the rack-level value.
 
     .PARAMETER Force
         Skip confirmation prompts
@@ -177,6 +195,12 @@ function Set-NBDCIMRack {
 
         [uint64]$Owner,
 
+        [AllowEmptyString()]
+        [ValidateSet('air-only', 'hybrid', 'liquid-only', '', IgnoreCase = $true)]
+        [string]$Cooling_Capability,
+
+        [Nullable[decimal]]$Cooling_Capacity,
+
         [switch]$Force,
 
 
@@ -191,9 +215,25 @@ function Set-NBDCIMRack {
         # Translate '' -> $null for clearable enum params BEFORE
         # BuildURIComponents, so the PATCH body carries JSON null
         # (NetBox rejects "" for these nullable enum fields).
-        foreach ($p in @('Airflow', 'Form_Factor')) {
+        foreach ($p in @('Airflow', 'Form_Factor', 'Cooling_Capability')) {
             if ($PSBoundParameters.ContainsKey($p) -and $PSBoundParameters[$p] -eq '') {
                 $PSBoundParameters[$p] = $null
+            }
+        }
+
+        # Rack-level geometry is now inferred from the rack type (NetBox 4.7);
+        # these params still work but go away in NetBox 5.0.
+        foreach ($p in @('Form_Factor', 'Width', 'Outer_Width', 'Outer_Depth', 'Outer_Height')) {
+            if ($PSBoundParameters.ContainsKey($p)) {
+                Write-Verbose "-$p is deprecated in NetBox 4.7 in favour of the rack type and will be removed in NetBox 5.0."
+            }
+        }
+
+        # NetBox 4.7+ only fields: drop them with a warning on older servers.
+        $skipParams = @('Id', 'Raw', 'Force')
+        foreach ($p in @('Cooling_Capability', 'Cooling_Capacity')) {
+            if (Test-NBMinimumVersion -ParameterName $p -MinimumVersion '4.7.0' -BoundParameters $PSBoundParameters -FeatureName "The -$p parameter") {
+                $skipParams += $p
             }
         }
 
@@ -202,7 +242,7 @@ function Set-NBDCIMRack {
             if ($Force -or $PSCmdlet.ShouldProcess("ID $RackId", "Update rack")) {
                 $Segments = [System.Collections.ArrayList]::new(@('dcim', 'racks', $RackId))
 
-                $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName 'Id', 'Raw', 'Force'
+                $URIComponents = BuildURIComponents -URISegments $Segments.Clone() -ParametersDictionary $PSBoundParameters -SkipParameterByName $skipParams
 
                 $URI = BuildNewURI -Segments $URIComponents.Segments
 

--- a/Functions/DCIM/RearPorts/Get-NBDCIMRearPort.ps1
+++ b/Functions/DCIM/RearPorts/Get-NBDCIMRearPort.ps1
@@ -28,7 +28,14 @@
     Specify which fields to exclude from the response.
     Requires Netbox 4.5.0 or later.
 
-.PARAMETER Limit
+.PARAMETER Tag
+        Filter by tag slug(s). Several values are combined with AND (object must carry all of them);
+        use Set-NBQueryOption -TagMatch Any (Netbox 4.6.6+) for OR semantics.
+
+    .PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
+    .PARAMETER Limit
     Maximum number of results to return per request (1-1000).
 
 .PARAMETER Offset
@@ -73,6 +80,12 @@ function Get-NBDCIMRearPort {
         [string[]]$Fields,
 
         [string[]]$Omit,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tag_Id,
 
         [ValidateRange(1, 1000)]
         [uint16]$Limit,

--- a/Functions/DCIM/Regions/Get-NBDCIMRegion.ps1
+++ b/Functions/DCIM/Regions/Get-NBDCIMRegion.ps1
@@ -22,6 +22,13 @@ function Get-NBDCIMRegion {
     .PARAMETER Parent_Id
         Filter by parent region ID
 
+    .PARAMETER Tag
+        Filter by tag slug(s). Several values are combined with AND (object must carry all of them);
+        use Set-NBQueryOption -TagMatch Any (Netbox 4.6.6+) for OR semantics.
+
+    .PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
     .PARAMETER Limit
         Limit the number of results
 
@@ -100,6 +107,12 @@ function Get-NBDCIMRegion {
 
         [Parameter(ParameterSetName = 'Query')]
         [uint64]$Parent_Id,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tag_Id,
 
         [ValidateRange(1, 1000)]
         [uint16]$Limit,

--- a/Functions/DCIM/SiteGroups/Get-NBDCIMSiteGroup.ps1
+++ b/Functions/DCIM/SiteGroups/Get-NBDCIMSiteGroup.ps1
@@ -22,6 +22,13 @@ function Get-NBDCIMSiteGroup {
     .PARAMETER Parent_Id
         Filter by parent site group ID
 
+    .PARAMETER Tag
+        Filter by tag slug(s). Several values are combined with AND (object must carry all of them);
+        use Set-NBQueryOption -TagMatch Any (Netbox 4.6.6+) for OR semantics.
+
+    .PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
     .PARAMETER Limit
         Limit the number of results
 
@@ -100,6 +107,12 @@ function Get-NBDCIMSiteGroup {
 
         [Parameter(ParameterSetName = 'Query')]
         [uint64]$Parent_Id,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tag_Id,
 
         [ValidateRange(1, 1000)]
         [uint16]$Limit,

--- a/Functions/DCIM/Sites/Get-NBDCIMSite.ps1
+++ b/Functions/DCIM/Sites/Get-NBDCIMSite.ps1
@@ -82,7 +82,14 @@
 .PARAMETER Region
     Filter by region (name or slug).
 
-.PARAMETER Limit
+.PARAMETER Tag
+        Filter by tag slug(s). Several values are combined with AND (object must carry all of them);
+        use Set-NBQueryOption -TagMatch Any (Netbox 4.6.6+) for OR semantics.
+
+    .PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
+    .PARAMETER Limit
     Maximum number of results to return per request (1-1000).
 
 .PARAMETER Offset
@@ -166,6 +173,12 @@ function Get-NBDCIMSite {
 
         [Parameter(ParameterSetName = 'Query')]
         [string]$Region,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tag_Id,
 
         [ValidateRange(1, 1000)]
         [uint16]$Limit,

--- a/Functions/DCIM/VirtualChassis/Get-NBDCIMVirtualChassis.ps1
+++ b/Functions/DCIM/VirtualChassis/Get-NBDCIMVirtualChassis.ps1
@@ -52,7 +52,14 @@
 .PARAMETER Query
     Free-text search across the object (NetBox 'q' parameter).
 
-.PARAMETER Limit
+.PARAMETER Tag
+        Filter by tag slug(s). Several values are combined with AND (object must carry all of them);
+        use Set-NBQueryOption -TagMatch Any (Netbox 4.6.6+) for OR semantics.
+
+    .PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
+    .PARAMETER Limit
     Maximum number of results to return per request (1-1000).
 
 .PARAMETER Offset
@@ -90,6 +97,12 @@ function Get-NBDCIMVirtualChassis {
         [Parameter(ParameterSetName = 'Query')][uint64]$Region_Id,
         [Parameter(ParameterSetName = 'Query')][uint64]$Tenant_Id,
         [Parameter(ParameterSetName = 'Query')][string]$Query,
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tag_Id,
+
         [ValidateRange(1, 1000)]
         [uint16]$Limit,
         [ValidateRange(0, [int]::MaxValue)]

--- a/Functions/DCIM/VirtualDeviceContexts/Get-NBDCIMVirtualDeviceContext.ps1
+++ b/Functions/DCIM/VirtualDeviceContexts/Get-NBDCIMVirtualDeviceContext.ps1
@@ -52,7 +52,14 @@
 .PARAMETER Query
     Free-text search across the object (NetBox 'q' parameter).
 
-.PARAMETER Limit
+.PARAMETER Tag
+        Filter by tag slug(s). Several values are combined with AND (object must carry all of them);
+        use Set-NBQueryOption -TagMatch Any (Netbox 4.6.6+) for OR semantics.
+
+    .PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
+    .PARAMETER Limit
     Maximum number of results to return per request (1-1000).
 
 .PARAMETER Offset
@@ -90,6 +97,12 @@ function Get-NBDCIMVirtualDeviceContext {
         [Parameter(ParameterSetName = 'Query')][uint64]$Primary_Ip4_Id,
         [Parameter(ParameterSetName = 'Query')][uint64]$Primary_Ip6_Id,
         [Parameter(ParameterSetName = 'Query')][string]$Query,
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tag_Id,
+
         [ValidateRange(1, 1000)]
         [uint16]$Limit,
         [ValidateRange(0, [int]::MaxValue)]

--- a/Functions/Extras/ConfigContexts/Get-NBConfigContext.ps1
+++ b/Functions/Extras/ConfigContexts/Get-NBConfigContext.ps1
@@ -17,7 +17,14 @@
 .PARAMETER Query
     Search query.
 
-.PARAMETER Limit
+.PARAMETER Tag
+        Filter by tag slug(s). Several values are combined with AND (object must carry all of them);
+        use Set-NBQueryOption -TagMatch Any (Netbox 4.6.6+) for OR semantics.
+
+    .PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
+    .PARAMETER Limit
     Number of results to return.
 
 .PARAMETER Offset
@@ -81,6 +88,12 @@ function Get-NBConfigContext {
 
         [Parameter(ParameterSetName = 'Query')]
         [string]$Query,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tag_Id,
 
         [ValidateRange(1, 1000)]
         [uint16]$Limit,

--- a/Functions/Extras/EventRules/Get-NBEventRule.ps1
+++ b/Functions/Extras/EventRules/Get-NBEventRule.ps1
@@ -26,7 +26,14 @@
 .PARAMETER Query
     Search query.
 
-.PARAMETER Limit
+.PARAMETER Tag
+        Filter by tag slug(s). Several values are combined with AND (object must carry all of them);
+        use Set-NBQueryOption -TagMatch Any (Netbox 4.6.6+) for OR semantics.
+
+    .PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
+    .PARAMETER Limit
     Number of results to return.
 
 .PARAMETER Offset
@@ -99,6 +106,12 @@ function Get-NBEventRule {
 
         [Parameter(ParameterSetName = 'Query')]
         [string]$Query,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tag_Id,
 
         [ValidateRange(1, 1000)]
         [uint16]$Limit,

--- a/Functions/Extras/JournalEntries/Get-NBJournalEntry.ps1
+++ b/Functions/Extras/JournalEntries/Get-NBJournalEntry.ps1
@@ -23,7 +23,14 @@
 .PARAMETER Query
     Search query.
 
-.PARAMETER Limit
+.PARAMETER Tag
+        Filter by tag slug(s). Several values are combined with AND (object must carry all of them);
+        use Set-NBQueryOption -TagMatch Any (Netbox 4.6.6+) for OR semantics.
+
+    .PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
+    .PARAMETER Limit
     Number of results to return.
 
 .PARAMETER Offset
@@ -94,6 +101,12 @@ function Get-NBJournalEntry {
 
         [Parameter(ParameterSetName = 'Query')]
         [string]$Query,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tag_Id,
 
         [ValidateRange(1, 1000)]
         [uint16]$Limit,

--- a/Functions/Extras/Tags/Set-NBObjectTag.ps1
+++ b/Functions/Extras/Tags/Set-NBObjectTag.ps1
@@ -1,0 +1,93 @@
+<#
+.SYNOPSIS
+    Adds and/or removes tags on any Netbox object without replacing its whole tag list.
+.DESCRIPTION
+    Netbox 4.6+ accepts 'add_tags' and 'remove_tags' in a PATCH request (partial tag assignment), so a
+    tag can be added or removed without first reading and resending the complete 'tags' array - which
+    is both faster and safe against a concurrent edit of the other tags.
+
+    Pass the object itself (any Get-NB* result; its 'url' property identifies it) or the object's API
+    path. The request is always sent to the configured Netbox host - only the path of the object URL is
+    used - so a proxied or renamed host in the object URL cannot redirect the request.
+
+    Tags may be given as IDs or names. Older Netbox versions silently ignore add_tags/remove_tags, so
+    on a server below 4.6 this cmdlet throws instead of pretending to succeed.
+.PARAMETER InputObject
+    The Netbox object (from any Get-NB* cmdlet, pipeline supported). Must carry a 'url' property.
+.PARAMETER Url
+    The object's API URL or path instead of an object, e.g. '/api/dcim/devices/42/'.
+.PARAMETER Add
+    Tags to add (IDs or names). Tags the object already carries are left untouched.
+.PARAMETER Remove
+    Tags to remove (IDs or names). Tags the object does not carry are ignored.
+.PARAMETER Raw
+    Return the raw API response.
+.EXAMPLE
+    Get-NBDCIMDevice -Name 'core-01' | Set-NBObjectTag -Add 'maintenance'
+
+    Adds the 'maintenance' tag to the device, keeping its other tags.
+.EXAMPLE
+    Get-NBDCIMDevice -Tag 'maintenance' | Set-NBObjectTag -Remove 'maintenance' -Add 12
+
+    Swaps the 'maintenance' tag for tag ID 12 on every matching device.
+.EXAMPLE
+    Set-NBObjectTag -Url '/api/ipam/prefixes/7/' -Add 'audited'
+.LINK
+    https://netbox.readthedocs.io/en/stable/rest-api/overview/
+.NOTES
+    AddedInVersion: v4.7.1.0
+    Requires Netbox 4.6+ (netbox-community/netbox#21771).
+#>
+function Set-NBObjectTag {
+    [CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Medium', DefaultParameterSetName = 'ByObject')]
+    [OutputType([PSCustomObject])]
+    param (
+        [Parameter(Mandatory = $true, ValueFromPipeline = $true, ParameterSetName = 'ByObject')]
+        [PSObject]$InputObject,
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'ByUrl')]
+        [ValidateNotNullOrEmpty()]
+        [string]$Url,
+
+        [object[]]$Add,
+
+        [object[]]$Remove,
+
+        [switch]$Raw
+    )
+
+    begin {
+        if (-not $Add -and -not $Remove) {
+            throw "Specify -Add and/or -Remove."
+        }
+        CheckNetboxIsConnected
+        if ($script:NetboxConfig.ParsedVersion -and $script:NetboxConfig.ParsedVersion -lt [version]'4.6.0') {
+            throw "Partial tag assignment (add_tags/remove_tags) requires Netbox 4.6.0 or higher (connected to $($script:NetboxConfig.ParsedVersion)). Older servers silently ignore these fields, so this cmdlet refuses rather than pretending to succeed."
+        }
+
+        $body = @{}
+        if ($Add) { $body['add_tags'] = ConvertToNBTagReference -Tags $Add }
+        if ($Remove) { $body['remove_tags'] = ConvertToNBTagReference -Tags $Remove }
+    }
+
+    process {
+        $target = if ($PSCmdlet.ParameterSetName -eq 'ByUrl') { $Url } else { $InputObject.url }
+        if (-not $target) {
+            throw "The input object has no 'url' property; pass a Get-NB* result or use -Url."
+        }
+
+        # Only the path is taken from the object URL; host/scheme/port come from the active connection.
+        $path = if ($target -match '^https?://') { ([System.Uri]$target).AbsolutePath } else { $target }
+        $segments = [System.Collections.ArrayList]::new(@($path -split '/' | Where-Object { $_ -and $_ -ne 'api' }))
+        if ($segments.Count -lt 3) {
+            throw "'$target' does not look like a Netbox object URL (expected /api/<app>/<endpoint>/<id>/)."
+        }
+
+        $uri = BuildNewURI -Segments $segments
+        $display = if ($InputObject -and $InputObject.display) { $InputObject.display } else { $path }
+        Write-Verbose "Partial tag update on $path (add: $($Add -join ', '); remove: $($Remove -join ', '))"
+        if ($PSCmdlet.ShouldProcess($display, 'Update tags')) {
+            InvokeNetboxRequest -URI $uri -Method PATCH -Body $body -Raw:$Raw
+        }
+    }
+}

--- a/Functions/Extras/Webhooks/Get-NBWebhook.ps1
+++ b/Functions/Extras/Webhooks/Get-NBWebhook.ps1
@@ -17,7 +17,14 @@
 .PARAMETER Query
     Search query.
 
-.PARAMETER Limit
+.PARAMETER Tag
+        Filter by tag slug(s). Several values are combined with AND (object must carry all of them);
+        use Set-NBQueryOption -TagMatch Any (Netbox 4.6.6+) for OR semantics.
+
+    .PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
+    .PARAMETER Limit
     Number of results to return.
 
 .PARAMETER Offset
@@ -81,6 +88,12 @@ function Get-NBWebhook {
 
         [Parameter(ParameterSetName = 'Query')]
         [string]$Query,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tag_Id,
 
         [ValidateRange(1, 1000)]
         [uint16]$Limit,

--- a/Functions/Helpers/BuildNewURI.ps1
+++ b/Functions/Helpers/BuildNewURI.ps1
@@ -80,6 +80,17 @@ function BuildNewURI {
                 Write-Verbose " Parameter $($param.Key) for endpoint $apiCheck is not in the ignore case list"
                 $paramKey = "$($param.Key)$($Script:QueryParameterDecoration)"
             }
+            # Set-NBQueryOption -TagMatch Any: Netbox 4.6.6+ 'tag__any' / 'tag_id__any' match objects carrying ANY of
+            # the listed tags (default 'tag' requires all of them). Older servers silently ignore unknown lookups and
+            # would return the whole table, so the rewrite is version-gated here as well as at option-set time.
+            if ($Script:NetboxConfig.TagMatch -eq 'Any' -and ($param.Key -eq 'tag' -or $param.Key -eq 'tag_id')) {
+                if ($Script:NetboxConfig.ParsedVersion -and $Script:NetboxConfig.ParsedVersion -ge [version]'4.6.6') {
+                    $paramKey = "$($param.Key)__any"
+                }
+                else {
+                    Write-Verbose " TagMatch Any needs Netbox 4.6.6+; sending plain $($param.Key) (all-tags semantics)"
+                }
+            }
 
             $EncodedKey = [System.Uri]::EscapeDataString($paramKey)
             foreach ($thisValue in $param.Value) {

--- a/Functions/Helpers/BuildURIComponents.ps1
+++ b/Functions/Helpers/BuildURIComponents.ps1
@@ -86,6 +86,14 @@ function BuildURIComponents {
                 break
             }
 
+            { $_ -in @('Tags', 'Add_Tags', 'Remove_Tags') } {
+                # Netbox only accepts numeric IDs or attribute dictionaries for tag references;
+                # bare names become @{ name = ... } so "-Tags 'web', 12" works as documented.
+                Write-Verbose " Adding $($CmdletParameterName.ToLower()) parameter (tag references)"
+                $URIParameters[$CmdletParameterName.ToLower()] = ConvertToNBTagReference -Tags $ParametersDictionary[$CmdletParameterName]
+                break
+            }
+
             default {
                 Write-Verbose " Adding $($CmdletParameterName.ToLower()) parameter"
                 $URIParameters[$CmdletParameterName.ToLower()] = $ParametersDictionary[$CmdletParameterName]

--- a/Functions/Helpers/ConvertToNBTagReference.ps1
+++ b/Functions/Helpers/ConvertToNBTagReference.ps1
@@ -1,0 +1,48 @@
+<#
+.SYNOPSIS
+    Normalises a -Tags / -Add / -Remove value into what the Netbox API accepts for tag references.
+.DESCRIPTION
+    Netbox resolves related objects in a request body only from a numeric ID or from a dictionary of
+    attributes; a bare tag name string is rejected with
+    "Related objects must be referenced by numeric ID or by dictionary of attributes".
+    This helper turns numeric strings into IDs and other strings into @{ name = '<tag>' }, and passes
+    hashtables / objects (already attribute dictionaries) through unchanged, so every cmdlet that
+    documents "tag names or IDs" really accepts both.
+.PARAMETER Tags
+    The raw values as bound to the cmdlet parameter.
+.OUTPUTS
+    [object[]] Tag references safe to serialise into the request body.
+.EXAMPLE
+    ConvertToNBTagReference -Tags 'web', 12, @{ slug = 'prod' }
+    # -> @{ name = 'web' }, 12, @{ slug = 'prod' }
+.NOTES
+    AddedInVersion: v4.7.1.0
+    Internal helper (not exported in production builds).
+#>
+function ConvertToNBTagReference {
+    [CmdletBinding()]
+    [OutputType([object[]])]
+    param (
+        [AllowNull()]
+        [AllowEmptyCollection()]
+        [object[]]$Tags
+    )
+
+    if ($null -eq $Tags) { return , @() }
+
+    # NOTE: '-is [PSCustomObject]' is true for ANY PSObject-wrapped value (including strings),
+    # so test strings and numbers explicitly and let everything else pass through unchanged.
+    $refs = foreach ($tag in $Tags) {
+        if ($null -eq $tag) { continue }
+        if ($tag -is [string]) {
+            if ($tag -match '^\d+$') { [uint64]$tag } else { @{ name = $tag } }
+        }
+        elseif ($tag -is [ValueType]) {
+            [uint64]$tag
+        }
+        else {
+            $tag
+        }
+    }
+    return , @($refs)
+}

--- a/Functions/Helpers/InvokeNetboxRequest.ps1
+++ b/Functions/Helpers/InvokeNetboxRequest.ps1
@@ -106,6 +106,20 @@ function InvokeNetboxRequest {
             $URI.Query = "limit=$PageSize"
         }
 
+        # Cursor pagination (Set-NBQueryOption -Pagination Cursor): Netbox 4.6+ '?start=<pk>' walks the table by
+        # primary key instead of limit/offset, which stays constant-time on very large tables. The server puts
+        # the next 'start' value into '.next', so the loop below (including the origin check) is unchanged.
+        # An explicit offset always wins, and older servers fall back to offset paging.
+        if ($script:NetboxConfig.Pagination -eq 'Cursor' -and $URI.Query -notmatch '(^\??|&)offset=') {
+            if ($script:NetboxConfig.ParsedVersion -and $script:NetboxConfig.ParsedVersion -lt [version]'4.6.0') {
+                Write-Verbose "Cursor pagination requires Netbox 4.6+ (connected to $($script:NetboxConfig.ParsedVersion)); using offset pagination"
+            }
+            elseif ($URI.Query -notmatch '(^\??|&)start=') {
+                $URI.Query = "$($URI.Query.TrimStart('?'))&start=0"
+                Write-Verbose "Cursor pagination enabled (?start=)"
+            }
+        }
+
         $allResults = [System.Collections.ArrayList]::new()
         $pageNum = 0
         $nextUrl = $null
@@ -197,6 +211,31 @@ function InvokeNetboxRequest {
         $Headers[$key] = $requestHeaders[$key]
     }
 
+    # Optimistic concurrency (Set-NBQueryOption -OptimisticConcurrency): Netbox 4.6+ returns an ETag on
+    # single-object GETs and honours If-Match on PATCH/PUT/DELETE (HTTP 412 on mismatch). Remember the
+    # ETag per object URL and replay it on the next write to that object. Reading response headers
+    # needs Invoke-RestMethod -ResponseHeadersVariable, i.e. PowerShell 7+.
+    $etagMode = $script:NetboxConfig.OptimisticConcurrency -eq $true
+    $etagKey = $null
+    if ($etagMode) {
+        if ($PSVersionTable.PSEdition -ne 'Core') {
+            if (-not $script:NetboxConfig.OptimisticConcurrencyWarned) {
+                Write-Warning "Optimistic concurrency (ETag/If-Match) needs PowerShell 7+ to read response headers; requests are sent without If-Match on Windows PowerShell 5.1."
+                $script:NetboxConfig.OptimisticConcurrencyWarned = $true
+            }
+            $etagMode = $false
+        }
+        else {
+            if ($null -eq $script:NetboxConfig.ETagCache) { $script:NetboxConfig.ETagCache = @{} }
+            $etagKey = $URI.Uri.GetLeftPart([System.UriPartial]::Path)
+            if (($Method -eq 'PATCH' -or $Method -eq 'PUT' -or $Method -eq 'DELETE') -and
+                $script:NetboxConfig.ETagCache.ContainsKey($etagKey) -and -not $Headers.ContainsKey('If-Match')) {
+                $Headers['If-Match'] = $script:NetboxConfig.ETagCache[$etagKey]
+                Write-Verbose "If-Match: $($Headers['If-Match'])"
+            }
+        }
+    }
+
     $splat = @{
         'Method'      = $Method
         'Uri'         = $URI.Uri.AbsoluteUri
@@ -204,6 +243,9 @@ function InvokeNetboxRequest {
         'TimeoutSec'  = $Timeout
         'ContentType' = 'application/json'
         'ErrorAction' = 'Stop'
+    }
+    if ($etagMode) {
+        $splat['ResponseHeadersVariable'] = 'nbResponseHeaders'
     }
 
     $splat += Get-NBInvokeParams
@@ -240,6 +282,22 @@ function InvokeNetboxRequest {
         try {
             Write-Verbose "[$attempt/$MaxRetries] $Method $($URI.Uri.AbsoluteUri)"
             $result = Invoke-RestMethod @splat
+
+            if ($etagMode) {
+                if ($Method -eq 'DELETE') {
+                    $null = $script:NetboxConfig.ETagCache.Remove($etagKey)
+                }
+                else {
+                    $respHeaders = Get-Variable -Name nbResponseHeaders -ValueOnly -ErrorAction SilentlyContinue
+                    if ($respHeaders) {
+                        $etagName = @($respHeaders.Keys | Where-Object { $_ -ieq 'ETag' })[0]
+                        if ($etagName) {
+                            $script:NetboxConfig.ETagCache[$etagKey] = [string](@($respHeaders[$etagName])[0])
+                            Write-Verbose "Cached ETag for $etagKey"
+                        }
+                    }
+                }
+            }
 
             # Success - return result
             if ($Raw) {
@@ -382,6 +440,7 @@ function GetHttpStatusName {
         405 = 'Method Not Allowed'
         408 = 'Request Timeout'
         409 = 'Conflict'
+        412 = 'Precondition Failed'
         429 = 'Too Many Requests'
         500 = 'Internal Server Error'
         502 = 'Bad Gateway'
@@ -408,6 +467,7 @@ function GetErrorCategory {
         405 { return [System.Management.Automation.ErrorCategory]::InvalidOperation }
         408 { return [System.Management.Automation.ErrorCategory]::OperationTimeout }
         409 { return [System.Management.Automation.ErrorCategory]::ResourceExists }
+        412 { return [System.Management.Automation.ErrorCategory]::WriteError }
         429 { return [System.Management.Automation.ErrorCategory]::LimitsExceeded }
         { $_ -ge 500 } { return [System.Management.Automation.ErrorCategory]::ConnectionError }
         default { return [System.Management.Automation.ErrorCategory]::InvalidOperation }
@@ -474,6 +534,13 @@ function BuildDetailedErrorMessage {
                 "- Verify the resource ID exists in Netbox"
                 "- Check if the resource was deleted"
                 "- Ensure the API endpoint is correct for your Netbox version"
+            ) -join "`n"
+        }
+        412 {
+            @(
+                "- The object changed on the server after it was read (ETag / If-Match mismatch)"
+                "- Re-read the object with its Get-NB* cmdlet and retry the update"
+                "- Optimistic concurrency is controlled by Set-NBQueryOption -OptimisticConcurrency"
             ) -join "`n"
         }
         429 {

--- a/Functions/Helpers/Send-NBBulkRequest.ps1
+++ b/Functions/Helpers/Send-NBBulkRequest.ps1
@@ -29,7 +29,12 @@
     Name to display in the progress bar.
 
 .PARAMETER MaxItems
-    MaxItems.
+    Refuse to process more than this many items in one call (guard against runaway pipelines). Default: 10000.
+.PARAMETER Background
+    Netbox 4.7+: append '?background=true' so each batch is queued as a background job instead of being
+    processed synchronously (avoids proxy/gateway timeouts on large batches). The API answers 202 Accepted
+    with the job object; the job objects are returned as the Succeeded items, and validation happens in the
+    worker, so inspect the job (Get-NBJob) for the real outcome. Requires a running RQ worker on the server.
 
 .OUTPUTS
     [BulkOperationResult] Object containing succeeded and failed items.
@@ -64,7 +69,9 @@ function Send-NBBulkRequest {
 
         [switch]$ShowProgress,
 
-        [string]$ActivityName = 'Bulk operation'
+        [string]$ActivityName = 'Bulk operation',
+
+        [switch]$Background
     )
 
     $result = [BulkOperationResult]::new()
@@ -108,10 +115,21 @@ function Send-NBBulkRequest {
             Write-Verbose "[$currentBatch/$totalBatches] Sending batch of $($batch.Count) items"
 
             # For bulk operations, we send an array directly
-            $response = InvokeNetboxRequest -URI $URI -Method $Method -Body $batch -Raw
+            $batchUri = $URI
+            if ($Background) {
+                # Netbox 4.7+: ?background=true -> 202 Accepted + job object
+                $batchUri = [System.UriBuilder]::new($URI.Uri)
+                $batchUri.Query = (@($URI.Query.TrimStart('?'), 'background=true') | Where-Object { $_ }) -join '&'
+            }
+            $response = InvokeNetboxRequest -URI $batchUri -Method $Method -Body $batch -Raw
 
             # Process response - Netbox returns an array of results for bulk operations
-            if ($response -is [array]) {
+            if ($Background -and $response.job) {
+                # Netbox 4.7+ background write: 202 {"job": {"id", "url", "status"}} - the job is the result
+                Write-Verbose "[$currentBatch/$totalBatches] Queued as background job $($response.job.id) ($($response.job.status))"
+                $result.AddSuccess($response.job)
+            }
+            elseif ($response -is [array]) {
                 foreach ($item in $response) {
                     if ($item.id) {
                         $result.AddSuccess($item)

--- a/Functions/IPAM/ASN/Get-NBIPAMASN.ps1
+++ b/Functions/IPAM/ASN/Get-NBIPAMASN.ps1
@@ -27,6 +27,13 @@ function Get-NBIPAMASN {
     .PARAMETER Role_Id
         Filter by role ID (NetBox 4.6+)
 
+    .PARAMETER Tag
+        Filter by tag slug(s). Several values are combined with AND (object must carry all of them);
+        use Set-NBQueryOption -TagMatch Any (Netbox 4.6.6+) for OR semantics.
+
+    .PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
     .PARAMETER Limit
         Limit the number of results
 
@@ -106,6 +113,12 @@ function Get-NBIPAMASN {
 
         [Parameter(ParameterSetName = 'Query')]
         [uint64]$Role_Id,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tag_Id,
 
         [ValidateRange(1, 1000)]
         [uint16]$Limit,

--- a/Functions/IPAM/ASNRange/Get-NBIPAMASNRange.ps1
+++ b/Functions/IPAM/ASNRange/Get-NBIPAMASNRange.ps1
@@ -21,6 +21,13 @@ function Get-NBIPAMASNRange {
     .PARAMETER Tenant_Id
         Filter by tenant ID
 
+    .PARAMETER Tag
+        Filter by tag slug(s). Several values are combined with AND (object must carry all of them);
+        use Set-NBQueryOption -TagMatch Any (Netbox 4.6.6+) for OR semantics.
+
+    .PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
     .PARAMETER Limit
         Limit the number of results
 
@@ -94,6 +101,12 @@ function Get-NBIPAMASNRange {
 
         [Parameter(ParameterSetName = 'Query')]
         [uint64]$Tenant_Id,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tag_Id,
 
         [ValidateRange(1, 1000)]
         [uint16]$Limit,

--- a/Functions/IPAM/Address/Get-NBIPAMAddress.ps1
+++ b/Functions/IPAM/Address/Get-NBIPAMAddress.ps1
@@ -79,7 +79,14 @@
 .PARAMETER Role
     Filter by role (name or slug).
 
-.PARAMETER Limit
+.PARAMETER Tag
+        Filter by tag slug(s). Several values are combined with AND (object must carry all of them);
+        use Set-NBQueryOption -TagMatch Any (Netbox 4.6.6+) for OR semantics.
+
+    .PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
+    .PARAMETER Limit
     Maximum number of results to return per request (1-1000).
 
 .PARAMETER Offset
@@ -168,6 +175,12 @@ function Get-NBIPAMAddress {
         [Parameter(ParameterSetName = 'Query')]
         [ValidateSet('loopback', 'secondary', 'anycast', 'vip', 'vrrp', 'hsrp', 'glbp', 'carp', IgnoreCase = $true)]
         [string]$Role,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tag_Id,
 
         [ValidateRange(1, 1000)]
         [uint16]$Limit,

--- a/Functions/IPAM/Address/New-NBIPAMAddress.ps1
+++ b/Functions/IPAM/Address/New-NBIPAMAddress.ps1
@@ -57,6 +57,10 @@
     Number of IP addresses to create per API request in bulk mode.
     Default: 50, Range: 1-1000
 
+.PARAMETER Background
+    Netbox 4.7+: queue each bulk batch as a background job (?background=true) instead of processing it
+    synchronously; the returned items are the job objects (check them with Get-NBJob). Ignored with a
+    warning on older Netbox versions. Only meaningful together with -BatchSize pipeline input.
 .PARAMETER Force
     Skip confirmation prompts for bulk operations.
 
@@ -157,6 +161,8 @@ function New-NBIPAMAddress {
         [ValidateRange(1, 1000)]
         [int]$BatchSize = 100,
 
+        [switch]$Background,
+
         [Parameter(ParameterSetName = 'Bulk')]
         [switch]$Force,
 
@@ -214,6 +220,7 @@ function New-NBIPAMAddress {
             if ($Force -or $PSCmdlet.ShouldProcess($target, 'Create IP addresses (bulk)')) {
                 Write-Verbose "Processing $($bulkItems.Count) IP addresses in bulk mode with batch size $BatchSize"
 
+                $useBackground = $Background -and -not (Test-NBMinimumVersion -ParameterName 'Background' -MinimumVersion '4.7.0' -BoundParameters $PSBoundParameters -FeatureName 'Background bulk processing (-Background)')
                 $bulkParams = @{
                     URI          = $URI
                     Items        = $bulkItems.ToArray()
@@ -221,6 +228,7 @@ function New-NBIPAMAddress {
                     BatchSize    = $BatchSize
                     ShowProgress = $true
                     ActivityName = 'Creating IP addresses'
+                    Background   = $useBackground
                 }
                 $result = Send-NBBulkRequest @bulkParams
 

--- a/Functions/IPAM/Address/Remove-NBIPAMAddress.ps1
+++ b/Functions/IPAM/Address/Remove-NBIPAMAddress.ps1
@@ -19,6 +19,10 @@
     Number of IP addresses to delete per API request in bulk mode.
     Default: 50, Range: 1-1000
 
+.PARAMETER Background
+    Netbox 4.7+: queue each bulk batch as a background job (?background=true) instead of processing it
+    synchronously; the returned items are the job objects (check them with Get-NBJob). Ignored with a
+    warning on older Netbox versions. Only meaningful together with -BatchSize pipeline input.
 .PARAMETER Force
     Skip confirmation prompts.
 
@@ -70,6 +74,8 @@ function Remove-NBIPAMAddress {
         [Parameter(ParameterSetName = 'Bulk')]
         [ValidateRange(1, 1000)]
         [int]$BatchSize = 100,
+
+        [switch]$Background,
 
         # Common parameters
         [Parameter()]
@@ -126,6 +132,7 @@ function Remove-NBIPAMAddress {
             if ($Force -or $PSCmdlet.ShouldProcess($target, 'Delete IP addresses (bulk)')) {
                 Write-Verbose "Processing $($bulkItems.Count) IP addresses in bulk DELETE mode with batch size $BatchSize"
 
+                $useBackground = $Background -and -not (Test-NBMinimumVersion -ParameterName 'Background' -MinimumVersion '4.7.0' -BoundParameters $PSBoundParameters -FeatureName 'Background bulk processing (-Background)')
                 $bulkParams = @{
                     URI          = $URI
                     Items        = $bulkItems.ToArray()
@@ -133,6 +140,7 @@ function Remove-NBIPAMAddress {
                     BatchSize    = $BatchSize
                     ShowProgress = $true
                     ActivityName = 'Deleting IP addresses'
+                    Background   = $useBackground
                 }
                 $result = Send-NBBulkRequest @bulkParams
 

--- a/Functions/IPAM/Address/Set-NBIPAMAddress.ps1
+++ b/Functions/IPAM/Address/Set-NBIPAMAddress.ps1
@@ -55,6 +55,10 @@
     Number of IP addresses to update per API request in bulk mode.
     Default: 50, Range: 1-1000
 
+.PARAMETER Background
+    Netbox 4.7+: queue each bulk batch as a background job (?background=true) instead of processing it
+    synchronously; the returned items are the job objects (check them with Get-NBJob). Ignored with a
+    warning on older Netbox versions. Only meaningful together with -BatchSize pipeline input.
 .PARAMETER Force
     Skip confirmation prompts.
 
@@ -150,6 +154,8 @@ function Set-NBIPAMAddress {
         [ValidateRange(1, 1000)]
         [int]$BatchSize = 100,
 
+        [switch]$Background,
+
         # Common parameters
         [Parameter()]
         [switch]$Force,
@@ -225,6 +231,7 @@ function Set-NBIPAMAddress {
             if ($Force -or $PSCmdlet.ShouldProcess($target, 'Update IP addresses (bulk)')) {
                 Write-Verbose "Processing $($bulkItems.Count) IP addresses in bulk PATCH mode with batch size $BatchSize"
 
+                $useBackground = $Background -and -not (Test-NBMinimumVersion -ParameterName 'Background' -MinimumVersion '4.7.0' -BoundParameters $PSBoundParameters -FeatureName 'Background bulk processing (-Background)')
                 $bulkParams = @{
                     URI          = $URI
                     Items        = $bulkItems.ToArray()
@@ -232,6 +239,7 @@ function Set-NBIPAMAddress {
                     BatchSize    = $BatchSize
                     ShowProgress = $true
                     ActivityName = 'Updating IP addresses'
+                    Background   = $useBackground
                 }
                 $result = Send-NBBulkRequest @bulkParams
 

--- a/Functions/IPAM/Aggregate/Get-NBIPAMAggregate.ps1
+++ b/Functions/IPAM/Aggregate/Get-NBIPAMAggregate.ps1
@@ -49,7 +49,14 @@
 .PARAMETER Date_Added
     Filter by date added.
 
-.PARAMETER Limit
+.PARAMETER Tag
+        Filter by tag slug(s). Several values are combined with AND (object must carry all of them);
+        use Set-NBQueryOption -TagMatch Any (Netbox 4.6.6+) for OR semantics.
+
+    .PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
+    .PARAMETER Limit
     Maximum number of results to return per request (1-1000).
 
 .PARAMETER Offset
@@ -101,6 +108,12 @@ function Get-NBIPAMAggregate {
 
         [Parameter(ParameterSetName = 'Query')]
         [datetime]$Date_Added,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tag_Id,
 
         [ValidateRange(1, 1000)]
         [uint16]$Limit,

--- a/Functions/IPAM/FHRPGroup/Get-NBIPAMFHRPGroup.ps1
+++ b/Functions/IPAM/FHRPGroup/Get-NBIPAMFHRPGroup.ps1
@@ -43,7 +43,14 @@
 .PARAMETER Query
     Free-text search across the object (NetBox 'q' parameter).
 
-.PARAMETER Limit
+.PARAMETER Tag
+        Filter by tag slug(s). Several values are combined with AND (object must carry all of them);
+        use Set-NBQueryOption -TagMatch Any (Netbox 4.6.6+) for OR semantics.
+
+    .PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
+    .PARAMETER Limit
     Maximum number of results to return per request (1-1000).
 
 .PARAMETER Offset
@@ -78,6 +85,12 @@ function Get-NBIPAMFHRPGroup {
         [Parameter(ParameterSetName = 'Query')][string]$Protocol,
         [Parameter(ParameterSetName = 'Query')][uint16]$Group_Id,
         [Parameter(ParameterSetName = 'Query')][string]$Query,
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tag_Id,
+
         [ValidateRange(1, 1000)]
         [uint16]$Limit,
         [ValidateRange(0, [int]::MaxValue)]

--- a/Functions/IPAM/Prefix/Get-NBIPAMPrefix.ps1
+++ b/Functions/IPAM/Prefix/Get-NBIPAMPrefix.ps1
@@ -14,6 +14,13 @@ function Get-NBIPAMPrefix {
     .PARAMETER Id
         Database ID of the prefix.
 
+    .PARAMETER Tag
+        Filter by tag slug(s). Several values are combined with AND (object must carry all of them);
+        use Set-NBQueryOption -TagMatch Any (Netbox 4.6.6+) for OR semantics.
+
+    .PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
     .PARAMETER Limit
         Maximum number of results to return (1-1000).
 
@@ -188,6 +195,12 @@ function Get-NBIPAMPrefix {
 
         [Parameter(ParameterSetName = 'Query')]
         [uint64]$Role_Id,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tag_Id,
 
         [ValidateRange(1, 1000)]
         [uint16]$Limit,

--- a/Functions/IPAM/Prefix/New-NBIPAMPrefix.ps1
+++ b/Functions/IPAM/Prefix/New-NBIPAMPrefix.ps1
@@ -56,6 +56,10 @@
     Number of prefixes to create per API request in bulk mode.
     Default: 50, Range: 1-1000
 
+.PARAMETER Background
+    Netbox 4.7+: queue each bulk batch as a background job (?background=true) instead of processing it
+    synchronously; the returned items are the job objects (check them with Get-NBJob). Ignored with a
+    warning on older Netbox versions. Only meaningful together with -BatchSize pipeline input.
 .PARAMETER Force
     Skip confirmation prompts for bulk operations.
 
@@ -149,6 +153,8 @@ function New-NBIPAMPrefix {
         [ValidateRange(1, 1000)]
         [int]$BatchSize = 100,
 
+        [switch]$Background,
+
         [Parameter(ParameterSetName = 'Bulk')]
         [switch]$Force,
 
@@ -219,6 +225,7 @@ function New-NBIPAMPrefix {
             if ($Force -or $PSCmdlet.ShouldProcess($target, 'Create prefixes (bulk)')) {
                 Write-Verbose "Processing $($bulkItems.Count) prefixes in bulk mode with batch size $BatchSize"
 
+                $useBackground = $Background -and -not (Test-NBMinimumVersion -ParameterName 'Background' -MinimumVersion '4.7.0' -BoundParameters $PSBoundParameters -FeatureName 'Background bulk processing (-Background)')
                 $bulkParams = @{
                     URI          = $URI
                     Items        = $bulkItems.ToArray()
@@ -226,6 +233,7 @@ function New-NBIPAMPrefix {
                     BatchSize    = $BatchSize
                     ShowProgress = $true
                     ActivityName = 'Creating prefixes'
+                    Background   = $useBackground
                 }
                 $result = Send-NBBulkRequest @bulkParams
 

--- a/Functions/IPAM/RIR/Get-NBIPAMRIR.ps1
+++ b/Functions/IPAM/RIR/Get-NBIPAMRIR.ps1
@@ -43,7 +43,14 @@
 .PARAMETER Is_Private
     IP space managed by this RIR is considered private
 
-.PARAMETER Limit
+.PARAMETER Tag
+        Filter by tag slug(s). Several values are combined with AND (object must carry all of them);
+        use Set-NBQueryOption -TagMatch Any (Netbox 4.6.6+) for OR semantics.
+
+    .PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
+    .PARAMETER Limit
     Maximum number of results to return per request (1-1000).
 
 .PARAMETER Offset
@@ -78,6 +85,12 @@ function Get-NBIPAMRIR {
         [Parameter(ParameterSetName = 'Query')][string]$Slug,
         [Parameter(ParameterSetName = 'Query')][string]$Query,
         [Parameter(ParameterSetName = 'Query')][bool]$Is_Private,
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tag_Id,
+
         [ValidateRange(1, 1000)]
         [uint16]$Limit,
         [ValidateRange(0, [int]::MaxValue)]

--- a/Functions/IPAM/Range/Get-NBIPAMAddressRange.ps1
+++ b/Functions/IPAM/Range/Get-NBIPAMAddressRange.ps1
@@ -67,7 +67,14 @@
 .PARAMETER Mark_Populated
     Prevent the creation of IP addresses within this range
 
-.PARAMETER Limit
+.PARAMETER Tag
+        Filter by tag slug(s). Several values are combined with AND (object must carry all of them);
+        use Set-NBQueryOption -TagMatch Any (Netbox 4.6.6+) for OR semantics.
+
+    .PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
+    .PARAMETER Limit
     Maximum number of results to return per request (1-1000).
 
 .PARAMETER Offset
@@ -139,6 +146,12 @@ function Get-NBIPAMAddressRange {
 
         [Parameter(ParameterSetName = 'Query')]
         [bool]$Mark_Populated,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tag_Id,
 
         [ValidateRange(1, 1000)]
         [uint16]$Limit,

--- a/Functions/IPAM/Role/Get-NBIPAMRole.ps1
+++ b/Functions/IPAM/Role/Get-NBIPAMRole.ps1
@@ -22,6 +22,13 @@ function Get-NBIPAMRole {
     .PARAMETER Brief
         Brief format
 
+    .PARAMETER Tag
+        Filter by tag slug(s). Several values are combined with AND (object must carry all of them);
+        use Set-NBQueryOption -TagMatch Any (Netbox 4.6.6+) for OR semantics.
+
+    .PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
     .PARAMETER Limit
         Result limit
 
@@ -82,6 +89,12 @@ function Get-NBIPAMRole {
 
         [Parameter(ParameterSetName = 'Query')]
         [string]$Slug,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tag_Id,
 
         [ValidateRange(1, 1000)]
         [uint16]$Limit,

--- a/Functions/IPAM/RouteTarget/Get-NBIPAMRouteTarget.ps1
+++ b/Functions/IPAM/RouteTarget/Get-NBIPAMRouteTarget.ps1
@@ -28,6 +28,13 @@ function Get-NBIPAMRouteTarget {
     .PARAMETER Exporting_VRF_Id
         Filter by VRF ID that exports this target
 
+    .PARAMETER Tag
+        Filter by tag slug(s). Several values are combined with AND (object must carry all of them);
+        use Set-NBQueryOption -TagMatch Any (Netbox 4.6.6+) for OR semantics.
+
+    .PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
     .PARAMETER Limit
         Limit the number of results
 
@@ -107,6 +114,12 @@ function Get-NBIPAMRouteTarget {
 
         [Parameter(ParameterSetName = 'Query')]
         [uint64]$Exporting_VRF_Id,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tag_Id,
 
         [ValidateRange(1, 1000)]
         [uint16]$Limit,

--- a/Functions/IPAM/Service/Get-NBIPAMService.ps1
+++ b/Functions/IPAM/Service/Get-NBIPAMService.ps1
@@ -32,6 +32,13 @@ function Get-NBIPAMService {
     .PARAMETER Virtual_Machine_Id
         Filter by virtual machine ID
 
+    .PARAMETER Tag
+        Filter by tag slug(s). Several values are combined with AND (object must carry all of them);
+        use Set-NBQueryOption -TagMatch Any (Netbox 4.6.6+) for OR semantics.
+
+    .PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
     .PARAMETER Limit
         Limit the number of results
 
@@ -115,6 +122,12 @@ function Get-NBIPAMService {
 
         [Parameter(ParameterSetName = 'Query')]
         [uint64]$Virtual_Machine_Id,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tag_Id,
 
         [ValidateRange(1, 1000)]
         [uint16]$Limit,

--- a/Functions/IPAM/Service/New-NBIPAMService.ps1
+++ b/Functions/IPAM/Service/New-NBIPAMService.ps1
@@ -133,7 +133,7 @@ function New-NBIPAMService {
         if ($Description) { $Body['description'] = $Description }
         if ($Comments) { $Body['comments'] = $Comments }
         if ($Custom_Fields) { $Body['custom_fields'] = $Custom_Fields }
-        if ($Tags) { $Body['tags'] = $Tags }
+        if ($Tags) { $Body['tags'] = ConvertToNBTagReference -Tags $Tags }
 
         $URI = BuildNewURI -Segments $Segments
 

--- a/Functions/IPAM/ServiceTemplate/Get-NBIPAMServiceTemplate.ps1
+++ b/Functions/IPAM/ServiceTemplate/Get-NBIPAMServiceTemplate.ps1
@@ -26,6 +26,13 @@ function Get-NBIPAMServiceTemplate {
     .PARAMETER Port
         Filter by port number
 
+    .PARAMETER Tag
+        Filter by tag slug(s). Several values are combined with AND (object must carry all of them);
+        use Set-NBQueryOption -TagMatch Any (Netbox 4.6.6+) for OR semantics.
+
+    .PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
     .PARAMETER Limit
         Limit the number of results
 
@@ -103,6 +110,12 @@ function Get-NBIPAMServiceTemplate {
 
         [Parameter(ParameterSetName = 'Query')]
         [string[]]$Port_Mappings,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tag_Id,
 
         [ValidateRange(1, 1000)]
         [uint16]$Limit,

--- a/Functions/IPAM/VLAN/Get-NBIPAMVLAN.ps1
+++ b/Functions/IPAM/VLAN/Get-NBIPAMVLAN.ps1
@@ -76,7 +76,14 @@
 .PARAMETER Role_Id
     Filter by role database ID.
 
-.PARAMETER Limit
+.PARAMETER Tag
+        Filter by tag slug(s). Several values are combined with AND (object must carry all of them);
+        use Set-NBQueryOption -TagMatch Any (Netbox 4.6.6+) for OR semantics.
+
+    .PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
+    .PARAMETER Limit
     Maximum number of results to return per request (1-1000).
 
 .PARAMETER Offset
@@ -157,6 +164,12 @@ function Get-NBIPAMVLAN {
 
         [Parameter(ParameterSetName = 'Query')]
         [uint64]$Role_Id,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tag_Id,
 
         [ValidateRange(1, 1000)]
         [uint16]$Limit,

--- a/Functions/IPAM/VLAN/New-NBIPAMVLAN.ps1
+++ b/Functions/IPAM/VLAN/New-NBIPAMVLAN.ps1
@@ -48,6 +48,10 @@
     Number of VLANs to create per API request in bulk mode.
     Default: 50, Range: 1-1000
 
+.PARAMETER Background
+    Netbox 4.7+: queue each bulk batch as a background job (?background=true) instead of processing it
+    synchronously; the returned items are the job objects (check them with Get-NBJob). Ignored with a
+    warning on older Netbox versions. Only meaningful together with -BatchSize pipeline input.
 .PARAMETER Force
     Skip confirmation prompts for bulk operations.
 
@@ -130,6 +134,8 @@ function New-NBIPAMVLAN {
         [ValidateRange(1, 1000)]
         [int]$BatchSize = 100,
 
+        [switch]$Background,
+
         [Parameter(ParameterSetName = 'Bulk')]
         [switch]$Force,
 
@@ -188,6 +194,7 @@ function New-NBIPAMVLAN {
             if ($Force -or $PSCmdlet.ShouldProcess($target, 'Create VLANs (bulk)')) {
                 Write-Verbose "Processing $($bulkItems.Count) VLANs in bulk mode with batch size $BatchSize"
 
+                $useBackground = $Background -and -not (Test-NBMinimumVersion -ParameterName 'Background' -MinimumVersion '4.7.0' -BoundParameters $PSBoundParameters -FeatureName 'Background bulk processing (-Background)')
                 $bulkParams = @{
                     URI          = $URI
                     Items        = $bulkItems.ToArray()
@@ -195,6 +202,7 @@ function New-NBIPAMVLAN {
                     BatchSize    = $BatchSize
                     ShowProgress = $true
                     ActivityName = 'Creating VLANs'
+                    Background   = $useBackground
                 }
                 $result = Send-NBBulkRequest @bulkParams
 

--- a/Functions/IPAM/VLANGroup/Get-NBIPAMVLANGroup.ps1
+++ b/Functions/IPAM/VLANGroup/Get-NBIPAMVLANGroup.ps1
@@ -52,7 +52,14 @@
 .PARAMETER Rack_Id
     Filter by rack database ID.
 
-.PARAMETER Limit
+.PARAMETER Tag
+        Filter by tag slug(s). Several values are combined with AND (object must carry all of them);
+        use Set-NBQueryOption -TagMatch Any (Netbox 4.6.6+) for OR semantics.
+
+    .PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
+    .PARAMETER Limit
     Maximum number of results to return per request (1-1000).
 
 .PARAMETER Offset
@@ -90,6 +97,12 @@ function Get-NBIPAMVLANGroup {
         [Parameter(ParameterSetName = 'Query')][string]$Site,
         [Parameter(ParameterSetName = 'Query')][uint64]$Location_Id,
         [Parameter(ParameterSetName = 'Query')][uint64]$Rack_Id,
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tag_Id,
+
         [ValidateRange(1, 1000)]
         [uint16]$Limit,
         [ValidateRange(0, [int]::MaxValue)]

--- a/Functions/IPAM/VLANTranslationPolicy/Get-NBIPAMVLANTranslationPolicy.ps1
+++ b/Functions/IPAM/VLANTranslationPolicy/Get-NBIPAMVLANTranslationPolicy.ps1
@@ -37,7 +37,14 @@
 .PARAMETER Query
     Free-text search across the object (NetBox 'q' parameter).
 
-.PARAMETER Limit
+.PARAMETER Tag
+        Filter by tag slug(s). Several values are combined with AND (object must carry all of them);
+        use Set-NBQueryOption -TagMatch Any (Netbox 4.6.6+) for OR semantics.
+
+    .PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
+    .PARAMETER Limit
     Maximum number of results to return per request (1-1000).
 
 .PARAMETER Offset
@@ -70,6 +77,12 @@ function Get-NBIPAMVLANTranslationPolicy {
         [Parameter(ParameterSetName = 'ByID', ValueFromPipelineByPropertyName = $true)][uint64[]]$Id,
         [Parameter(ParameterSetName = 'Query')][string]$Name,
         [Parameter(ParameterSetName = 'Query')][string]$Query,
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tag_Id,
+
         [ValidateRange(1, 1000)]
         [uint16]$Limit,
         [ValidateRange(0, [int]::MaxValue)]

--- a/Functions/IPAM/VLANTranslationRule/Get-NBIPAMVLANTranslationRule.ps1
+++ b/Functions/IPAM/VLANTranslationRule/Get-NBIPAMVLANTranslationRule.ps1
@@ -40,7 +40,14 @@
 .PARAMETER Remote_Vid
     Numeric VLAN ID (1-4094)
 
-.PARAMETER Limit
+.PARAMETER Tag
+        Filter by tag slug(s). Several values are combined with AND (object must carry all of them);
+        use Set-NBQueryOption -TagMatch Any (Netbox 4.6.6+) for OR semantics.
+
+    .PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
+    .PARAMETER Limit
     Maximum number of results to return per request (1-1000).
 
 .PARAMETER Offset
@@ -74,6 +81,12 @@ function Get-NBIPAMVLANTranslationRule {
         [Parameter(ParameterSetName = 'Query')][uint64]$Policy_Id,
         [Parameter(ParameterSetName = 'Query')][uint64]$Local_Vid,
         [Parameter(ParameterSetName = 'Query')][uint64]$Remote_Vid,
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tag_Id,
+
         [ValidateRange(1, 1000)]
         [uint16]$Limit,
         [ValidateRange(0, [int]::MaxValue)]

--- a/Functions/IPAM/VRF/Get-NBIPAMVRF.ps1
+++ b/Functions/IPAM/VRF/Get-NBIPAMVRF.ps1
@@ -27,6 +27,13 @@ function Get-NBIPAMVRF {
     .PARAMETER Enforce_Unique
         Filter by enforce unique flag
 
+    .PARAMETER Tag
+        Filter by tag slug(s). Several values are combined with AND (object must carry all of them);
+        use Set-NBQueryOption -TagMatch Any (Netbox 4.6.6+) for OR semantics.
+
+    .PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
     .PARAMETER Limit
         Limit the number of results
 
@@ -111,6 +118,12 @@ function Get-NBIPAMVRF {
 
         [Parameter(ParameterSetName = 'Query')]
         [bool]$Enforce_Unique,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tag_Id,
 
         [ValidateRange(1, 1000)]
         [uint16]$Limit,

--- a/Functions/Setup/Get-NBQueryOption.ps1
+++ b/Functions/Setup/Get-NBQueryOption.ps1
@@ -31,4 +31,16 @@ function Get-NBQueryOption {
         Name = "MatchMode"
         Value = $script:NetboxConfig.MatchMode
     }
+    [PSCustomObject]@{
+        Name = "Pagination"
+        Value = $script:NetboxConfig.Pagination
+    }
+    [PSCustomObject]@{
+        Name = "TagMatch"
+        Value = $script:NetboxConfig.TagMatch
+    }
+    [PSCustomObject]@{
+        Name = "OptimisticConcurrency"
+        Value = [bool]$script:NetboxConfig.OptimisticConcurrency
+    }
 }

--- a/Functions/Setup/Set-NBQueryOption.ps1
+++ b/Functions/Setup/Set-NBQueryOption.ps1
@@ -14,6 +14,26 @@
     - Wildcard: Query parameters will be treated as Powershell wildcards.
     - Regex: Query parameters will be treated as regular expressions (Netbox's `regex`).
 
+.PARAMETER Pagination
+    How -All walks large result sets. 'Offset' (default) uses limit/offset pages exactly as before.
+    'Cursor' uses Netbox 4.6+ cursor pagination (?start=<pk>, results ordered by primary key), which
+    stays fast on very large tables where offset paging degrades. Requires Netbox 4.6+; on older
+    servers offset paging is used automatically. Explicit -Offset on a Get cmdlet always wins.
+
+.PARAMETER TagMatch
+    How multiple values of a -Tag / -Tag_Id filter combine. 'All' (default) is Netbox's native
+    behaviour: an object must carry every listed tag. 'Any' sends Netbox 4.6.6+ 'tag__any' /
+    'tag_id__any' so an object matches when it carries at least one of them. Below Netbox 4.6.6 the
+    option is ignored (plain 'tag' is sent) because an unknown lookup would silently return every object.
+
+.PARAMETER OptimisticConcurrency
+    Netbox 4.6+ returns an ETag on single-object GETs and honours If-Match on PATCH/PUT/DELETE
+    (HTTP 412 when the object changed in between). When enabled, the module remembers the ETag of
+    every object it reads and sends it as If-Match on the next update or delete of that same object,
+    so concurrent edits fail loudly instead of silently overwriting each other. Needs PowerShell 7+
+    (response headers are not exposed on Windows PowerShell 5.1). Use -OptimisticConcurrency:$false
+    to disable; disabling also clears the cached ETags.
+
 .EXAMPLE
     Set-NBQueryOption -IgnoreCase
     Sets the Netbox API query parameters to be case-insensitive.
@@ -25,6 +45,22 @@
 .EXAMPLE
     Set-NBQueryOption -MatchMode 'Wildcard'
     Sets the Netbox API query parameters to be treated as Powershell wildcards.
+
+.EXAMPLE
+    Set-NBQueryOption -Pagination Cursor
+    Get-NBIPAMAddress -All
+    Walks the whole IP address table with cursor pagination (Netbox 4.6+).
+
+.EXAMPLE
+    Set-NBQueryOption -TagMatch Any
+    Get-NBDCIMDevice -Tag 'edge', 'core'
+    Returns devices tagged 'edge' OR 'core' (Netbox 4.6.6+); with the default 'All' both tags are required.
+
+.EXAMPLE
+    Set-NBQueryOption -OptimisticConcurrency
+    $dev = Get-NBDCIMDevice -Id 42
+    Set-NBDCIMDevice -Id 42 -Description 'changed'
+    The PATCH carries If-Match with the ETag from the GET; it fails with HTTP 412 if someone else changed device 42 in between.
 
 .LINK
     https://netbox.readthedocs.io/en/stable/rest-api/overview/
@@ -45,7 +81,18 @@ function Set-NBQueryOption {
 
         [Parameter(ParameterSetName = 'MatchMode', Mandatory = $true)]
         [ValidateSet('Exact', 'Wildcard', 'Regex')]
-        [string]$MatchMode = 'Exact'
+        [string]$MatchMode = 'Exact',
+
+        [Parameter(ParameterSetName = 'Pagination', Mandatory = $true)]
+        [ValidateSet('Offset', 'Cursor')]
+        [string]$Pagination,
+
+        [Parameter(ParameterSetName = 'TagMatch', Mandatory = $true)]
+        [ValidateSet('All', 'Any')]
+        [string]$TagMatch,
+
+        [Parameter(ParameterSetName = 'OptimisticConcurrency', Mandatory = $true)]
+        [switch]$OptimisticConcurrency
     )
 
     if ($PSCmdlet.ShouldProcess('Netbox Query Options', 'Set')) {
@@ -56,6 +103,33 @@ function Set-NBQueryOption {
             }
             'MatchMode' {
                 $script:NetboxConfig.MatchMode = $MatchMode
+            }
+            'Pagination' {
+                $script:NetboxConfig.Pagination = $Pagination
+                if ($Pagination -eq 'Cursor' -and $script:NetboxConfig.ParsedVersion -and $script:NetboxConfig.ParsedVersion -lt [version]'4.6.0') {
+                    Write-Warning "Cursor pagination requires Netbox 4.6.0 or higher (connected to $($script:NetboxConfig.ParsedVersion)). Offset pagination will be used until you connect to a newer server."
+                }
+                Write-Verbose "Set Pagination to $Pagination"
+                return $script:NetboxConfig.Pagination
+            }
+            'TagMatch' {
+                $script:NetboxConfig.TagMatch = $TagMatch
+                if ($TagMatch -eq 'Any' -and $script:NetboxConfig.ParsedVersion -and $script:NetboxConfig.ParsedVersion -lt [version]'4.6.6') {
+                    Write-Warning "TagMatch 'Any' requires Netbox 4.6.6 or higher (connected to $($script:NetboxConfig.ParsedVersion)). Tag filters keep the default all-tags semantics until you connect to a newer server."
+                }
+                Write-Verbose "Set TagMatch to $TagMatch"
+                return $script:NetboxConfig.TagMatch
+            }
+            'OptimisticConcurrency' {
+                $script:NetboxConfig.OptimisticConcurrency = [bool]$OptimisticConcurrency
+                if (-not $OptimisticConcurrency) {
+                    $script:NetboxConfig.ETagCache = @{}
+                }
+                elseif ($script:NetboxConfig.ParsedVersion -and $script:NetboxConfig.ParsedVersion -lt [version]'4.6.0') {
+                    Write-Warning "Optimistic concurrency (ETag/If-Match) requires Netbox 4.6.0 or higher (connected to $($script:NetboxConfig.ParsedVersion)). Older servers send no ETag, so updates are sent without If-Match."
+                }
+                Write-Verbose "Set OptimisticConcurrency to $($script:NetboxConfig.OptimisticConcurrency)"
+                return $script:NetboxConfig.OptimisticConcurrency
             }
         }
 

--- a/Functions/Setup/Support/SetupNetboxConfigVariable.ps1
+++ b/Functions/Setup/Support/SetupNetboxConfigVariable.ps1
@@ -21,6 +21,10 @@ function SetupNetboxConfigVariable {
             'BranchStack'   = [System.Collections.Generic.Stack[object]]::new()
             'IgnoreCaseInQueries' = $false
             'MatchMode'     = 'Exact'
+            'Pagination'    = 'Offset'      # Set-NBQueryOption -Pagination Offset|Cursor (Netbox 4.6+ ?start=)
+            'TagMatch'      = 'All'         # Set-NBQueryOption -TagMatch All|Any   (Netbox 4.6.6+ tag__any)
+            'OptimisticConcurrency' = $false  # Set-NBQueryOption -OptimisticConcurrency (Netbox 4.6+ ETag/If-Match)
+            'ETagCache'     = @{}           # object URL -> last seen ETag (only used with OptimisticConcurrency)
         }
     }
     else {

--- a/Functions/Tenancy/ContactAssignment/Get-NBContactAssignment.ps1
+++ b/Functions/Tenancy/ContactAssignment/Get-NBContactAssignment.ps1
@@ -29,6 +29,13 @@ function Get-NBContactAssignment {
     .PARAMETER Role_Id
         Filter by contact role database ID.
 
+    .PARAMETER Tag
+        Filter by tag slug(s). Several values are combined with AND (object must carry all of them);
+        use Set-NBQueryOption -TagMatch Any (Netbox 4.6.6+) for OR semantics.
+
+    .PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
     .PARAMETER Limit
         Limit the number of results to this number
 
@@ -104,6 +111,12 @@ function Get-NBContactAssignment {
 
         [Parameter(ParameterSetName = 'Query')]
         [uint64[]]$Role_Id,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tag_Id,
 
         [ValidateRange(1, 1000)]
         [uint16]$Limit,

--- a/Functions/Tenancy/ContactGroups/Get-NBContactGroup.ps1
+++ b/Functions/Tenancy/ContactGroups/Get-NBContactGroup.ps1
@@ -46,6 +46,13 @@ function Get-NBContactGroup {
         Number of items per page when using -All. Default: 100.
         Range: 1-1000.
 
+    .PARAMETER Tag
+        Filter by tag slug(s). Several values are combined with AND (object must carry all of them);
+        use Set-NBQueryOption -TagMatch Any (Netbox 4.6.6+) for OR semantics.
+
+    .PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
     .PARAMETER Limit
         Limit the number of results to this number
 
@@ -86,6 +93,12 @@ function Get-NBContactGroup {
 
         [ValidateRange(1, 1000)]
         [int]$PageSize = 100,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tag_Id,
 
         [ValidateRange(1, 1000)]
         [uint16]$Limit,

--- a/Functions/Tenancy/ContactRoles/Get-NBContactRole.ps1
+++ b/Functions/Tenancy/ContactRoles/Get-NBContactRole.ps1
@@ -23,6 +23,13 @@ function Get-NBContactRole {
     .PARAMETER Description
         Filter by description field (supports partial matches)
 
+    .PARAMETER Tag
+        Filter by tag slug(s). Several values are combined with AND (object must carry all of them);
+        use Set-NBQueryOption -TagMatch Any (Netbox 4.6.6+) for OR semantics.
+
+    .PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
     .PARAMETER Limit
         Limit the number of results to this number
 
@@ -92,6 +99,12 @@ function Get-NBContactRole {
 
         [Parameter(ParameterSetName = 'Query')]
         [string[]]$Description,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tag_Id,
 
         [ValidateRange(1, 1000)]
         [uint16]$Limit,

--- a/Functions/Tenancy/Contacts/Get-NBContact.ps1
+++ b/Functions/Tenancy/Contacts/Get-NBContact.ps1
@@ -34,6 +34,13 @@ function Get-NBContact {
     .PARAMETER Group_ID
         A database ID of the group in Netbox which contacts should be filtered by. Alias: -GroupId for backwards compatibility.
 
+    .PARAMETER Tag
+        Filter by tag slug(s). Several values are combined with AND (object must carry all of them);
+        use Set-NBQueryOption -TagMatch Any (Netbox 4.6.6+) for OR semantics.
+
+    .PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
     .PARAMETER Limit
         Limit the number of results to this number
 
@@ -115,6 +122,12 @@ function Get-NBContact {
         [Parameter(ParameterSetName = 'Query')]
         [Alias('GroupId')]
         [uint64[]]$Group_Id,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tag_Id,
 
         [ValidateRange(1, 1000)]
         [uint16]$Limit,

--- a/Functions/Tenancy/TenantGroups/Get-NBTenantGroup.ps1
+++ b/Functions/Tenancy/TenantGroups/Get-NBTenantGroup.ps1
@@ -24,7 +24,14 @@
 .PARAMETER Query
     General search query.
 
-.PARAMETER Limit
+.PARAMETER Tag
+        Filter by tag slug(s). Several values are combined with AND (object must carry all of them);
+        use Set-NBQueryOption -TagMatch Any (Netbox 4.6.6+) for OR semantics.
+
+    .PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
+    .PARAMETER Limit
     Maximum number of results to return (1-1000).
 
 .PARAMETER Offset
@@ -108,6 +115,12 @@ function Get-NBTenantGroup {
         [Parameter(ParameterSetName = 'Query')]
         [Alias('q')]
         [string]$Query,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tag_Id,
 
         [ValidateRange(1, 1000)]
         [uint16]$Limit,

--- a/Functions/Tenancy/Tenants/Get-NBTenant.ps1
+++ b/Functions/Tenancy/Tenants/Get-NBTenant.ps1
@@ -29,6 +29,13 @@ function Get-NBTenant {
     .PARAMETER Custom_Fields
         Hashtable in the format @{"field_name" = "value"} to search
 
+    .PARAMETER Tag
+        Filter by tag slug(s). Several values are combined with AND (object must carry all of them);
+        use Set-NBQueryOption -TagMatch Any (Netbox 4.6.6+) for OR semantics.
+
+    .PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
     .PARAMETER Limit
         Limit the number of results to this number
 
@@ -103,6 +110,12 @@ function Get-NBTenant {
 
         [Parameter(ParameterSetName = 'Query')]
         [hashtable]$Custom_Fields,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tag_Id,
 
         [ValidateRange(1, 1000)]
         [uint16]$Limit,

--- a/Functions/VPN/IKEPolicy/Get-NBVPNIKEPolicy.ps1
+++ b/Functions/VPN/IKEPolicy/Get-NBVPNIKEPolicy.ps1
@@ -34,7 +34,14 @@
 .PARAMETER Name
     Filter by name.
 
-.PARAMETER Limit
+.PARAMETER Tag
+        Filter by tag slug(s). Several values are combined with AND (object must carry all of them);
+        use Set-NBQueryOption -TagMatch Any (Netbox 4.6.6+) for OR semantics.
+
+    .PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
+    .PARAMETER Limit
     Maximum number of results to return per request (1-1000).
 
 .PARAMETER Offset
@@ -69,6 +76,12 @@ function Get-NBVPNIKEPolicy {
 
         [Parameter(ParameterSetName = 'Query')]
         [string]$Name,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tag_Id,
 
         [ValidateRange(1, 1000)]
         [uint16]$Limit,

--- a/Functions/VPN/IKEProposal/Get-NBVPNIKEProposal.ps1
+++ b/Functions/VPN/IKEProposal/Get-NBVPNIKEProposal.ps1
@@ -34,7 +34,14 @@
 .PARAMETER Name
     Filter by name.
 
-.PARAMETER Limit
+.PARAMETER Tag
+        Filter by tag slug(s). Several values are combined with AND (object must carry all of them);
+        use Set-NBQueryOption -TagMatch Any (Netbox 4.6.6+) for OR semantics.
+
+    .PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
+    .PARAMETER Limit
     Maximum number of results to return per request (1-1000).
 
 .PARAMETER Offset
@@ -69,6 +76,12 @@ function Get-NBVPNIKEProposal {
 
         [Parameter(ParameterSetName = 'Query')]
         [string]$Name,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tag_Id,
 
         [ValidateRange(1, 1000)]
         [uint16]$Limit,

--- a/Functions/VPN/IPSecPolicy/Get-NBVPNIPSecPolicy.ps1
+++ b/Functions/VPN/IPSecPolicy/Get-NBVPNIPSecPolicy.ps1
@@ -34,7 +34,14 @@
 .PARAMETER Name
     Filter by name.
 
-.PARAMETER Limit
+.PARAMETER Tag
+        Filter by tag slug(s). Several values are combined with AND (object must carry all of them);
+        use Set-NBQueryOption -TagMatch Any (Netbox 4.6.6+) for OR semantics.
+
+    .PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
+    .PARAMETER Limit
     Maximum number of results to return per request (1-1000).
 
 .PARAMETER Offset
@@ -69,6 +76,12 @@ function Get-NBVPNIPSecPolicy {
 
         [Parameter(ParameterSetName = 'Query')]
         [string]$Name,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tag_Id,
 
         [ValidateRange(1, 1000)]
         [uint16]$Limit,

--- a/Functions/VPN/IPSecProfile/Get-NBVPNIPSecProfile.ps1
+++ b/Functions/VPN/IPSecProfile/Get-NBVPNIPSecProfile.ps1
@@ -34,7 +34,14 @@
 .PARAMETER Name
     Filter by name.
 
-.PARAMETER Limit
+.PARAMETER Tag
+        Filter by tag slug(s). Several values are combined with AND (object must carry all of them);
+        use Set-NBQueryOption -TagMatch Any (Netbox 4.6.6+) for OR semantics.
+
+    .PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
+    .PARAMETER Limit
     Maximum number of results to return per request (1-1000).
 
 .PARAMETER Offset
@@ -69,6 +76,12 @@ function Get-NBVPNIPSecProfile {
 
         [Parameter(ParameterSetName = 'Query')]
         [string]$Name,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tag_Id,
 
         [ValidateRange(1, 1000)]
         [uint16]$Limit,

--- a/Functions/VPN/IPSecProposal/Get-NBVPNIPSecProposal.ps1
+++ b/Functions/VPN/IPSecProposal/Get-NBVPNIPSecProposal.ps1
@@ -34,7 +34,14 @@
 .PARAMETER Name
     Filter by name.
 
-.PARAMETER Limit
+.PARAMETER Tag
+        Filter by tag slug(s). Several values are combined with AND (object must carry all of them);
+        use Set-NBQueryOption -TagMatch Any (Netbox 4.6.6+) for OR semantics.
+
+    .PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
+    .PARAMETER Limit
     Maximum number of results to return per request (1-1000).
 
 .PARAMETER Offset
@@ -69,6 +76,12 @@ function Get-NBVPNIPSecProposal {
 
         [Parameter(ParameterSetName = 'Query')]
         [string]$Name,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tag_Id,
 
         [ValidateRange(1, 1000)]
         [uint16]$Limit,

--- a/Functions/VPN/L2VPN/Get-NBVPNL2VPN.ps1
+++ b/Functions/VPN/L2VPN/Get-NBVPNL2VPN.ps1
@@ -43,7 +43,14 @@
 .PARAMETER Tenant_Id
     Filter by tenant database ID.
 
-.PARAMETER Limit
+.PARAMETER Tag
+        Filter by tag slug(s). Several values are combined with AND (object must carry all of them);
+        use Set-NBQueryOption -TagMatch Any (Netbox 4.6.6+) for OR semantics.
+
+    .PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
+    .PARAMETER Limit
     Maximum number of results to return per request (1-1000).
 
 .PARAMETER Offset
@@ -87,6 +94,12 @@ function Get-NBVPNL2VPN {
 
         [Parameter(ParameterSetName = 'Query')]
         [uint64]$Tenant_Id,
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tag_Id,
+
 
         [ValidateRange(1, 1000)]
         [uint16]$Limit,

--- a/Functions/VPN/L2VPNTermination/Get-NBVPNL2VPNTermination.ps1
+++ b/Functions/VPN/L2VPNTermination/Get-NBVPNL2VPNTermination.ps1
@@ -34,7 +34,14 @@
 .PARAMETER L2VPN_Id
     Filter by l2vpn database ID.
 
-.PARAMETER Limit
+.PARAMETER Tag
+        Filter by tag slug(s). Several values are combined with AND (object must carry all of them);
+        use Set-NBQueryOption -TagMatch Any (Netbox 4.6.6+) for OR semantics.
+
+    .PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
+    .PARAMETER Limit
     Maximum number of results to return per request (1-1000).
 
 .PARAMETER Offset
@@ -69,6 +76,12 @@ function Get-NBVPNL2VPNTermination {
 
         [Parameter(ParameterSetName = 'Query')]
         [uint64]$L2VPN_Id,
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tag_Id,
+
 
         [ValidateRange(1, 1000)]
         [uint16]$Limit,

--- a/Functions/VPN/Tunnel/Get-NBVPNTunnel.ps1
+++ b/Functions/VPN/Tunnel/Get-NBVPNTunnel.ps1
@@ -46,7 +46,14 @@
 .PARAMETER Encapsulation
     Filter by encapsulation.
 
-.PARAMETER Limit
+.PARAMETER Tag
+        Filter by tag slug(s). Several values are combined with AND (object must carry all of them);
+        use Set-NBQueryOption -TagMatch Any (Netbox 4.6.6+) for OR semantics.
+
+    .PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
+    .PARAMETER Limit
     Maximum number of results to return per request (1-1000).
 
 .PARAMETER Offset
@@ -84,6 +91,12 @@ function Get-NBVPNTunnel {
         [Parameter(ParameterSetName = 'Query')][string]$Status,
         [Parameter(ParameterSetName = 'Query')][uint64]$Group_Id,
         [Parameter(ParameterSetName = 'Query')][string]$Encapsulation,
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tag_Id,
+
         [ValidateRange(1, 1000)]
         [uint16]$Limit,
         [ValidateRange(0, [int]::MaxValue)]

--- a/Functions/VPN/TunnelGroup/Get-NBVPNTunnelGroup.ps1
+++ b/Functions/VPN/TunnelGroup/Get-NBVPNTunnelGroup.ps1
@@ -37,7 +37,14 @@
 .PARAMETER Slug
     Filter by URL slug.
 
-.PARAMETER Limit
+.PARAMETER Tag
+        Filter by tag slug(s). Several values are combined with AND (object must carry all of them);
+        use Set-NBQueryOption -TagMatch Any (Netbox 4.6.6+) for OR semantics.
+
+    .PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
+    .PARAMETER Limit
     Maximum number of results to return per request (1-1000).
 
 .PARAMETER Offset
@@ -75,6 +82,12 @@ function Get-NBVPNTunnelGroup {
 
         [Parameter(ParameterSetName = 'Query')]
         [string]$Slug,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tag_Id,
 
         [ValidateRange(1, 1000)]
         [uint16]$Limit,

--- a/Functions/VPN/TunnelTermination/Get-NBVPNTunnelTermination.ps1
+++ b/Functions/VPN/TunnelTermination/Get-NBVPNTunnelTermination.ps1
@@ -37,7 +37,14 @@
 .PARAMETER Role
     Filter by role (name or slug).
 
-.PARAMETER Limit
+.PARAMETER Tag
+        Filter by tag slug(s). Several values are combined with AND (object must carry all of them);
+        use Set-NBQueryOption -TagMatch Any (Netbox 4.6.6+) for OR semantics.
+
+    .PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
+    .PARAMETER Limit
     Maximum number of results to return per request (1-1000).
 
 .PARAMETER Offset
@@ -75,6 +82,12 @@ function Get-NBVPNTunnelTermination {
 
         [Parameter(ParameterSetName = 'Query')]
         [string]$Role,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tag_Id,
 
         [ValidateRange(1, 1000)]
         [uint16]$Limit,

--- a/Functions/Virtualization/VirtualDisk/Get-NBVirtualDisk.ps1
+++ b/Functions/Virtualization/VirtualDisk/Get-NBVirtualDisk.ps1
@@ -36,7 +36,14 @@
 .PARAMETER PageSize
     Page size to request while -All follows pagination.
 
-.PARAMETER Limit
+.PARAMETER Tag
+        Filter by tag slug(s). Several values are combined with AND (object must carry all of them);
+        use Set-NBQueryOption -TagMatch Any (Netbox 4.6.6+) for OR semantics.
+
+    .PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
+    .PARAMETER Limit
     Maximum number of results to return per request (1-1000).
 
 .PARAMETER Offset
@@ -73,6 +80,12 @@ function Get-NBVirtualDisk {
 
         [Parameter(ParameterSetName = 'Query')]
         [string]$Query,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tag_Id,
 
         [ValidateRange(1, 1000)]
         [uint16]$Limit,

--- a/Functions/Virtualization/VirtualMachine/Get-NBVirtualMachine.ps1
+++ b/Functions/Virtualization/VirtualMachine/Get-NBVirtualMachine.ps1
@@ -32,6 +32,13 @@ function Get-NBVirtualMachine {
         Include config_context in the response. By default, config_context is
         excluded for performance (can be 10-100x faster without it).
 
+    .PARAMETER Tag
+        Filter by tag slug(s). Several values are combined with AND (object must carry all of them);
+        use Set-NBQueryOption -TagMatch Any (Netbox 4.6.6+) for OR semantics.
+
+    .PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
     .PARAMETER Limit
         Number of results to return per page
 
@@ -217,6 +224,12 @@ function Get-NBVirtualMachine {
 
         [Parameter(ParameterSetName = 'Query')]
         [string[]]$Serial,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tag_Id,
 
         [ValidateRange(1, 1000)]
         [uint16]$Limit,

--- a/Functions/Virtualization/VirtualMachine/New-NBVirtualMachine.ps1
+++ b/Functions/Virtualization/VirtualMachine/New-NBVirtualMachine.ps1
@@ -77,6 +77,10 @@
     Number of VMs to create per API request in bulk mode.
     Default: 50, Range: 1-1000
 
+.PARAMETER Background
+    Netbox 4.7+: queue each bulk batch as a background job (?background=true) instead of processing it
+    synchronously; the returned items are the job objects (check them with Get-NBJob). Ignored with a
+    warning on older Netbox versions. Only meaningful together with -BatchSize pipeline input.
 .PARAMETER Force
     Skip confirmation prompts for bulk operations.
 
@@ -190,6 +194,8 @@ function New-NBVirtualMachine {
         [ValidateRange(1, 1000)]
         [int]$BatchSize = 100,
 
+        [switch]$Background,
+
         [Parameter(ParameterSetName = 'Bulk')]
         [switch]$Force,
 
@@ -245,6 +251,7 @@ function New-NBVirtualMachine {
             if ($Force -or $PSCmdlet.ShouldProcess($target, 'Create virtual machines (bulk)')) {
                 Write-Verbose "Processing $($bulkItems.Count) VMs in bulk mode with batch size $BatchSize"
 
+                $useBackground = $Background -and -not (Test-NBMinimumVersion -ParameterName 'Background' -MinimumVersion '4.7.0' -BoundParameters $PSBoundParameters -FeatureName 'Background bulk processing (-Background)')
                 $bulkParams = @{
                     URI          = $URI
                     Items        = $bulkItems.ToArray()
@@ -252,6 +259,7 @@ function New-NBVirtualMachine {
                     BatchSize    = $BatchSize
                     ShowProgress = $true
                     ActivityName = 'Creating virtual machines'
+                    Background   = $useBackground
                 }
                 $result = Send-NBBulkRequest @bulkParams
 

--- a/Functions/Virtualization/VirtualMachine/Remove-NBVirtualMachine.ps1
+++ b/Functions/Virtualization/VirtualMachine/Remove-NBVirtualMachine.ps1
@@ -19,6 +19,10 @@
     Number of VMs to delete per API request in bulk mode.
     Default: 50, Range: 1-1000
 
+.PARAMETER Background
+    Netbox 4.7+: queue each bulk batch as a background job (?background=true) instead of processing it
+    synchronously; the returned items are the job objects (check them with Get-NBJob). Ignored with a
+    warning on older Netbox versions. Only meaningful together with -BatchSize pipeline input.
 .PARAMETER Force
     Skip confirmation prompts.
 
@@ -70,6 +74,8 @@ function Remove-NBVirtualMachine {
         [Parameter(ParameterSetName = 'Bulk')]
         [ValidateRange(1, 1000)]
         [int]$BatchSize = 100,
+
+        [switch]$Background,
 
         # Common parameters
         [Parameter()]
@@ -126,6 +132,7 @@ function Remove-NBVirtualMachine {
             if ($Force -or $PSCmdlet.ShouldProcess($target, 'Delete virtual machines (bulk)')) {
                 Write-Verbose "Processing $($bulkItems.Count) VMs in bulk DELETE mode with batch size $BatchSize"
 
+                $useBackground = $Background -and -not (Test-NBMinimumVersion -ParameterName 'Background' -MinimumVersion '4.7.0' -BoundParameters $PSBoundParameters -FeatureName 'Background bulk processing (-Background)')
                 $bulkParams = @{
                     URI          = $URI
                     Items        = $bulkItems.ToArray()
@@ -133,6 +140,7 @@ function Remove-NBVirtualMachine {
                     BatchSize    = $BatchSize
                     ShowProgress = $true
                     ActivityName = 'Deleting virtual machines'
+                    Background   = $useBackground
                 }
                 $result = Send-NBBulkRequest @bulkParams
 

--- a/Functions/Virtualization/VirtualMachine/Set-NBVirtualMachine.ps1
+++ b/Functions/Virtualization/VirtualMachine/Set-NBVirtualMachine.ps1
@@ -74,6 +74,10 @@
     Number of VMs to update per API request in bulk mode.
     Default: 50, Range: 1-1000
 
+.PARAMETER Background
+    Netbox 4.7+: queue each bulk batch as a background job (?background=true) instead of processing it
+    synchronously; the returned items are the job objects (check them with Get-NBJob). Ignored with a
+    warning on older Netbox versions. Only meaningful together with -BatchSize pipeline input.
 .PARAMETER Force
     Skip confirmation prompts.
 
@@ -187,6 +191,8 @@ function Set-NBVirtualMachine {
         [ValidateRange(1, 1000)]
         [int]$BatchSize = 100,
 
+        [switch]$Background,
+
         # Common parameters
         [Parameter()]
         [switch]$Force,
@@ -251,6 +257,7 @@ function Set-NBVirtualMachine {
             if ($Force -or $PSCmdlet.ShouldProcess($target, 'Update virtual machines (bulk)')) {
                 Write-Verbose "Processing $($bulkItems.Count) VMs in bulk PATCH mode with batch size $BatchSize"
 
+                $useBackground = $Background -and -not (Test-NBMinimumVersion -ParameterName 'Background' -MinimumVersion '4.7.0' -BoundParameters $PSBoundParameters -FeatureName 'Background bulk processing (-Background)')
                 $bulkParams = @{
                     URI          = $URI
                     Items        = $bulkItems.ToArray()
@@ -258,6 +265,7 @@ function Set-NBVirtualMachine {
                     BatchSize    = $BatchSize
                     ShowProgress = $true
                     ActivityName = 'Updating virtual machines'
+                    Background   = $useBackground
                 }
                 $result = Send-NBBulkRequest @bulkParams
 

--- a/Functions/Virtualization/VirtualMachineInterface/Get-NBVirtualMachineInterface.ps1
+++ b/Functions/Virtualization/VirtualMachineInterface/Get-NBVirtualMachineInterface.ps1
@@ -7,6 +7,13 @@ function Get-NBVirtualMachineInterface {
     .DESCRIPTION
         Obtains the interface objects for one or more VMs
 
+    .PARAMETER Tag
+        Filter by tag slug(s). Several values are combined with AND (object must carry all of them);
+        use Set-NBQueryOption -TagMatch Any (Netbox 4.6.6+) for OR semantics.
+
+    .PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
     .PARAMETER Limit
         Number of results to return per page.
 
@@ -105,6 +112,12 @@ function Get-NBVirtualMachineInterface {
 
         [Parameter(ParameterSetName = 'Query')]
         [string]$MAC_Address,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tag_Id,
 
         [ValidateRange(1, 1000)]
         [uint16]$Limit,

--- a/Functions/Virtualization/VirtualMachineInterface/New-NBVirtualMachineInterface.ps1
+++ b/Functions/Virtualization/VirtualMachineInterface/New-NBVirtualMachineInterface.ps1
@@ -55,6 +55,10 @@
     Number of interfaces to create per API request in bulk mode.
     Default: 50, Range: 1-1000
 
+.PARAMETER Background
+    Netbox 4.7+: queue each bulk batch as a background job (?background=true) instead of processing it
+    synchronously; the returned items are the job objects (check them with Get-NBJob). Ignored with a
+    warning on older Netbox versions. Only meaningful together with -BatchSize pipeline input.
 .PARAMETER Force
     Skip confirmation prompts for bulk operations.
 
@@ -153,6 +157,8 @@ function New-NBVirtualMachineInterface {
         [ValidateRange(1, 1000)]
         [int]$BatchSize = 100,
 
+        [switch]$Background,
+
         [Parameter(ParameterSetName = 'Bulk')]
         [switch]$Force,
 
@@ -209,6 +215,7 @@ function New-NBVirtualMachineInterface {
             if ($Force -or $PSCmdlet.ShouldProcess($target, 'Create VM interfaces (bulk)')) {
                 Write-Verbose "Processing $($bulkItems.Count) VM interfaces in bulk mode with batch size $BatchSize"
 
+                $useBackground = $Background -and -not (Test-NBMinimumVersion -ParameterName 'Background' -MinimumVersion '4.7.0' -BoundParameters $PSBoundParameters -FeatureName 'Background bulk processing (-Background)')
                 $bulkParams = @{
                     URI          = $URI
                     Items        = $bulkItems.ToArray()
@@ -216,6 +223,7 @@ function New-NBVirtualMachineInterface {
                     BatchSize    = $BatchSize
                     ShowProgress = $true
                     ActivityName = 'Creating VM interfaces'
+                    Background   = $useBackground
                 }
                 $result = Send-NBBulkRequest @bulkParams
 

--- a/Functions/Virtualization/VirtualMachineType/Get-NBVirtualMachineType.ps1
+++ b/Functions/Virtualization/VirtualMachineType/Get-NBVirtualMachineType.ps1
@@ -37,7 +37,14 @@
 .PARAMETER PageSize
     Page size to request while -All follows pagination.
 
-.PARAMETER Limit
+.PARAMETER Tag
+        Filter by tag slug(s). Several values are combined with AND (object must carry all of them);
+        use Set-NBQueryOption -TagMatch Any (Netbox 4.6.6+) for OR semantics.
+
+    .PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
+    .PARAMETER Limit
     Maximum number of results to return per request (1-1000).
 
 .PARAMETER Offset
@@ -74,6 +81,12 @@ function Get-NBVirtualMachineType {
 
         [Parameter(ParameterSetName = 'Query')]
         [string]$Query,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tag_Id,
 
         [ValidateRange(1, 1000)]
         [uint16]$Limit,

--- a/Functions/Virtualization/VirtualizationCluster/Get-NBVirtualizationCluster.ps1
+++ b/Functions/Virtualization/VirtualizationCluster/Get-NBVirtualizationCluster.ps1
@@ -7,6 +7,13 @@ function Get-NBVirtualizationCluster {
     .DESCRIPTION
         Obtains one or more virtualization clusters based on provided filters.
 
+    .PARAMETER Tag
+        Filter by tag slug(s). Several values are combined with AND (object must carry all of them);
+        use Set-NBQueryOption -TagMatch Any (Netbox 4.6.6+) for OR semantics.
+
+    .PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
     .PARAMETER Limit
         Number of results to return per page
 
@@ -112,6 +119,12 @@ function Get-NBVirtualizationCluster {
 
         [Parameter(ParameterSetName = 'Query')]
         [uint64]$Site_Id,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tag_Id,
 
         [ValidateRange(1, 1000)]
         [uint16]$Limit,

--- a/Functions/Virtualization/VirtualizationCluster/Get-NBVirtualizationClusterGroup.ps1
+++ b/Functions/Virtualization/VirtualizationCluster/Get-NBVirtualizationClusterGroup.ps1
@@ -43,7 +43,14 @@
 .PARAMETER Id
     One or more database IDs to retrieve.
 
-.PARAMETER Limit
+.PARAMETER Tag
+        Filter by tag slug(s). Several values are combined with AND (object must carry all of them);
+        use Set-NBQueryOption -TagMatch Any (Netbox 4.6.6+) for OR semantics.
+
+    .PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
+    .PARAMETER Limit
     Maximum number of results to return per request (1-1000).
 
 .PARAMETER Offset
@@ -88,6 +95,12 @@ function Get-NBVirtualizationClusterGroup {
 
         [Parameter(ParameterSetName = 'ByID', ValueFromPipelineByPropertyName = $true)]
         [uint64[]]$Id,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tag_Id,
 
         [ValidateRange(1, 1000)]
         [uint16]$Limit,

--- a/Functions/Virtualization/VirtualizationClusterType/Get-NBVirtualizationClusterType.ps1
+++ b/Functions/Virtualization/VirtualizationClusterType/Get-NBVirtualizationClusterType.ps1
@@ -21,7 +21,14 @@
 .PARAMETER Query
     General search query.
 
-.PARAMETER Limit
+.PARAMETER Tag
+        Filter by tag slug(s). Several values are combined with AND (object must carry all of them);
+        use Set-NBQueryOption -TagMatch Any (Netbox 4.6.6+) for OR semantics.
+
+    .PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
+    .PARAMETER Limit
     Maximum number of results to return (1-1000).
 
 .PARAMETER Offset
@@ -102,6 +109,12 @@ function Get-NBVirtualizationClusterType {
         [Parameter(ParameterSetName = 'Query')]
         [Alias('q')]
         [string]$Query,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tag_Id,
 
         [ValidateRange(1, 1000)]
         [uint16]$Limit,

--- a/Functions/Wireless/WirelessLAN/Get-NBWirelessLAN.ps1
+++ b/Functions/Wireless/WirelessLAN/Get-NBWirelessLAN.ps1
@@ -43,7 +43,14 @@
 .PARAMETER VLAN_Id
     Filter by vlan database ID.
 
-.PARAMETER Limit
+.PARAMETER Tag
+        Filter by tag slug(s). Several values are combined with AND (object must carry all of them);
+        use Set-NBQueryOption -TagMatch Any (Netbox 4.6.6+) for OR semantics.
+
+    .PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
+    .PARAMETER Limit
     Maximum number of results to return per request (1-1000).
 
 .PARAMETER Offset
@@ -76,6 +83,12 @@ function Get-NBWirelessLAN {
         [Parameter(ParameterSetName = 'ByID', ValueFromPipelineByPropertyName = $true)][uint64[]]$Id,
         [Parameter(ParameterSetName = 'Query')][string]$SSID,[Parameter(ParameterSetName = 'Query')][uint64]$Group_Id,
         [Parameter(ParameterSetName = 'Query')][string]$Status,[Parameter(ParameterSetName = 'Query')][uint64]$VLAN_Id,
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tag_Id,
+
         [ValidateRange(1, 1000)]
         [uint16]$Limit,[ValidateRange(0, [int]::MaxValue)]
         [uint16]$Offset,[switch]$Raw)

--- a/Functions/Wireless/WirelessLANGroup/Get-NBWirelessLANGroup.ps1
+++ b/Functions/Wireless/WirelessLANGroup/Get-NBWirelessLANGroup.ps1
@@ -40,7 +40,14 @@
 .PARAMETER Parent_Id
     Filter by parent database ID.
 
-.PARAMETER Limit
+.PARAMETER Tag
+        Filter by tag slug(s). Several values are combined with AND (object must carry all of them);
+        use Set-NBQueryOption -TagMatch Any (Netbox 4.6.6+) for OR semantics.
+
+    .PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
+    .PARAMETER Limit
     Maximum number of results to return per request (1-1000).
 
 .PARAMETER Offset
@@ -70,11 +77,32 @@ function Get-NBWirelessLANGroup {
 
         [string[]]$Omit,
 
-        [Parameter(ParameterSetName = 'ByID', ValueFromPipelineByPropertyName = $true)][uint64[]]$Id,
-        [Parameter(ParameterSetName = 'Query')][string]$Name,[Parameter(ParameterSetName = 'Query')][string]$Slug,
-        [Parameter(ParameterSetName = 'Query')][uint64]$Parent_Id,[ValidateRange(1, 1000)]
-        [uint16]$Limit,[ValidateRange(0, [int]::MaxValue)]
-        [uint16]$Offset,[switch]$Raw)
+        [Parameter(ParameterSetName = 'ByID', ValueFromPipelineByPropertyName = $true)]
+        [uint64[]]$Id,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string]$Name,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string]$Slug,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64]$Parent_Id,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tag_Id,
+
+        [ValidateRange(1, 1000)]
+        [uint16]$Limit,
+
+        [ValidateRange(0, [int]::MaxValue)]
+        [uint16]$Offset,
+
+        [switch]$Raw
+    )
     process {
         AssertNBMutualExclusiveParam `
             -BoundParameters $PSBoundParameters `

--- a/Functions/Wireless/WirelessLink/Get-NBWirelessLink.ps1
+++ b/Functions/Wireless/WirelessLink/Get-NBWirelessLink.ps1
@@ -37,7 +37,14 @@
 .PARAMETER Status
     Filter by operational status.
 
-.PARAMETER Limit
+.PARAMETER Tag
+        Filter by tag slug(s). Several values are combined with AND (object must carry all of them);
+        use Set-NBQueryOption -TagMatch Any (Netbox 4.6.6+) for OR semantics.
+
+    .PARAMETER Tag_Id
+        Filter by tag ID(s); combines like -Tag.
+
+    .PARAMETER Limit
     Maximum number of results to return per request (1-1000).
 
 .PARAMETER Offset
@@ -69,6 +76,12 @@ function Get-NBWirelessLink {
 
         [Parameter(ParameterSetName = 'ByID', ValueFromPipelineByPropertyName = $true)][uint64[]]$Id,
         [Parameter(ParameterSetName = 'Query')][string]$SSID,[Parameter(ParameterSetName = 'Query')][string]$Status,
+        [Parameter(ParameterSetName = 'Query')]
+        [string[]]$Tag,
+
+        [Parameter(ParameterSetName = 'Query')]
+        [uint64[]]$Tag_Id,
+
         [ValidateRange(1, 1000)]
         [uint16]$Limit,[ValidateRange(0, [int]::MaxValue)]
         [uint16]$Offset,[switch]$Raw)

--- a/PowerNetbox.psd1
+++ b/PowerNetbox.psd1
@@ -12,7 +12,7 @@
 RootModule = 'PowerNetbox.psm1'
 
 # Version number of this module.
-ModuleVersion = '4.7.0.0'
+ModuleVersion = '4.7.1.0'
 
 # Supported PSEditions
 CompatiblePSEditions = 'Desktop', 'Core'

--- a/README.md
+++ b/README.md
@@ -91,6 +91,30 @@ You can influence this behaviour by choosing between three modes: Exact, Wildcar
 
 `Set-NBQueryOption -MatchMode Wildcard|Regex` or `Connect-NBAPI -Matchmode`.
 
+### Tag filters: all or any
+
+Every `Get-NB*` cmdlet for a taggable model has `-Tag <slug[]>` and `-Tag_Id <id[]>`. Multiple values are combined with AND by NetBox (the object must carry all of them). `Set-NBQueryOption -TagMatch Any` switches to NetBox 4.6.6+ `tag__any` / `tag_id__any` (object carries at least one). Below 4.6.6 the option is ignored on purpose, because an unknown lookup would silently return every object.
+
+```powershell
+Set-NBQueryOption -TagMatch Any
+Get-NBDCIMDevice -Tag 'edge', 'core'          # edge OR core
+Get-NBDCIMDevice -Name 'core-01' | Set-NBObjectTag -Add 'maintenance' -Remove 'staging'   # partial tag update (4.6+)
+```
+
+`-Tags` on `New-*`/`Set-*` accepts tag names or IDs (names are sent as `{ "name": ... }`, which is what the API requires).
+
+### Cursor pagination (NetBox 4.6+)
+
+`Set-NBQueryOption -Pagination Cursor` makes `-All` walk large tables with NetBox's `?start=<pk>` cursor instead of `limit`/`offset`, which stays fast on very large result sets. Results come back ordered by primary key. Older servers fall back to offset paging automatically; an explicit `-Offset` always wins.
+
+### Optimistic concurrency (NetBox 4.6+, PowerShell 7+)
+
+`Set-NBQueryOption -OptimisticConcurrency` remembers the `ETag` of every object you read and sends it as `If-Match` on the next `Set-*`/`Remove-*` of that object. If someone changed the object in between, NetBox answers `412 Precondition Failed` and the error tells you to re-read and retry, instead of silently overwriting their change.
+
+### Background bulk writes (NetBox 4.7+)
+
+The bulk-capable `New-*`/`Set-*`/`Remove-*` cmdlets (see the bulk operations guide) take `-Background`: each batch is queued as a NetBox background job (`?background=true`, HTTP 202) and the job objects are returned, so very large batches no longer hit proxy timeouts. Inspect the outcome with `Get-NBJob`. Needs an RQ worker on the server.
+
 ### Requirements and limitations
 
 Depending on the version of the NetBox API used, the API supports these options for a specific set of parameters and endpoints. Due to this current limitation, the module can only support case insensitivity and wildcard searches for the same set of cases.

--- a/Tests/DCIM.Cooling.Tests.ps1
+++ b/Tests/DCIM.Cooling.Tests.ps1
@@ -1,0 +1,587 @@
+<#
+.SYNOPSIS
+    Unit tests for DCIM cooling infrastructure functions (NetBox 4.7+).
+
+.DESCRIPTION
+    Tests for the facility-level cooling endpoints introduced in NetBox 4.7:
+    CoolingSources (/api/dcim/cooling-sources/) and CoolingFeeds
+    (/api/dcim/cooling-feeds/). Mocks at the InvokeNetboxRequest level.
+#>
+
+param()
+
+BeforeAll {
+    Import-Module Pester
+    Remove-Module PowerNetbox -Force -ErrorAction SilentlyContinue
+
+    $ModulePath = Join-Path (Join-Path $PSScriptRoot "..") "PowerNetbox/PowerNetbox.psd1"
+    if (Test-Path $ModulePath) {
+        Import-Module $ModulePath -ErrorAction Stop
+    }
+}
+
+Describe "DCIM Cooling Tests" -Tag 'DCIM' {
+    BeforeAll {
+        Mock -CommandName 'CheckNetboxIsConnected' -ModuleName 'PowerNetbox' -MockWith { return $true }
+        Mock -CommandName 'InvokeNetboxRequest' -ModuleName 'PowerNetbox' -MockWith {
+            return [ordered]@{
+                'Method' = if ($Method) { $Method } else { 'GET' }
+                'Uri'    = $URI.Uri.AbsoluteUri
+                'Body'   = if ($Body) { $Body | ConvertTo-Json -Compress -Depth 10 } else { $null }
+            }
+        }
+
+        InModuleScope -ModuleName 'PowerNetbox' {
+            $script:NetboxConfig.Hostname = 'netbox.domain.com'
+            $script:NetboxConfig.HostScheme = 'https'
+            $script:NetboxConfig.HostPort = 443
+        }
+    }
+
+    #region CoolingSources
+    Context "Get-NBDCIMCoolingSource" {
+        It "Should request the list endpoint" {
+            $Result = Get-NBDCIMCoolingSource
+            $Result.Method | Should -Be 'GET'
+            $Result.Uri | Should -Be 'https://netbox.domain.com/api/dcim/cooling-sources/'
+        }
+
+        It "Should request a cooling source by ID" {
+            $Result = Get-NBDCIMCoolingSource -Id 5
+            $Result.Method | Should -Be 'GET'
+            $Result.Uri | Should -Be 'https://netbox.domain.com/api/dcim/cooling-sources/5/'
+        }
+
+        It "Should fan out multiple IDs to one detail request each" {
+            $Result = @(Get-NBDCIMCoolingSource -Id 5, 6)
+            $Result.Count | Should -Be 2
+            $Result[0].Uri | Should -Be 'https://netbox.domain.com/api/dcim/cooling-sources/5/'
+            $Result[1].Uri | Should -Be 'https://netbox.domain.com/api/dcim/cooling-sources/6/'
+        }
+
+        It "Should pass -Brief through on the detail endpoint" {
+            $Result = Get-NBDCIMCoolingSource -Id 5 -Brief
+            $Result.Uri | Should -Match '/api/dcim/cooling-sources/5/\?brief=True'
+        }
+
+        It "Should filter by name" {
+            $Result = Get-NBDCIMCoolingSource -Name 'CH-01'
+            $Result.Uri | Should -Match 'name=CH-01'
+        }
+
+        It "Should emit repeat-key site_id filters" {
+            $Result = Get-NBDCIMCoolingSource -Site_Id 1, 2
+            $Result.Uri | Should -Match 'site_id=1'
+            $Result.Uri | Should -Match 'site_id=2'
+        }
+
+        It "Should filter by site slug" {
+            $Result = Get-NBDCIMCoolingSource -Site 'dc-1'
+            $Result.Uri | Should -Match 'site=dc-1'
+        }
+
+        It "Should filter by location_id" {
+            $Result = Get-NBDCIMCoolingSource -Location_Id 3
+            $Result.Uri | Should -Match 'location_id=3'
+        }
+
+        It "Should filter by location slug" {
+            $Result = Get-NBDCIMCoolingSource -Location 'room-a'
+            $Result.Uri | Should -Match 'location=room-a'
+        }
+
+        It "Should filter by region_id" {
+            $Result = Get-NBDCIMCoolingSource -Region_Id 4
+            $Result.Uri | Should -Match 'region_id=4'
+        }
+
+        It "Should filter by region slug" {
+            $Result = Get-NBDCIMCoolingSource -Region 'emea'
+            $Result.Uri | Should -Match 'region=emea'
+        }
+
+        It "Should filter by site_group_id" {
+            $Result = Get-NBDCIMCoolingSource -Site_Group_Id 8
+            $Result.Uri | Should -Match 'site_group_id=8'
+        }
+
+        It "Should filter by type" {
+            $Result = Get-NBDCIMCoolingSource -Type chiller
+            $Result.Uri | Should -Match 'type=chiller'
+        }
+
+        It "Should emit repeat-key type filters" {
+            $Result = Get-NBDCIMCoolingSource -Type chiller, crac
+            $Result.Uri | Should -Match 'type=chiller'
+            $Result.Uri | Should -Match 'type=crac'
+        }
+
+        It "Should reject an unknown type" {
+            { Get-NBDCIMCoolingSource -Type 'fridge' } | Should -Throw
+        }
+
+        It "Should filter by status" {
+            $Result = Get-NBDCIMCoolingSource -Status active
+            $Result.Uri | Should -Match 'status=active'
+        }
+
+        It "Should reject an unknown status" {
+            { Get-NBDCIMCoolingSource -Status 'broken' } | Should -Throw
+        }
+
+        It "Should filter by fluid_type" {
+            $Result = Get-NBDCIMCoolingSource -Fluid_Type water-glycol
+            $Result.Uri | Should -Match 'fluid_type=water-glycol'
+        }
+
+        It "Should filter by cooling_capacity" {
+            $Result = Get-NBDCIMCoolingSource -Cooling_Capacity 250.5
+            $Result.Uri | Should -Match 'cooling_capacity=250\.5'
+        }
+
+        It "Should filter by description" {
+            $Result = Get-NBDCIMCoolingSource -Description 'primary'
+            $Result.Uri | Should -Match 'description=primary'
+        }
+
+        It "Should filter by owner_id" {
+            $Result = Get-NBDCIMCoolingSource -Owner_Id 9
+            $Result.Uri | Should -Match 'owner_id=9'
+        }
+
+        It "Should filter by tag" {
+            $Result = Get-NBDCIMCoolingSource -Tag 'critical'
+            $Result.Uri | Should -Match 'tag=critical'
+        }
+
+        It "Should send -Query as q" {
+            $Result = Get-NBDCIMCoolingSource -Query 'chill' -WarningAction SilentlyContinue
+            $Result.Uri | Should -Match 'q=chill'
+        }
+
+        It "Should pass limit and offset" {
+            $Result = Get-NBDCIMCoolingSource -Limit 10 -Offset 20
+            $Result.Uri | Should -Match 'limit=10'
+            $Result.Uri | Should -Match 'offset=20'
+        }
+
+        It "Should accept an offset above uint16 range" {
+            $Result = Get-NBDCIMCoolingSource -Offset 70000
+            $Result.Uri | Should -Match 'offset=70000'
+        }
+
+        It "Should pass fields and omit" {
+            $Result = Get-NBDCIMCoolingSource -Fields 'id', 'name'
+            $Result.Uri | Should -Match 'fields=id(,|%2C)name'
+            $Result = Get-NBDCIMCoolingSource -Omit 'comments'
+            $Result.Uri | Should -Match 'omit=comments'
+        }
+
+        It "Should reject -Brief together with -Fields" {
+            { Get-NBDCIMCoolingSource -Brief -Fields 'id' } | Should -Throw
+        }
+    }
+
+    Context "New-NBDCIMCoolingSource" {
+        It "Should POST the required fields" {
+            $Result = New-NBDCIMCoolingSource -Site 1 -Name 'CH-01' -Type chiller
+            $Result.Method | Should -Be 'POST'
+            $Result.Uri | Should -Be 'https://netbox.domain.com/api/dcim/cooling-sources/'
+            $bodyObj = $Result.Body | ConvertFrom-Json
+            $bodyObj.site | Should -Be 1
+            $bodyObj.name | Should -Be 'CH-01'
+            $bodyObj.type | Should -Be 'chiller'
+        }
+
+        It "Should require Site, Name and Type" {
+            $cmd = Get-Command New-NBDCIMCoolingSource
+            foreach ($p in 'Site', 'Name', 'Type') {
+                $attr = $cmd.Parameters[$p].Attributes | Where-Object { $_ -is [System.Management.Automation.ParameterAttribute] }
+                $attr.Mandatory | Should -BeTrue -Because "$p is required by the API"
+            }
+        }
+
+        It "Should send every optional field" {
+            $Result = New-NBDCIMCoolingSource -Site 1 -Name 'CH-02' -Type crah -Location 3 -Status planned `
+                -Fluid_Type refrigerant -Cooling_Capacity 500.25 -Description 'desc' -Owner 7 -Comments 'notes' `
+                -Tags 'a', 'b' -Custom_Fields @{ vendor = 'ACME' }
+            $bodyObj = $Result.Body | ConvertFrom-Json
+            $bodyObj.location | Should -Be 3
+            $bodyObj.status | Should -Be 'planned'
+            $bodyObj.fluid_type | Should -Be 'refrigerant'
+            $bodyObj.cooling_capacity | Should -Be 500.25
+            $bodyObj.description | Should -Be 'desc'
+            $bodyObj.owner | Should -Be 7
+            $bodyObj.comments | Should -Be 'notes'
+            $bodyObj.tags | Should -Be @('a', 'b')
+            $bodyObj.custom_fields.vendor | Should -Be 'ACME'
+        }
+
+        It "Should accept mixed tag IDs and names" {
+            $Result = New-NBDCIMCoolingSource -Site 1 -Name 'CH-03' -Type crac -Tags 1, 'prod'
+            $bodyObj = $Result.Body | ConvertFrom-Json
+            $bodyObj.tags.Count | Should -Be 2
+        }
+
+        It "Should reject an unknown type" {
+            { New-NBDCIMCoolingSource -Site 1 -Name 'X' -Type 'fridge' } | Should -Throw
+        }
+
+        It "Should reject an unknown fluid type" {
+            { New-NBDCIMCoolingSource -Site 1 -Name 'X' -Type chiller -Fluid_Type 'beer' } | Should -Throw
+        }
+
+        It "Should not call the API with -WhatIf" {
+            New-NBDCIMCoolingSource -Site 1 -Name 'X' -Type chiller -WhatIf
+            Should -Invoke -CommandName 'InvokeNetboxRequest' -ModuleName 'PowerNetbox' -Times 0 -Exactly
+        }
+    }
+
+    Context "Set-NBDCIMCoolingSource" {
+        It "Should PATCH the detail endpoint" {
+            $Result = Set-NBDCIMCoolingSource -Id 5 -Status offline -Confirm:$false
+            $Result.Method | Should -Be 'PATCH'
+            $Result.Uri | Should -Be 'https://netbox.domain.com/api/dcim/cooling-sources/5/'
+            $bodyObj = $Result.Body | ConvertFrom-Json
+            $bodyObj.status | Should -Be 'offline'
+            $bodyObj.PSObject.Properties.Name | Should -Not -Contain 'id'
+        }
+
+        It "Should send updated scalar fields" {
+            $Result = Set-NBDCIMCoolingSource -Id 5 -Site 2 -Location 4 -Name 'CH-01b' -Type dry-cooler `
+                -Fluid_Type dielectric -Cooling_Capacity 750 -Description 'd' -Owner 3 -Comments 'c' `
+                -Tags 'x' -Custom_Fields @{ k = 'v' } -Confirm:$false
+            $bodyObj = $Result.Body | ConvertFrom-Json
+            $bodyObj.site | Should -Be 2
+            $bodyObj.location | Should -Be 4
+            $bodyObj.name | Should -Be 'CH-01b'
+            $bodyObj.type | Should -Be 'dry-cooler'
+            $bodyObj.fluid_type | Should -Be 'dielectric'
+            $bodyObj.cooling_capacity | Should -Be 750
+            $bodyObj.description | Should -Be 'd'
+            $bodyObj.owner | Should -Be 3
+            $bodyObj.comments | Should -Be 'c'
+            $bodyObj.tags | Should -Be @('x')
+            $bodyObj.custom_fields.k | Should -Be 'v'
+        }
+
+        It "Should clear fluid_type with the empty-string sentinel" {
+            $Result = Set-NBDCIMCoolingSource -Id 5 -Fluid_Type '' -Confirm:$false
+            $Result.Body | Should -Match '"fluid_type":null'
+        }
+
+        It "Should clear location with null" {
+            $Result = Set-NBDCIMCoolingSource -Id 5 -Location $null -Confirm:$false
+            $Result.Body | Should -Match '"location":null'
+        }
+
+        It "Should clear cooling_capacity with null" {
+            $Result = Set-NBDCIMCoolingSource -Id 5 -Cooling_Capacity $null -Confirm:$false
+            $Result.Body | Should -Match '"cooling_capacity":null'
+        }
+
+        It "Should reject an unknown fluid type" {
+            { Set-NBDCIMCoolingSource -Id 5 -Fluid_Type 'beer' -Confirm:$false } | Should -Throw
+        }
+
+        It "Should accept Id from the pipeline by property name" {
+            $Result = [PSCustomObject]@{ Id = 11 } | Set-NBDCIMCoolingSource -Status failed -Confirm:$false
+            $Result.Uri | Should -Match '/api/dcim/cooling-sources/11/'
+        }
+
+        It "Should not call the API with -WhatIf" {
+            Set-NBDCIMCoolingSource -Id 5 -Status active -WhatIf
+            Should -Invoke -CommandName 'InvokeNetboxRequest' -ModuleName 'PowerNetbox' -Times 0 -Exactly
+        }
+    }
+
+    Context "Remove-NBDCIMCoolingSource" {
+        It "Should DELETE the detail endpoint" {
+            $Result = Remove-NBDCIMCoolingSource -Id 5 -Confirm:$false
+            $Result.Method | Should -Be 'DELETE'
+            $Result.Uri | Should -Be 'https://netbox.domain.com/api/dcim/cooling-sources/5/'
+        }
+
+        It "Should accept Id from the pipeline by property name" {
+            $Result = [PSCustomObject]@{ Id = 12 } | Remove-NBDCIMCoolingSource -Confirm:$false
+            $Result.Uri | Should -Match '/api/dcim/cooling-sources/12/'
+        }
+
+        It "Should not call the API with -WhatIf" {
+            Remove-NBDCIMCoolingSource -Id 5 -WhatIf
+            Should -Invoke -CommandName 'InvokeNetboxRequest' -ModuleName 'PowerNetbox' -Times 0 -Exactly
+        }
+    }
+    #endregion CoolingSources
+
+    #region CoolingFeeds
+    Context "Get-NBDCIMCoolingFeed" {
+        It "Should request the list endpoint" {
+            $Result = Get-NBDCIMCoolingFeed
+            $Result.Method | Should -Be 'GET'
+            $Result.Uri | Should -Be 'https://netbox.domain.com/api/dcim/cooling-feeds/'
+        }
+
+        It "Should request a cooling feed by ID" {
+            $Result = Get-NBDCIMCoolingFeed -Id 7
+            $Result.Uri | Should -Be 'https://netbox.domain.com/api/dcim/cooling-feeds/7/'
+        }
+
+        It "Should pass -Brief through on the detail endpoint" {
+            $Result = Get-NBDCIMCoolingFeed -Id 7 -Brief
+            $Result.Uri | Should -Match '/api/dcim/cooling-feeds/7/\?brief=True'
+        }
+
+        It "Should filter by name" {
+            $Result = Get-NBDCIMCoolingFeed -Name 'CF-01'
+            $Result.Uri | Should -Match 'name=CF-01'
+        }
+
+        It "Should emit repeat-key cooling_source_id filters" {
+            $Result = Get-NBDCIMCoolingFeed -Cooling_Source_Id 3, 4
+            $Result.Uri | Should -Match 'cooling_source_id=3'
+            $Result.Uri | Should -Match 'cooling_source_id=4'
+        }
+
+        It "Should filter by rack_id" {
+            $Result = Get-NBDCIMCoolingFeed -Rack_Id 12
+            $Result.Uri | Should -Match 'rack_id=12'
+        }
+
+        It "Should filter by site_id" {
+            $Result = Get-NBDCIMCoolingFeed -Site_Id 1
+            $Result.Uri | Should -Match 'site_id=1'
+        }
+
+        It "Should filter by site slug" {
+            $Result = Get-NBDCIMCoolingFeed -Site 'dc-1'
+            $Result.Uri | Should -Match 'site=dc-1'
+        }
+
+        It "Should filter by region_id" {
+            $Result = Get-NBDCIMCoolingFeed -Region_Id 4
+            $Result.Uri | Should -Match 'region_id=4'
+        }
+
+        It "Should filter by tenant_id" {
+            $Result = Get-NBDCIMCoolingFeed -Tenant_Id 6
+            $Result.Uri | Should -Match 'tenant_id=6'
+        }
+
+        It "Should filter by tenant slug" {
+            $Result = Get-NBDCIMCoolingFeed -Tenant 'acme'
+            $Result.Uri | Should -Match 'tenant=acme'
+        }
+
+        It "Should filter by status" {
+            $Result = Get-NBDCIMCoolingFeed -Status planned
+            $Result.Uri | Should -Match 'status=planned'
+        }
+
+        It "Should reject an unknown status" {
+            { Get-NBDCIMCoolingFeed -Status 'broken' } | Should -Throw
+        }
+
+        It "Should filter by max_flow_unit" {
+            $Result = Get-NBDCIMCoolingFeed -Max_Flow_Unit gpm
+            $Result.Uri | Should -Match 'max_flow_unit=gpm'
+        }
+
+        It "Should reject an unknown max_flow_unit" {
+            { Get-NBDCIMCoolingFeed -Max_Flow_Unit 'buckets' } | Should -Throw
+        }
+
+        It "Should filter by cooling_capacity" {
+            $Result = Get-NBDCIMCoolingFeed -Cooling_Capacity 25
+            $Result.Uri | Should -Match 'cooling_capacity=25'
+        }
+
+        It "Should filter by max_flow" {
+            $Result = Get-NBDCIMCoolingFeed -Max_Flow 40.5
+            $Result.Uri | Should -Match 'max_flow=40\.5'
+        }
+
+        It "Should filter by description" {
+            $Result = Get-NBDCIMCoolingFeed -Description 'primary'
+            $Result.Uri | Should -Match 'description=primary'
+        }
+
+        It "Should filter by tag" {
+            $Result = Get-NBDCIMCoolingFeed -Tag 'critical'
+            $Result.Uri | Should -Match 'tag=critical'
+        }
+
+        It "Should send -Query as q" {
+            $Result = Get-NBDCIMCoolingFeed -Query 'feed' -WarningAction SilentlyContinue
+            $Result.Uri | Should -Match 'q=feed'
+        }
+
+        It "Should pass limit and offset" {
+            $Result = Get-NBDCIMCoolingFeed -Limit 10 -Offset 70000
+            $Result.Uri | Should -Match 'limit=10'
+            $Result.Uri | Should -Match 'offset=70000'
+        }
+
+        It "Should reject -Brief together with -Omit" {
+            { Get-NBDCIMCoolingFeed -Brief -Omit 'comments' } | Should -Throw
+        }
+    }
+
+    Context "New-NBDCIMCoolingFeed" {
+        It "Should POST the required fields" {
+            $Result = New-NBDCIMCoolingFeed -Cooling_Source 3 -Name 'CF-01'
+            $Result.Method | Should -Be 'POST'
+            $Result.Uri | Should -Be 'https://netbox.domain.com/api/dcim/cooling-feeds/'
+            $bodyObj = $Result.Body | ConvertFrom-Json
+            $bodyObj.cooling_source | Should -Be 3
+            $bodyObj.name | Should -Be 'CF-01'
+        }
+
+        It "Should require Cooling_Source and Name" {
+            $cmd = Get-Command New-NBDCIMCoolingFeed
+            foreach ($p in 'Cooling_Source', 'Name') {
+                $attr = $cmd.Parameters[$p].Attributes | Where-Object { $_ -is [System.Management.Automation.ParameterAttribute] }
+                $attr.Mandatory | Should -BeTrue -Because "$p is required by the API"
+            }
+        }
+
+        It "Should send every optional field" {
+            $Result = New-NBDCIMCoolingFeed -Cooling_Source 3 -Name 'CF-02' -Rack 12 -Status planned `
+                -Cooling_Capacity 25.5 -Max_Flow 40 -Max_Flow_Unit lpm -Description 'desc' -Tenant 6 -Owner 7 `
+                -Comments 'notes' -Tags 'a', 'b' -Custom_Fields @{ loop = 'A' }
+            $bodyObj = $Result.Body | ConvertFrom-Json
+            $bodyObj.rack | Should -Be 12
+            $bodyObj.status | Should -Be 'planned'
+            $bodyObj.cooling_capacity | Should -Be 25.5
+            $bodyObj.max_flow | Should -Be 40
+            $bodyObj.max_flow_unit | Should -Be 'lpm'
+            $bodyObj.description | Should -Be 'desc'
+            $bodyObj.tenant | Should -Be 6
+            $bodyObj.owner | Should -Be 7
+            $bodyObj.comments | Should -Be 'notes'
+            $bodyObj.tags | Should -Be @('a', 'b')
+            $bodyObj.custom_fields.loop | Should -Be 'A'
+        }
+
+        It "Should reject an unknown max_flow_unit" {
+            { New-NBDCIMCoolingFeed -Cooling_Source 3 -Name 'X' -Max_Flow_Unit 'buckets' } | Should -Throw
+        }
+
+        It "Should reject an unknown status" {
+            { New-NBDCIMCoolingFeed -Cooling_Source 3 -Name 'X' -Status 'broken' } | Should -Throw
+        }
+
+        It "Should not call the API with -WhatIf" {
+            New-NBDCIMCoolingFeed -Cooling_Source 3 -Name 'X' -WhatIf
+            Should -Invoke -CommandName 'InvokeNetboxRequest' -ModuleName 'PowerNetbox' -Times 0 -Exactly
+        }
+    }
+
+    Context "Set-NBDCIMCoolingFeed" {
+        It "Should PATCH the detail endpoint" {
+            $Result = Set-NBDCIMCoolingFeed -Id 7 -Status offline -Confirm:$false
+            $Result.Method | Should -Be 'PATCH'
+            $Result.Uri | Should -Be 'https://netbox.domain.com/api/dcim/cooling-feeds/7/'
+            $bodyObj = $Result.Body | ConvertFrom-Json
+            $bodyObj.status | Should -Be 'offline'
+            $bodyObj.PSObject.Properties.Name | Should -Not -Contain 'id'
+        }
+
+        It "Should send updated scalar fields" {
+            $Result = Set-NBDCIMCoolingFeed -Id 7 -Cooling_Source 4 -Rack 13 -Name 'CF-01b' -Cooling_Capacity 30 `
+                -Max_Flow 55.5 -Max_Flow_Unit m3ph -Description 'd' -Tenant 8 -Owner 3 -Comments 'c' `
+                -Tags 'x' -Custom_Fields @{ k = 'v' } -Confirm:$false
+            $bodyObj = $Result.Body | ConvertFrom-Json
+            $bodyObj.cooling_source | Should -Be 4
+            $bodyObj.rack | Should -Be 13
+            $bodyObj.name | Should -Be 'CF-01b'
+            $bodyObj.cooling_capacity | Should -Be 30
+            $bodyObj.max_flow | Should -Be 55.5
+            $bodyObj.max_flow_unit | Should -Be 'm3ph'
+            $bodyObj.description | Should -Be 'd'
+            $bodyObj.tenant | Should -Be 8
+            $bodyObj.owner | Should -Be 3
+            $bodyObj.comments | Should -Be 'c'
+            $bodyObj.tags | Should -Be @('x')
+            $bodyObj.custom_fields.k | Should -Be 'v'
+        }
+
+        It "Should clear max_flow_unit with the empty-string sentinel" {
+            $Result = Set-NBDCIMCoolingFeed -Id 7 -Max_Flow_Unit '' -Confirm:$false
+            $Result.Body | Should -Match '"max_flow_unit":null'
+        }
+
+        It "Should clear rack and tenant with null" {
+            $Result = Set-NBDCIMCoolingFeed -Id 7 -Rack $null -Tenant $null -Confirm:$false
+            $Result.Body | Should -Match '"rack":null'
+            $Result.Body | Should -Match '"tenant":null'
+        }
+
+        It "Should clear cooling_capacity and max_flow with null" {
+            $Result = Set-NBDCIMCoolingFeed -Id 7 -Cooling_Capacity $null -Max_Flow $null -Confirm:$false
+            $Result.Body | Should -Match '"cooling_capacity":null'
+            $Result.Body | Should -Match '"max_flow":null'
+        }
+
+        It "Should reject an unknown max_flow_unit" {
+            { Set-NBDCIMCoolingFeed -Id 7 -Max_Flow_Unit 'buckets' -Confirm:$false } | Should -Throw
+        }
+
+        It "Should accept Id from the pipeline by property name" {
+            $Result = [PSCustomObject]@{ Id = 21 } | Set-NBDCIMCoolingFeed -Status failed -Confirm:$false
+            $Result.Uri | Should -Match '/api/dcim/cooling-feeds/21/'
+        }
+
+        It "Should not call the API with -WhatIf" {
+            Set-NBDCIMCoolingFeed -Id 7 -Status active -WhatIf
+            Should -Invoke -CommandName 'InvokeNetboxRequest' -ModuleName 'PowerNetbox' -Times 0 -Exactly
+        }
+    }
+
+    Context "Remove-NBDCIMCoolingFeed" {
+        It "Should DELETE the detail endpoint" {
+            $Result = Remove-NBDCIMCoolingFeed -Id 7 -Confirm:$false
+            $Result.Method | Should -Be 'DELETE'
+            $Result.Uri | Should -Be 'https://netbox.domain.com/api/dcim/cooling-feeds/7/'
+        }
+
+        It "Should accept Id from the pipeline by property name" {
+            $Result = [PSCustomObject]@{ Id = 22 } | Remove-NBDCIMCoolingFeed -Confirm:$false
+            $Result.Uri | Should -Match '/api/dcim/cooling-feeds/22/'
+        }
+
+        It "Should not call the API with -WhatIf" {
+            Remove-NBDCIMCoolingFeed -Id 7 -WhatIf
+            Should -Invoke -CommandName 'InvokeNetboxRequest' -ModuleName 'PowerNetbox' -Times 0 -Exactly
+        }
+    }
+    #endregion CoolingFeeds
+
+    Context "Cooling cmdlet conventions" {
+        It "<Command> should support ShouldProcess" -TestCases @(
+            @{ Command = 'New-NBDCIMCoolingSource' }
+            @{ Command = 'Set-NBDCIMCoolingSource' }
+            @{ Command = 'Remove-NBDCIMCoolingSource' }
+            @{ Command = 'New-NBDCIMCoolingFeed' }
+            @{ Command = 'Set-NBDCIMCoolingFeed' }
+            @{ Command = 'Remove-NBDCIMCoolingFeed' }
+        ) {
+            param($Command)
+            $cmd = Get-Command $Command
+            $cmd.Parameters.Keys | Should -Contain 'WhatIf'
+            $cmd.Parameters.Keys | Should -Contain 'Confirm'
+        }
+
+        It "<Command> should expose -Raw, -All, -PageSize, -Brief, -Fields and -Omit" -TestCases @(
+            @{ Command = 'Get-NBDCIMCoolingSource' }
+            @{ Command = 'Get-NBDCIMCoolingFeed' }
+        ) {
+            param($Command)
+            $cmd = Get-Command $Command
+            foreach ($p in 'Raw', 'All', 'PageSize', 'Brief', 'Fields', 'Omit') {
+                $cmd.Parameters.Keys | Should -Contain $p
+            }
+            $cmd.Parameters['Offset'].ParameterType | Should -Be ([uint32])
+        }
+    }
+}

--- a/Tests/DCIM.Cooling.Tests.ps1
+++ b/Tests/DCIM.Cooling.Tests.ps1
@@ -213,7 +213,7 @@ Describe "DCIM Cooling Tests" -Tag 'DCIM' {
             $bodyObj.description | Should -Be 'desc'
             $bodyObj.owner | Should -Be 7
             $bodyObj.comments | Should -Be 'notes'
-            $bodyObj.tags | Should -Be @('a', 'b')
+            $bodyObj.tags.name | Should -Be @('a', 'b')
             $bodyObj.custom_fields.vendor | Should -Be 'ACME'
         }
 
@@ -261,7 +261,7 @@ Describe "DCIM Cooling Tests" -Tag 'DCIM' {
             $bodyObj.description | Should -Be 'd'
             $bodyObj.owner | Should -Be 3
             $bodyObj.comments | Should -Be 'c'
-            $bodyObj.tags | Should -Be @('x')
+            $bodyObj.tags[0].name | Should -Be 'x'
             $bodyObj.custom_fields.k | Should -Be 'v'
         }
 
@@ -459,7 +459,7 @@ Describe "DCIM Cooling Tests" -Tag 'DCIM' {
             $bodyObj.tenant | Should -Be 6
             $bodyObj.owner | Should -Be 7
             $bodyObj.comments | Should -Be 'notes'
-            $bodyObj.tags | Should -Be @('a', 'b')
+            $bodyObj.tags.name | Should -Be @('a', 'b')
             $bodyObj.custom_fields.loop | Should -Be 'A'
         }
 
@@ -502,7 +502,7 @@ Describe "DCIM Cooling Tests" -Tag 'DCIM' {
             $bodyObj.tenant | Should -Be 8
             $bodyObj.owner | Should -Be 3
             $bodyObj.comments | Should -Be 'c'
-            $bodyObj.tags | Should -Be @('x')
+            $bodyObj.tags[0].name | Should -Be 'x'
             $bodyObj.custom_fields.k | Should -Be 'v'
         }
 

--- a/Tests/DCIM.CoolingComponents.Tests.ps1
+++ b/Tests/DCIM.CoolingComponents.Tests.ps1
@@ -147,7 +147,8 @@ Describe "DCIM Cooling Component Functions" -Tag 'Build', 'DCIM' {
             $body.cooling_outflow | Should -Be 44
             $body.description | Should -Be 'desc'
             $body.owner | Should -Be 2
-            $body.tags | Should -Be @('liquid', 7)
+            $body.tags[0].name | Should -Be 'liquid'
+            $body.tags[1] | Should -Be 7
             $body.custom_fields.loop | Should -Be 'A'
         }
 
@@ -206,7 +207,7 @@ Describe "DCIM Cooling Component Functions" -Tag 'Build', 'DCIM' {
             $body.cooling_outflow | Should -Be 44
             $body.description | Should -Be 'd'
             $body.owner | Should -Be 2
-            $body.tags | Should -Be @('liquid')
+            $body.tags[0].name | Should -Be 'liquid'
             $body.custom_fields.loop | Should -Be 'B'
         }
 
@@ -331,7 +332,7 @@ Describe "DCIM Cooling Component Functions" -Tag 'Build', 'DCIM' {
             $body.cooling_intake | Should -Be 55
             $body.description | Should -Be 'desc'
             $body.owner | Should -Be 2
-            $body.tags | Should -Be @('liquid')
+            $body.tags[0].name | Should -Be 'liquid'
             $body.custom_fields.loop | Should -Be 'A'
         }
 
@@ -365,7 +366,7 @@ Describe "DCIM Cooling Component Functions" -Tag 'Build', 'DCIM' {
             $body.cooling_intake | Should -Be 55
             $body.description | Should -Be 'd'
             $body.owner | Should -Be 2
-            $body.tags | Should -Be @('a')
+            $body.tags[0].name | Should -Be 'a'
             $body.custom_fields.loop | Should -Be 'C'
         }
 

--- a/Tests/DCIM.CoolingComponents.Tests.ps1
+++ b/Tests/DCIM.CoolingComponents.Tests.ps1
@@ -1,0 +1,688 @@
+<#
+.SYNOPSIS
+    Unit tests for the NetBox 4.7 cooling device components.
+
+.DESCRIPTION
+    Tests for the DCIM cooling component endpoints added in NetBox 4.7:
+    CoolingIntakes, CoolingOutflows, CoolingIntakeTemplates and
+    CoolingOutflowTemplates (Get / New / Set / Remove for each).
+#>
+
+param()
+
+BeforeAll {
+    Import-Module Pester
+    Remove-Module PowerNetbox -Force -ErrorAction SilentlyContinue
+
+    $ModulePath = Join-Path (Join-Path $PSScriptRoot "..") "PowerNetbox/PowerNetbox.psd1"
+    if (Test-Path $ModulePath) {
+        Import-Module $ModulePath -ErrorAction Stop
+    }
+}
+
+Describe "DCIM Cooling Component Functions" -Tag 'Build', 'DCIM' {
+    BeforeAll {
+        Mock -CommandName 'CheckNetboxIsConnected' -ModuleName 'PowerNetbox' -MockWith { return $true }
+        Mock -CommandName 'InvokeNetboxRequest' -ModuleName 'PowerNetbox' -MockWith {
+            return [ordered]@{
+                'Method' = if ($Method) { $Method } else { 'GET' }
+                'Uri'    = $URI.Uri.AbsoluteUri
+                'Body'   = if ($Body) { $Body | ConvertTo-Json -Compress } else { $null }
+            }
+        }
+
+        InModuleScope -ModuleName 'PowerNetbox' {
+            $script:NetboxConfig.Hostname = 'netbox.domain.com'
+            $script:NetboxConfig.HostScheme = 'https'
+            $script:NetboxConfig.HostPort = 443
+        }
+    }
+
+    #region CoolingIntakes
+    Context "Get-NBDCIMCoolingIntake" {
+        It "Should request the cooling-intakes list endpoint" {
+            $Result = Get-NBDCIMCoolingIntake
+            $Result.Method | Should -Be 'GET'
+            $Result.Uri | Should -Be 'https://netbox.domain.com/api/dcim/cooling-intakes/'
+        }
+
+        It "Should request a cooling intake by ID" {
+            $Result = Get-NBDCIMCoolingIntake -Id 5
+            $Result.Uri | Should -Be 'https://netbox.domain.com/api/dcim/cooling-intakes/5/'
+        }
+
+        It "Should request each ID separately when given multiple IDs" {
+            $Result = Get-NBDCIMCoolingIntake -Id 5, 6
+            $Result.Count | Should -Be 2
+            $Result[1].Uri | Should -Be 'https://netbox.domain.com/api/dcim/cooling-intakes/6/'
+        }
+
+        It "Should pass -Brief through on the detail endpoint" {
+            $Result = Get-NBDCIMCoolingIntake -Id 5 -Brief
+            $Result.Uri | Should -Be 'https://netbox.domain.com/api/dcim/cooling-intakes/5/?brief=True'
+        }
+
+        It "Should filter by <Param> as a repeated query key" -TestCases @(
+            @{ Param = 'Name';           Values = @('in0', 'in1');   Key = 'name' }
+            @{ Param = 'Label';          Values = @('A', 'B');       Key = 'label' }
+            @{ Param = 'Device_Id';      Values = @(1, 2);           Key = 'device_id' }
+            @{ Param = 'Device';         Values = @('sw1', 'sw2');   Key = 'device' }
+            @{ Param = 'Device_Type_Id'; Values = @(3, 4);           Key = 'device_type_id' }
+            @{ Param = 'Module_Id';      Values = @(5, 6);           Key = 'module_id' }
+            @{ Param = 'Site_Id';        Values = @(7, 8);           Key = 'site_id' }
+            @{ Param = 'Site';           Values = @('ams', 'fra');   Key = 'site' }
+            @{ Param = 'Location_Id';    Values = @(9, 10);          Key = 'location_id' }
+            @{ Param = 'Rack_Id';        Values = @(11, 12);         Key = 'rack_id' }
+            @{ Param = 'Type';           Values = @('uqd', 'qdc');   Key = 'type' }
+            @{ Param = 'Diameter';       Values = @(12.7, 25.4);     Key = 'diameter' }
+            @{ Param = 'Diameter_Unit';  Values = @('mm', 'in');     Key = 'diameter_unit' }
+            @{ Param = 'Max_Flow';       Values = @(8, 16.5);        Key = 'max_flow' }
+            @{ Param = 'Max_Flow_Unit';  Values = @('lpm', 'gpm');   Key = 'max_flow_unit' }
+            @{ Param = 'Cooling_Outflow_Id'; Values = @(13, 14);     Key = 'cooling_outflow_id' }
+            @{ Param = 'Description';    Values = @('x', 'y');       Key = 'description' }
+            @{ Param = 'Tag';            Values = @('t1', 't2');     Key = 'tag' }
+        ) {
+            $splat = @{ $Param = $Values }
+            $Result = Get-NBDCIMCoolingIntake @splat
+            $Result.Uri | Should -Be "https://netbox.domain.com/api/dcim/cooling-intakes/?$Key=$($Values[0])&$Key=$($Values[1])"
+        }
+
+        It "Should send -Query as q" {
+            $Result = Get-NBDCIMCoolingIntake -Query 'coolant' -WarningAction SilentlyContinue
+            $Result.Uri | Should -Be 'https://netbox.domain.com/api/dcim/cooling-intakes/?q=coolant'
+        }
+
+        It "Should send -Limit and -Offset" {
+            $Result = Get-NBDCIMCoolingIntake -Limit 50 -Offset 100000
+            $Result.Uri | Should -Match 'limit=50'
+            $Result.Uri | Should -Match 'offset=100000'
+        }
+
+        It "Should send -Fields and -Omit" {
+            (Get-NBDCIMCoolingIntake -Fields 'id', 'name').Uri | Should -Match 'fields=id%2Cname'
+            (Get-NBDCIMCoolingIntake -Omit 'custom_fields').Uri | Should -Match 'omit=custom_fields'
+        }
+
+        It "Should reject -Brief together with -Fields" {
+            { Get-NBDCIMCoolingIntake -Brief -Fields 'id' } | Should -Throw
+        }
+
+        It "Should pass -All and -PageSize to InvokeNetboxRequest" {
+            Get-NBDCIMCoolingIntake -All -PageSize 250 | Out-Null
+            Should -Invoke -CommandName 'InvokeNetboxRequest' -ModuleName 'PowerNetbox' -Times 1 -Exactly -ParameterFilter {
+                $All -eq $true -and $PageSize -eq 250
+            }
+        }
+    }
+
+    Context "New-NBDCIMCoolingIntake" {
+        It "Should require Device and Name" {
+            $cmd = Get-Command New-NBDCIMCoolingIntake
+            $cmd.Parameters['Device'].Attributes.Where({ $_ -is [System.Management.Automation.ParameterAttribute] }).Mandatory | Should -Be $true
+            $cmd.Parameters['Name'].Attributes.Where({ $_ -is [System.Management.Automation.ParameterAttribute] }).Mandatory | Should -Be $true
+        }
+
+        It "Should POST a minimal cooling intake" {
+            $Result = New-NBDCIMCoolingIntake -Device 12 -Name 'Coolant In' -Confirm:$false
+            $Result.Method | Should -Be 'POST'
+            $Result.Uri | Should -Be 'https://netbox.domain.com/api/dcim/cooling-intakes/'
+            $body = $Result.Body | ConvertFrom-Json
+            $body.device | Should -Be 12
+            $body.name | Should -Be 'Coolant In'
+        }
+
+        It "Should POST every writable field" {
+            $Result = New-NBDCIMCoolingIntake -Device 12 -Module 3 -Name 'Coolant In' -Label 'IN-1' -Type 'uqd' `
+                -Diameter 12.7 -Diameter_Unit 'mm' -Max_Flow 8.5 -Max_Flow_Unit 'lpm' -Cooling_Outflow 44 `
+                -Description 'desc' -Owner 2 -Tags 'liquid', 7 -Custom_Fields @{ loop = 'A' } -Confirm:$false
+            $body = $Result.Body | ConvertFrom-Json
+            $body.device | Should -Be 12
+            $body.module | Should -Be 3
+            $body.label | Should -Be 'IN-1'
+            $body.type | Should -Be 'uqd'
+            $body.diameter | Should -Be 12.7
+            $body.diameter_unit | Should -Be 'mm'
+            $body.max_flow | Should -Be 8.5
+            $body.max_flow_unit | Should -Be 'lpm'
+            $body.cooling_outflow | Should -Be 44
+            $body.description | Should -Be 'desc'
+            $body.owner | Should -Be 2
+            $body.tags | Should -Be @('liquid', 7)
+            $body.custom_fields.loop | Should -Be 'A'
+        }
+
+        It "Should accept every connector type" -TestCases @(
+            @{ Type = 'uqd' }, @{ Type = 'uqdb' }, @{ Type = 'qdc' }, @{ Type = 'camlock' },
+            @{ Type = 'npt' }, @{ Type = 'bsp' }, @{ Type = 'proprietary' }
+        ) {
+            $Result = New-NBDCIMCoolingIntake -Device 1 -Name 'x' -Type $Type -Confirm:$false
+            ($Result.Body | ConvertFrom-Json).type | Should -Be $Type
+        }
+
+        It "Should reject an invalid -Type" {
+            { New-NBDCIMCoolingIntake -Device 1 -Name 'x' -Type 'garden-hose' -Confirm:$false } | Should -Throw
+        }
+
+        It "Should reject an invalid -Diameter_Unit" {
+            { New-NBDCIMCoolingIntake -Device 1 -Name 'x' -Diameter_Unit 'ft' -Confirm:$false } | Should -Throw
+        }
+
+        It "Should reject an invalid -Max_Flow_Unit" {
+            { New-NBDCIMCoolingIntake -Device 1 -Name 'x' -Max_Flow_Unit 'lps' -Confirm:$false } | Should -Throw
+        }
+
+        It "Should reject a -Diameter below 0.01" {
+            { New-NBDCIMCoolingIntake -Device 1 -Name 'x' -Diameter 0 -Confirm:$false } | Should -Throw
+        }
+
+        It "Should not call the API with -WhatIf" {
+            New-NBDCIMCoolingIntake -Device 1 -Name 'x' -WhatIf
+            Should -Invoke -CommandName 'InvokeNetboxRequest' -ModuleName 'PowerNetbox' -Times 0 -Exactly
+        }
+    }
+
+    Context "Set-NBDCIMCoolingIntake" {
+        It "Should PATCH the detail endpoint" {
+            $Result = Set-NBDCIMCoolingIntake -Id 5 -Label 'IN-2' -Confirm:$false
+            $Result.Method | Should -Be 'PATCH'
+            $Result.Uri | Should -Be 'https://netbox.domain.com/api/dcim/cooling-intakes/5/'
+            $Result.Body | Should -Be '{"label":"IN-2"}'
+        }
+
+        It "Should PATCH every writable field" {
+            $Result = Set-NBDCIMCoolingIntake -Id 5 -Device 12 -Module 3 -Name 'n' -Label 'l' -Type 'qdc' `
+                -Diameter 25.4 -Diameter_Unit 'in' -Max_Flow 16 -Max_Flow_Unit 'gpm' -Cooling_Outflow 44 `
+                -Description 'd' -Owner 2 -Tags 'liquid' -Custom_Fields @{ loop = 'B' } -Confirm:$false
+            $body = $Result.Body | ConvertFrom-Json
+            $body.device | Should -Be 12
+            $body.module | Should -Be 3
+            $body.name | Should -Be 'n'
+            $body.label | Should -Be 'l'
+            $body.type | Should -Be 'qdc'
+            $body.diameter | Should -Be 25.4
+            $body.diameter_unit | Should -Be 'in'
+            $body.max_flow | Should -Be 16
+            $body.max_flow_unit | Should -Be 'gpm'
+            $body.cooling_outflow | Should -Be 44
+            $body.description | Should -Be 'd'
+            $body.owner | Should -Be 2
+            $body.tags | Should -Be @('liquid')
+            $body.custom_fields.loop | Should -Be 'B'
+        }
+
+        It "Should send JSON null when <Param> is cleared with ''" -TestCases @(
+            @{ Param = 'Type';          Key = 'type' }
+            @{ Param = 'Diameter_Unit'; Key = 'diameter_unit' }
+            @{ Param = 'Max_Flow_Unit'; Key = 'max_flow_unit' }
+        ) {
+            $splat = @{ Id = 5; $Param = ''; Confirm = $false }
+            $Result = Set-NBDCIMCoolingIntake @splat
+            $Result.Body | Should -Be "{`"$Key`":null}"
+        }
+
+        It "Should send JSON null when <Param> is set to `$null" -TestCases @(
+            @{ Param = 'Module';          Key = 'module' }
+            @{ Param = 'Diameter';        Key = 'diameter' }
+            @{ Param = 'Max_Flow';        Key = 'max_flow' }
+            @{ Param = 'Cooling_Outflow'; Key = 'cooling_outflow' }
+        ) {
+            $splat = @{ Id = 5; $Param = $null; Confirm = $false }
+            $Result = Set-NBDCIMCoolingIntake @splat
+            $Result.Body | Should -Be "{`"$Key`":null}"
+        }
+
+        It "Should reject an invalid -Type" {
+            { Set-NBDCIMCoolingIntake -Id 5 -Type 'garden-hose' -Confirm:$false } | Should -Throw
+        }
+
+        It "Should accept Id from the pipeline by property name" {
+            $Result = [PSCustomObject]@{ Id = 9 } | Set-NBDCIMCoolingIntake -Label 'p' -Confirm:$false
+            $Result.Uri | Should -Be 'https://netbox.domain.com/api/dcim/cooling-intakes/9/'
+        }
+    }
+
+    Context "Remove-NBDCIMCoolingIntake" {
+        It "Should DELETE the detail endpoint" {
+            $Result = Remove-NBDCIMCoolingIntake -Id 5 -Confirm:$false
+            $Result.Method | Should -Be 'DELETE'
+            $Result.Uri | Should -Be 'https://netbox.domain.com/api/dcim/cooling-intakes/5/'
+        }
+
+        It "Should accept Id from the pipeline" {
+            $Result = [PSCustomObject]@{ Id = 7 } | Remove-NBDCIMCoolingIntake -Confirm:$false
+            $Result.Uri | Should -Be 'https://netbox.domain.com/api/dcim/cooling-intakes/7/'
+        }
+
+        It "Should not call the API with -WhatIf" {
+            Remove-NBDCIMCoolingIntake -Id 5 -WhatIf
+            Should -Invoke -CommandName 'InvokeNetboxRequest' -ModuleName 'PowerNetbox' -Times 0 -Exactly
+        }
+    }
+    #endregion
+
+    #region CoolingOutflows
+    Context "Get-NBDCIMCoolingOutflow" {
+        It "Should request the cooling-outflows list endpoint" {
+            $Result = Get-NBDCIMCoolingOutflow
+            $Result.Method | Should -Be 'GET'
+            $Result.Uri | Should -Be 'https://netbox.domain.com/api/dcim/cooling-outflows/'
+        }
+
+        It "Should request a cooling outflow by ID" {
+            $Result = Get-NBDCIMCoolingOutflow -Id 5
+            $Result.Uri | Should -Be 'https://netbox.domain.com/api/dcim/cooling-outflows/5/'
+        }
+
+        It "Should filter by <Param> as a repeated query key" -TestCases @(
+            @{ Param = 'Name';           Values = @('out0', 'out1'); Key = 'name' }
+            @{ Param = 'Label';          Values = @('A', 'B');       Key = 'label' }
+            @{ Param = 'Device_Id';      Values = @(1, 2);           Key = 'device_id' }
+            @{ Param = 'Device';         Values = @('sw1', 'sw2');   Key = 'device' }
+            @{ Param = 'Device_Type_Id'; Values = @(3, 4);           Key = 'device_type_id' }
+            @{ Param = 'Module_Id';      Values = @(5, 6);           Key = 'module_id' }
+            @{ Param = 'Site_Id';        Values = @(7, 8);           Key = 'site_id' }
+            @{ Param = 'Site';           Values = @('ams', 'fra');   Key = 'site' }
+            @{ Param = 'Location_Id';    Values = @(9, 10);          Key = 'location_id' }
+            @{ Param = 'Rack_Id';        Values = @(11, 12);         Key = 'rack_id' }
+            @{ Param = 'Type';           Values = @('uqd', 'qdc');   Key = 'type' }
+            @{ Param = 'Diameter';       Values = @(12.7, 25.4);     Key = 'diameter' }
+            @{ Param = 'Diameter_Unit';  Values = @('mm', 'in');     Key = 'diameter_unit' }
+            @{ Param = 'Cooling_Intake_Id'; Values = @(13, 14);      Key = 'cooling_intake_id' }
+            @{ Param = 'Description';    Values = @('x', 'y');       Key = 'description' }
+            @{ Param = 'Tag';            Values = @('t1', 't2');     Key = 'tag' }
+        ) {
+            $splat = @{ $Param = $Values }
+            $Result = Get-NBDCIMCoolingOutflow @splat
+            $Result.Uri | Should -Be "https://netbox.domain.com/api/dcim/cooling-outflows/?$Key=$($Values[0])&$Key=$($Values[1])"
+        }
+
+        It "Should not expose intake-only filters" {
+            $cmd = Get-Command Get-NBDCIMCoolingOutflow
+            $cmd.Parameters.Keys | Should -Not -Contain 'Max_Flow'
+            $cmd.Parameters.Keys | Should -Not -Contain 'Max_Flow_Unit'
+            $cmd.Parameters.Keys | Should -Not -Contain 'Cooling_Outflow_Id'
+        }
+
+        It "Should send -Query as q" {
+            $Result = Get-NBDCIMCoolingOutflow -Query 'coolant' -WarningAction SilentlyContinue
+            $Result.Uri | Should -Be 'https://netbox.domain.com/api/dcim/cooling-outflows/?q=coolant'
+        }
+
+        It "Should reject -Brief together with -Omit" {
+            { Get-NBDCIMCoolingOutflow -Brief -Omit 'tags' } | Should -Throw
+        }
+    }
+
+    Context "New-NBDCIMCoolingOutflow" {
+        It "Should POST every writable field" {
+            $Result = New-NBDCIMCoolingOutflow -Device 12 -Module 3 -Name 'Coolant Out' -Label 'OUT-1' -Type 'camlock' `
+                -Diameter 19.05 -Diameter_Unit 'mm' -Cooling_Intake 55 -Description 'desc' -Owner 2 `
+                -Tags 'liquid' -Custom_Fields @{ loop = 'A' } -Confirm:$false
+            $Result.Method | Should -Be 'POST'
+            $Result.Uri | Should -Be 'https://netbox.domain.com/api/dcim/cooling-outflows/'
+            $body = $Result.Body | ConvertFrom-Json
+            $body.device | Should -Be 12
+            $body.module | Should -Be 3
+            $body.name | Should -Be 'Coolant Out'
+            $body.label | Should -Be 'OUT-1'
+            $body.type | Should -Be 'camlock'
+            $body.diameter | Should -Be 19.05
+            $body.diameter_unit | Should -Be 'mm'
+            $body.cooling_intake | Should -Be 55
+            $body.description | Should -Be 'desc'
+            $body.owner | Should -Be 2
+            $body.tags | Should -Be @('liquid')
+            $body.custom_fields.loop | Should -Be 'A'
+        }
+
+        It "Should not expose intake-only fields" {
+            $cmd = Get-Command New-NBDCIMCoolingOutflow
+            $cmd.Parameters.Keys | Should -Not -Contain 'Max_Flow'
+            $cmd.Parameters.Keys | Should -Not -Contain 'Max_Flow_Unit'
+            $cmd.Parameters.Keys | Should -Not -Contain 'Cooling_Outflow'
+        }
+
+        It "Should reject an invalid -Type" {
+            { New-NBDCIMCoolingOutflow -Device 1 -Name 'x' -Type 'garden-hose' -Confirm:$false } | Should -Throw
+        }
+    }
+
+    Context "Set-NBDCIMCoolingOutflow" {
+        It "Should PATCH the detail endpoint with every writable field" {
+            $Result = Set-NBDCIMCoolingOutflow -Id 5 -Device 12 -Module 3 -Name 'n' -Label 'l' -Type 'npt' `
+                -Diameter 6.35 -Diameter_Unit 'cm' -Cooling_Intake 55 -Description 'd' -Owner 2 -Tags 'a' `
+                -Custom_Fields @{ loop = 'C' } -Confirm:$false
+            $Result.Method | Should -Be 'PATCH'
+            $Result.Uri | Should -Be 'https://netbox.domain.com/api/dcim/cooling-outflows/5/'
+            $body = $Result.Body | ConvertFrom-Json
+            $body.device | Should -Be 12
+            $body.module | Should -Be 3
+            $body.name | Should -Be 'n'
+            $body.label | Should -Be 'l'
+            $body.type | Should -Be 'npt'
+            $body.diameter | Should -Be 6.35
+            $body.diameter_unit | Should -Be 'cm'
+            $body.cooling_intake | Should -Be 55
+            $body.description | Should -Be 'd'
+            $body.owner | Should -Be 2
+            $body.tags | Should -Be @('a')
+            $body.custom_fields.loop | Should -Be 'C'
+        }
+
+        It "Should send JSON null when <Param> is cleared with ''" -TestCases @(
+            @{ Param = 'Type';          Key = 'type' }
+            @{ Param = 'Diameter_Unit'; Key = 'diameter_unit' }
+        ) {
+            $splat = @{ Id = 5; $Param = ''; Confirm = $false }
+            (Set-NBDCIMCoolingOutflow @splat).Body | Should -Be "{`"$Key`":null}"
+        }
+
+        It "Should send JSON null when <Param> is set to `$null" -TestCases @(
+            @{ Param = 'Module';         Key = 'module' }
+            @{ Param = 'Diameter';       Key = 'diameter' }
+            @{ Param = 'Cooling_Intake'; Key = 'cooling_intake' }
+        ) {
+            $splat = @{ Id = 5; $Param = $null; Confirm = $false }
+            (Set-NBDCIMCoolingOutflow @splat).Body | Should -Be "{`"$Key`":null}"
+        }
+    }
+
+    Context "Remove-NBDCIMCoolingOutflow" {
+        It "Should DELETE the detail endpoint" {
+            $Result = Remove-NBDCIMCoolingOutflow -Id 5 -Confirm:$false
+            $Result.Method | Should -Be 'DELETE'
+            $Result.Uri | Should -Be 'https://netbox.domain.com/api/dcim/cooling-outflows/5/'
+        }
+
+        It "Should not call the API with -WhatIf" {
+            Remove-NBDCIMCoolingOutflow -Id 5 -WhatIf
+            Should -Invoke -CommandName 'InvokeNetboxRequest' -ModuleName 'PowerNetbox' -Times 0 -Exactly
+        }
+    }
+    #endregion
+
+    #region CoolingIntakeTemplates
+    Context "Get-NBDCIMCoolingIntakeTemplate" {
+        It "Should request the cooling-intake-templates list endpoint" {
+            $Result = Get-NBDCIMCoolingIntakeTemplate
+            $Result.Method | Should -Be 'GET'
+            $Result.Uri | Should -Be 'https://netbox.domain.com/api/dcim/cooling-intake-templates/'
+        }
+
+        It "Should request a cooling intake template by ID" {
+            $Result = Get-NBDCIMCoolingIntakeTemplate -Id 5
+            $Result.Uri | Should -Be 'https://netbox.domain.com/api/dcim/cooling-intake-templates/5/'
+        }
+
+        It "Should filter by <Param> as a repeated query key" -TestCases @(
+            @{ Param = 'Name';           Values = @('in0', 'in1');   Key = 'name' }
+            @{ Param = 'Label';          Values = @('A', 'B');       Key = 'label' }
+            @{ Param = 'Device_Type_Id'; Values = @(3, 4);           Key = 'device_type_id' }
+            @{ Param = 'Module_Type_Id'; Values = @(5, 6);           Key = 'module_type_id' }
+            @{ Param = 'Type';           Values = @('uqd', 'qdc');   Key = 'type' }
+            @{ Param = 'Diameter';       Values = @(12.7, 25.4);     Key = 'diameter' }
+            @{ Param = 'Diameter_Unit';  Values = @('mm', 'in');     Key = 'diameter_unit' }
+            @{ Param = 'Max_Flow';       Values = @(8, 16.5);        Key = 'max_flow' }
+            @{ Param = 'Max_Flow_Unit';  Values = @('lpm', 'gpm');   Key = 'max_flow_unit' }
+            @{ Param = 'Description';    Values = @('x', 'y');       Key = 'description' }
+        ) {
+            $splat = @{ $Param = $Values }
+            $Result = Get-NBDCIMCoolingIntakeTemplate @splat
+            $Result.Uri | Should -Be "https://netbox.domain.com/api/dcim/cooling-intake-templates/?$Key=$($Values[0])&$Key=$($Values[1])"
+        }
+
+        It "Should not expose device-level filters" {
+            $cmd = Get-Command Get-NBDCIMCoolingIntakeTemplate
+            $cmd.Parameters.Keys | Should -Not -Contain 'Device_Id'
+            $cmd.Parameters.Keys | Should -Not -Contain 'Site_Id'
+            $cmd.Parameters.Keys | Should -Not -Contain 'Tag'
+        }
+
+        It "Should send -Query as q" {
+            $Result = Get-NBDCIMCoolingIntakeTemplate -Query 'coolant' -WarningAction SilentlyContinue
+            $Result.Uri | Should -Be 'https://netbox.domain.com/api/dcim/cooling-intake-templates/?q=coolant'
+        }
+    }
+
+    Context "New-NBDCIMCoolingIntakeTemplate" {
+        It "Should require Name only" {
+            $cmd = Get-Command New-NBDCIMCoolingIntakeTemplate
+            $cmd.Parameters['Name'].Attributes.Where({ $_ -is [System.Management.Automation.ParameterAttribute] }).Mandatory | Should -Be $true
+            $cmd.Parameters['Device_Type'].Attributes.Where({ $_ -is [System.Management.Automation.ParameterAttribute] }).Mandatory | Should -Not -Contain $true
+        }
+
+        It "Should POST every writable field on a device type" {
+            $Result = New-NBDCIMCoolingIntakeTemplate -Device_Type 4 -Name 'Coolant In' -Label 'IN-1' -Type 'uqdb' `
+                -Diameter 12.7 -Diameter_Unit 'mm' -Max_Flow 8 -Max_Flow_Unit 'm3ph' -Description 'desc' -Confirm:$false
+            $Result.Method | Should -Be 'POST'
+            $Result.Uri | Should -Be 'https://netbox.domain.com/api/dcim/cooling-intake-templates/'
+            $body = $Result.Body | ConvertFrom-Json
+            $body.device_type | Should -Be 4
+            $body.name | Should -Be 'Coolant In'
+            $body.label | Should -Be 'IN-1'
+            $body.type | Should -Be 'uqdb'
+            $body.diameter | Should -Be 12.7
+            $body.diameter_unit | Should -Be 'mm'
+            $body.max_flow | Should -Be 8
+            $body.max_flow_unit | Should -Be 'm3ph'
+            $body.description | Should -Be 'desc'
+            $body.PSObject.Properties.Name | Should -Not -Contain 'module_type'
+        }
+
+        It "Should POST a module type template" {
+            $Result = New-NBDCIMCoolingIntakeTemplate -Module_Type 8 -Name 'In {module}' -Confirm:$false
+            $body = $Result.Body | ConvertFrom-Json
+            $body.module_type | Should -Be 8
+            $body.name | Should -Be 'In {module}'
+        }
+
+        It "Should not expose component-only fields" {
+            $cmd = Get-Command New-NBDCIMCoolingIntakeTemplate
+            foreach ($p in 'Device', 'Module', 'Owner', 'Tags', 'Custom_Fields', 'Cooling_Outflow') {
+                $cmd.Parameters.Keys | Should -Not -Contain $p
+            }
+        }
+
+        It "Should reject an invalid -Max_Flow_Unit" {
+            { New-NBDCIMCoolingIntakeTemplate -Name 'x' -Max_Flow_Unit 'lps' -Confirm:$false } | Should -Throw
+        }
+    }
+
+    Context "Set-NBDCIMCoolingIntakeTemplate" {
+        It "Should PATCH the detail endpoint with every writable field" {
+            $Result = Set-NBDCIMCoolingIntakeTemplate -Id 5 -Device_Type 4 -Module_Type 8 -Name 'n' -Label 'l' -Type 'bsp' `
+                -Diameter 1 -Diameter_Unit 'in' -Max_Flow 2 -Max_Flow_Unit 'gpm' -Description 'd' -Confirm:$false
+            $Result.Method | Should -Be 'PATCH'
+            $Result.Uri | Should -Be 'https://netbox.domain.com/api/dcim/cooling-intake-templates/5/'
+            $body = $Result.Body | ConvertFrom-Json
+            $body.device_type | Should -Be 4
+            $body.module_type | Should -Be 8
+            $body.name | Should -Be 'n'
+            $body.label | Should -Be 'l'
+            $body.type | Should -Be 'bsp'
+            $body.diameter | Should -Be 1
+            $body.diameter_unit | Should -Be 'in'
+            $body.max_flow | Should -Be 2
+            $body.max_flow_unit | Should -Be 'gpm'
+            $body.description | Should -Be 'd'
+        }
+
+        It "Should send JSON null when <Param> is cleared with ''" -TestCases @(
+            @{ Param = 'Type';          Key = 'type' }
+            @{ Param = 'Diameter_Unit'; Key = 'diameter_unit' }
+            @{ Param = 'Max_Flow_Unit'; Key = 'max_flow_unit' }
+        ) {
+            $splat = @{ Id = 5; $Param = ''; Confirm = $false }
+            (Set-NBDCIMCoolingIntakeTemplate @splat).Body | Should -Be "{`"$Key`":null}"
+        }
+
+        It "Should send JSON null when <Param> is set to `$null" -TestCases @(
+            @{ Param = 'Device_Type'; Key = 'device_type' }
+            @{ Param = 'Module_Type'; Key = 'module_type' }
+            @{ Param = 'Diameter';    Key = 'diameter' }
+            @{ Param = 'Max_Flow';    Key = 'max_flow' }
+        ) {
+            $splat = @{ Id = 5; $Param = $null; Confirm = $false }
+            (Set-NBDCIMCoolingIntakeTemplate @splat).Body | Should -Be "{`"$Key`":null}"
+        }
+    }
+
+    Context "Remove-NBDCIMCoolingIntakeTemplate" {
+        It "Should DELETE the detail endpoint" {
+            $Result = Remove-NBDCIMCoolingIntakeTemplate -Id 5 -Confirm:$false
+            $Result.Method | Should -Be 'DELETE'
+            $Result.Uri | Should -Be 'https://netbox.domain.com/api/dcim/cooling-intake-templates/5/'
+        }
+
+        It "Should not call the API with -WhatIf" {
+            Remove-NBDCIMCoolingIntakeTemplate -Id 5 -WhatIf
+            Should -Invoke -CommandName 'InvokeNetboxRequest' -ModuleName 'PowerNetbox' -Times 0 -Exactly
+        }
+    }
+    #endregion
+
+    #region CoolingOutflowTemplates
+    Context "Get-NBDCIMCoolingOutflowTemplate" {
+        It "Should request the cooling-outflow-templates list endpoint" {
+            $Result = Get-NBDCIMCoolingOutflowTemplate
+            $Result.Method | Should -Be 'GET'
+            $Result.Uri | Should -Be 'https://netbox.domain.com/api/dcim/cooling-outflow-templates/'
+        }
+
+        It "Should request a cooling outflow template by ID" {
+            $Result = Get-NBDCIMCoolingOutflowTemplate -Id 5
+            $Result.Uri | Should -Be 'https://netbox.domain.com/api/dcim/cooling-outflow-templates/5/'
+        }
+
+        It "Should filter by <Param> as a repeated query key" -TestCases @(
+            @{ Param = 'Name';           Values = @('out0', 'out1'); Key = 'name' }
+            @{ Param = 'Label';          Values = @('A', 'B');       Key = 'label' }
+            @{ Param = 'Device_Type_Id'; Values = @(3, 4);           Key = 'device_type_id' }
+            @{ Param = 'Module_Type_Id'; Values = @(5, 6);           Key = 'module_type_id' }
+            @{ Param = 'Type';           Values = @('uqd', 'qdc');   Key = 'type' }
+            @{ Param = 'Diameter';       Values = @(12.7, 25.4);     Key = 'diameter' }
+            @{ Param = 'Diameter_Unit';  Values = @('mm', 'in');     Key = 'diameter_unit' }
+            @{ Param = 'Cooling_Intake_Id'; Values = @(13, 14);      Key = 'cooling_intake_id' }
+            @{ Param = 'Description';    Values = @('x', 'y');       Key = 'description' }
+        ) {
+            $splat = @{ $Param = $Values }
+            $Result = Get-NBDCIMCoolingOutflowTemplate @splat
+            $Result.Uri | Should -Be "https://netbox.domain.com/api/dcim/cooling-outflow-templates/?$Key=$($Values[0])&$Key=$($Values[1])"
+        }
+
+        It "Should not expose intake-only filters" {
+            $cmd = Get-Command Get-NBDCIMCoolingOutflowTemplate
+            $cmd.Parameters.Keys | Should -Not -Contain 'Max_Flow'
+            $cmd.Parameters.Keys | Should -Not -Contain 'Max_Flow_Unit'
+        }
+    }
+
+    Context "New-NBDCIMCoolingOutflowTemplate" {
+        It "Should POST every writable field" {
+            $Result = New-NBDCIMCoolingOutflowTemplate -Device_Type 4 -Name 'Coolant Out' -Label 'OUT-1' -Type 'proprietary' `
+                -Diameter 12.7 -Diameter_Unit 'mm' -Cooling_Intake 9 -Description 'desc' -Confirm:$false
+            $Result.Method | Should -Be 'POST'
+            $Result.Uri | Should -Be 'https://netbox.domain.com/api/dcim/cooling-outflow-templates/'
+            $body = $Result.Body | ConvertFrom-Json
+            $body.device_type | Should -Be 4
+            $body.name | Should -Be 'Coolant Out'
+            $body.label | Should -Be 'OUT-1'
+            $body.type | Should -Be 'proprietary'
+            $body.diameter | Should -Be 12.7
+            $body.diameter_unit | Should -Be 'mm'
+            $body.cooling_intake | Should -Be 9
+            $body.description | Should -Be 'desc'
+        }
+
+        It "Should POST a module type template" {
+            $Result = New-NBDCIMCoolingOutflowTemplate -Module_Type 8 -Name 'Out {module}' -Confirm:$false
+            ($Result.Body | ConvertFrom-Json).module_type | Should -Be 8
+        }
+
+        It "Should reject an invalid -Diameter_Unit" {
+            { New-NBDCIMCoolingOutflowTemplate -Name 'x' -Diameter_Unit 'ft' -Confirm:$false } | Should -Throw
+        }
+    }
+
+    Context "Set-NBDCIMCoolingOutflowTemplate" {
+        It "Should PATCH the detail endpoint with every writable field" {
+            $Result = Set-NBDCIMCoolingOutflowTemplate -Id 5 -Device_Type 4 -Module_Type 8 -Name 'n' -Label 'l' -Type 'uqd' `
+                -Diameter 3 -Diameter_Unit 'cm' -Cooling_Intake 9 -Description 'd' -Confirm:$false
+            $Result.Method | Should -Be 'PATCH'
+            $Result.Uri | Should -Be 'https://netbox.domain.com/api/dcim/cooling-outflow-templates/5/'
+            $body = $Result.Body | ConvertFrom-Json
+            $body.device_type | Should -Be 4
+            $body.module_type | Should -Be 8
+            $body.name | Should -Be 'n'
+            $body.label | Should -Be 'l'
+            $body.type | Should -Be 'uqd'
+            $body.diameter | Should -Be 3
+            $body.diameter_unit | Should -Be 'cm'
+            $body.cooling_intake | Should -Be 9
+            $body.description | Should -Be 'd'
+        }
+
+        It "Should send JSON null when <Param> is cleared with ''" -TestCases @(
+            @{ Param = 'Type';          Key = 'type' }
+            @{ Param = 'Diameter_Unit'; Key = 'diameter_unit' }
+        ) {
+            $splat = @{ Id = 5; $Param = ''; Confirm = $false }
+            (Set-NBDCIMCoolingOutflowTemplate @splat).Body | Should -Be "{`"$Key`":null}"
+        }
+
+        It "Should send JSON null when <Param> is set to `$null" -TestCases @(
+            @{ Param = 'Device_Type';    Key = 'device_type' }
+            @{ Param = 'Module_Type';    Key = 'module_type' }
+            @{ Param = 'Diameter';       Key = 'diameter' }
+            @{ Param = 'Cooling_Intake'; Key = 'cooling_intake' }
+        ) {
+            $splat = @{ Id = 5; $Param = $null; Confirm = $false }
+            (Set-NBDCIMCoolingOutflowTemplate @splat).Body | Should -Be "{`"$Key`":null}"
+        }
+    }
+
+    Context "Remove-NBDCIMCoolingOutflowTemplate" {
+        It "Should DELETE the detail endpoint" {
+            $Result = Remove-NBDCIMCoolingOutflowTemplate -Id 5 -Confirm:$false
+            $Result.Method | Should -Be 'DELETE'
+            $Result.Uri | Should -Be 'https://netbox.domain.com/api/dcim/cooling-outflow-templates/5/'
+        }
+
+        It "Should not call the API with -WhatIf" {
+            Remove-NBDCIMCoolingOutflowTemplate -Id 5 -WhatIf
+            Should -Invoke -CommandName 'InvokeNetboxRequest' -ModuleName 'PowerNetbox' -Times 0 -Exactly
+        }
+    }
+    #endregion
+
+    Context "Cmdlet metadata" {
+        It "<Name> should declare ConfirmImpact <Impact> and support ShouldProcess" -TestCases @(
+            @{ Name = 'New-NBDCIMCoolingIntake';            Impact = 'Low' }
+            @{ Name = 'Set-NBDCIMCoolingIntake';            Impact = 'Medium' }
+            @{ Name = 'Remove-NBDCIMCoolingIntake';         Impact = 'High' }
+            @{ Name = 'New-NBDCIMCoolingOutflow';           Impact = 'Low' }
+            @{ Name = 'Set-NBDCIMCoolingOutflow';           Impact = 'Medium' }
+            @{ Name = 'Remove-NBDCIMCoolingOutflow';        Impact = 'High' }
+            @{ Name = 'New-NBDCIMCoolingIntakeTemplate';    Impact = 'Low' }
+            @{ Name = 'Set-NBDCIMCoolingIntakeTemplate';    Impact = 'Medium' }
+            @{ Name = 'Remove-NBDCIMCoolingIntakeTemplate'; Impact = 'High' }
+            @{ Name = 'New-NBDCIMCoolingOutflowTemplate';   Impact = 'Low' }
+            @{ Name = 'Set-NBDCIMCoolingOutflowTemplate';   Impact = 'Medium' }
+            @{ Name = 'Remove-NBDCIMCoolingOutflowTemplate'; Impact = 'High' }
+        ) {
+            $cmd = Get-Command $Name
+            $cmd.Parameters.Keys | Should -Contain 'WhatIf'
+            $attr = $cmd.ScriptBlock.Attributes.Where({ $_ -is [System.Management.Automation.CmdletBindingAttribute] })
+            $attr.ConfirmImpact | Should -Be $Impact
+        }
+
+        It "<Name> should type -Offset as uint32" -TestCases @(
+            @{ Name = 'Get-NBDCIMCoolingIntake' }
+            @{ Name = 'Get-NBDCIMCoolingOutflow' }
+            @{ Name = 'Get-NBDCIMCoolingIntakeTemplate' }
+            @{ Name = 'Get-NBDCIMCoolingOutflowTemplate' }
+        ) {
+            (Get-Command $Name).Parameters['Offset'].ParameterType | Should -Be ([uint32])
+        }
+    }
+}

--- a/Tests/DCIM.Fields47.Tests.ps1
+++ b/Tests/DCIM.Fields47.Tests.ps1
@@ -1,0 +1,401 @@
+<#
+.SYNOPSIS
+    Unit tests for the NetBox 4.7 fields added to existing DCIM cmdlets.
+
+.DESCRIPTION
+    Covers the version-gated 4.7-only parameters on:
+      - Interfaces / Interface templates: -Channels, -Channel_Id, -MAC_Address (writable)
+      - Device / DeviceType / ModuleType: -Cooling_Method, -End_Of_Life
+      - Rack / RackType: -Cooling_Capability, -Cooling_Capacity
+
+    Every parameter is asserted twice: present on the wire when the connected
+    NetBox is 4.7.0, and dropped with a warning when it is 4.6.10.
+#>
+
+param()
+
+BeforeAll {
+    Import-Module Pester
+    Remove-Module PowerNetbox -Force -ErrorAction SilentlyContinue
+
+    $ModulePath = Join-Path (Join-Path $PSScriptRoot "..") "PowerNetbox/PowerNetbox.psd1"
+    if (Test-Path $ModulePath) {
+        Import-Module $ModulePath -ErrorAction Stop
+    }
+
+    $script:TestPath = $PSScriptRoot
+}
+
+Describe "DCIM NetBox 4.7 field tests" -Tag 'DCIM', 'Fields47' {
+    BeforeAll {
+        Mock -CommandName 'CheckNetboxIsConnected' -ModuleName 'PowerNetbox' -MockWith { return $true }
+
+        Mock -CommandName 'InvokeNetboxRequest' -ModuleName 'PowerNetbox' -MockWith {
+            return [ordered]@{
+                'Method' = if ($Method) { $Method } else { 'GET' }
+                'Uri'    = $URI.Uri.AbsoluteUri
+                'Body'   = if ($Body) { $Body | ConvertTo-Json -Compress } else { $null }
+            }
+        }
+
+        InModuleScope -ModuleName 'PowerNetbox' -ArgumentList $script:TestPath -ScriptBlock {
+            param($TestPath)
+            $script:NetboxConfig.Hostname = 'netbox.domain.com'
+            $script:NetboxConfig.HostScheme = 'https'
+            $script:NetboxConfig.HostPort = 443
+        }
+
+        $script:parsedVersionBefore = InModuleScope -ModuleName 'PowerNetbox' { $script:NetboxConfig.ParsedVersion }
+        InModuleScope -ModuleName 'PowerNetbox' { $script:NetboxConfig.ParsedVersion = [version]'4.7.0' }
+    }
+
+    AfterAll {
+        InModuleScope -ModuleName 'PowerNetbox' -Parameters @{ v = $script:parsedVersionBefore } { $script:NetboxConfig.ParsedVersion = $v }
+    }
+
+    #region Interfaces
+    Context "Interfaces: -Channels / -Channel_Id / -MAC_Address (NetBox 4.7+)" {
+        It "New-NBDCIMInterface sends channels for a breakout parent" {
+            $Result = New-NBDCIMInterface -Device 1 -Name 'et-0/0/0' -Type '400gbase-x-qsfpdd' -Channels 4
+            $Result.Method | Should -Be 'POST'
+            $body = $Result.Body | ConvertFrom-Json
+            $body.channels | Should -Be 4
+        }
+
+        It "New-NBDCIMInterface sends channel_id + parent for a channel subinterface" {
+            $Result = New-NBDCIMInterface -Device 1 -Name 'et-0/0/0:1' -Type 'channel' -Parent 10 -Channel_Id 1
+            $body = $Result.Body | ConvertFrom-Json
+            $body.type | Should -Be 'channel'
+            $body.parent | Should -Be 10
+            $body.channel_id | Should -Be 1
+        }
+
+        It "New-NBDCIMInterface sends mac_address by value" {
+            $Result = New-NBDCIMInterface -Device 1 -Name 'eth0' -Type '1000base-t' -MAC_Address '00:11:22:33:44:55'
+            $body = $Result.Body | ConvertFrom-Json
+            $body.mac_address | Should -Be '00:11:22:33:44:55'
+        }
+
+        It "New-NBDCIMInterface rejects -Channels outside 1-1024" {
+            { New-NBDCIMInterface -Device 1 -Name 'x' -Type '1000base-t' -Channels 0 } | Should -Throw
+            { New-NBDCIMInterface -Device 1 -Name 'x' -Type '1000base-t' -Channels 2000 } | Should -Throw
+        }
+
+        It "Set-NBDCIMInterface sends channels and channel_id" {
+            $Result = Set-NBDCIMInterface -Id 42 -Channels 8 -Channel_Id 3
+            $Result.Method | Should -Be 'PATCH'
+            $body = $Result.Body | ConvertFrom-Json
+            $body.channels | Should -Be 8
+            $body.channel_id | Should -Be 3
+        }
+
+        It "Set-NBDCIMInterface sends null when -Channels / -Channel_Id are `$null" {
+            $Result = Set-NBDCIMInterface -Id 42 -Channels $null -Channel_Id $null
+            $Result.Body | Should -Match '"channels":null'
+            $Result.Body | Should -Match '"channel_id":null'
+        }
+
+        It "Set-NBDCIMInterface sends mac_address by value" {
+            $Result = Set-NBDCIMInterface -Id 42 -MAC_Address 'AA:BB:CC:DD:EE:FF'
+            $body = $Result.Body | ConvertFrom-Json
+            $body.mac_address | Should -Be 'AA:BB:CC:DD:EE:FF'
+        }
+
+        It "Set-NBDCIMInterface translates -MAC_Address '' to JSON null" {
+            $Result = Set-NBDCIMInterface -Id 42 -MAC_Address ''
+            $Result.Body | Should -Match '"mac_address":null'
+        }
+
+        It "Set-NBDCIMInterface keeps -Primary_MAC_Address as a numeric ID alongside -MAC_Address" {
+            $Result = Set-NBDCIMInterface -Id 42 -Primary_MAC_Address 7
+            $body = $Result.Body | ConvertFrom-Json
+            $body.primary_mac_address | Should -Be 7
+            $body.PSObject.Properties.Name | Should -Not -Contain 'mac_address'
+        }
+
+        It "Get-NBDCIMInterface emits repeat-key channels / channel_id filters" {
+            $Result = Get-NBDCIMInterface -Channels 4, 8 -Channel_Id 1
+            $Result.Uri | Should -Match 'channels=4'
+            $Result.Uri | Should -Match 'channels=8'
+            $Result.Uri | Should -Match 'channel_id=1'
+        }
+
+        It "Get-NBDCIMInterface accepts multiple -MAC_Address values" {
+            $Result = Get-NBDCIMInterface -MAC_Address '00:11:22:33:44:55', 'AA:BB:CC:DD:EE:FF'
+            $Result.Uri | Should -Match 'mac_address=00%3A11%3A22%3A33%3A44%3A55'
+            $Result.Uri | Should -Match 'mac_address=AA%3ABB%3ACC%3ADD%3AEE%3AFF'
+        }
+    }
+
+    Context "Interface templates: -Channels / -Channel_Id (NetBox 4.7+)" {
+        It "New-NBDCIMInterfaceTemplate sends channels and channel_id" {
+            $Result = New-NBDCIMInterfaceTemplate -Device_Type 1 -Name 'et-{module}/0/0' -Type '400gbase-x-qsfpdd' -Channels 4
+            $body = $Result.Body | ConvertFrom-Json
+            $body.channels | Should -Be 4
+
+            $Result = New-NBDCIMInterfaceTemplate -Device_Type 1 -Name 'et-{module}/0/0:1' -Type 'channel' -Channel_Id 1
+            $body = $Result.Body | ConvertFrom-Json
+            $body.channel_id | Should -Be 1
+        }
+
+        It "Set-NBDCIMInterfaceTemplate sends channels / channel_id and null to clear" {
+            $Result = Set-NBDCIMInterfaceTemplate -Id 5 -Channels 2 -Channel_Id 2
+            $body = $Result.Body | ConvertFrom-Json
+            $body.channels | Should -Be 2
+            $body.channel_id | Should -Be 2
+
+            $Result = Set-NBDCIMInterfaceTemplate -Id 5 -Channels $null
+            $Result.Body | Should -Match '"channels":null'
+        }
+
+        It "Get-NBDCIMInterfaceTemplate emits channels / channel_id filters" {
+            $Result = Get-NBDCIMInterfaceTemplate -Channels 4 -Channel_Id 1, 2
+            $Result.Uri | Should -Match 'channels=4'
+            $Result.Uri | Should -Match 'channel_id=1'
+            $Result.Uri | Should -Match 'channel_id=2'
+        }
+    }
+    #endregion
+
+    #region Cooling method / End of life
+    Context "Cooling method on Device / DeviceType / ModuleType (NetBox 4.7+)" {
+        It "New-NBDCIMDevice sends cooling_method" {
+            $Result = New-NBDCIMDevice -Name 'srv1' -Role 1 -Device_Type 1 -Site 1 -Cooling_Method 'liquid'
+            $body = $Result.Body | ConvertFrom-Json
+            $body.cooling_method | Should -Be 'liquid'
+        }
+
+        It "Set-NBDCIMDevice sends cooling_method and translates '' to null" {
+            $Result = Set-NBDCIMDevice -Id 1 -Cooling_Method 'immersion'
+            ($Result.Body | ConvertFrom-Json).cooling_method | Should -Be 'immersion'
+
+            $Result = Set-NBDCIMDevice -Id 1 -Cooling_Method ''
+            $Result.Body | Should -Match '"cooling_method":null'
+        }
+
+        It "Get-NBDCIMDevice emits the (scalar) cooling_method filter" {
+            $Result = Get-NBDCIMDevice -Cooling_Method 'air'
+            $Result.Uri | Should -Match 'cooling_method=air'
+        }
+
+        It "New-NBDCIMDeviceType sends cooling_method" {
+            $Result = New-NBDCIMDeviceType -Manufacturer 1 -Model 'X1' -Cooling_Method 'hybrid'
+            ($Result.Body | ConvertFrom-Json).cooling_method | Should -Be 'hybrid'
+        }
+
+        It "New-NBDCIMDeviceType rejects an unknown cooling method" {
+            { New-NBDCIMDeviceType -Manufacturer 1 -Model 'X1' -Cooling_Method 'water' } | Should -Throw
+        }
+
+        It "Set-NBDCIMDeviceType sends cooling_method and translates '' to null" {
+            $Result = Set-NBDCIMDeviceType -Id 3 -Cooling_Method 'air'
+            ($Result.Body | ConvertFrom-Json).cooling_method | Should -Be 'air'
+
+            $Result = Set-NBDCIMDeviceType -Id 3 -Cooling_Method ''
+            $Result.Body | Should -Match '"cooling_method":null'
+        }
+
+        It "Get-NBDCIMDeviceType emits the cooling_method filter" {
+            $Result = Get-NBDCIMDeviceType -Cooling_Method 'immersion'
+            $Result.Uri | Should -Match 'cooling_method=immersion'
+        }
+
+        It "New-NBDCIMModuleType sends cooling_method" {
+            $Result = New-NBDCIMModuleType -Manufacturer 1 -Model 'M1' -Cooling_Method 'air'
+            ($Result.Body | ConvertFrom-Json).cooling_method | Should -Be 'air'
+        }
+
+        It "Set-NBDCIMModuleType sends cooling_method and translates '' to null" {
+            $Result = Set-NBDCIMModuleType -Id 3 -Cooling_Method 'liquid'
+            ($Result.Body | ConvertFrom-Json).cooling_method | Should -Be 'liquid'
+
+            $Result = Set-NBDCIMModuleType -Id 3 -Cooling_Method ''
+            $Result.Body | Should -Match '"cooling_method":null'
+        }
+
+        It "Get-NBDCIMModuleType emits the cooling_method filter" {
+            $Result = Get-NBDCIMModuleType -Cooling_Method 'hybrid'
+            $Result.Uri | Should -Match 'cooling_method=hybrid'
+        }
+    }
+
+    Context "End of life on DeviceType / ModuleType (NetBox 4.7+)" {
+        It "New-NBDCIMDeviceType serializes end_of_life as yyyy-MM-dd" {
+            $Result = New-NBDCIMDeviceType -Manufacturer 1 -Model 'X1' -End_Of_Life (Get-Date '2030-06-30')
+            ($Result.Body | ConvertFrom-Json).end_of_life | Should -Be '2030-06-30'
+        }
+
+        It "Set-NBDCIMDeviceType serializes end_of_life and sends null to clear" {
+            $Result = Set-NBDCIMDeviceType -Id 3 -End_Of_Life '2031-01-15'
+            ($Result.Body | ConvertFrom-Json).end_of_life | Should -Be '2031-01-15'
+
+            $Result = Set-NBDCIMDeviceType -Id 3 -End_Of_Life $null
+            $Result.Body | Should -Match '"end_of_life":null'
+        }
+
+        It "Get-NBDCIMDeviceType emits end_of_life filter values as yyyy-MM-dd" {
+            $Result = Get-NBDCIMDeviceType -End_Of_Life (Get-Date '2030-06-30'), (Get-Date '2031-01-15')
+            $Result.Uri | Should -Match 'end_of_life=2030-06-30'
+            $Result.Uri | Should -Match 'end_of_life=2031-01-15'
+        }
+
+        It "New-NBDCIMModuleType serializes end_of_life as yyyy-MM-dd" {
+            $Result = New-NBDCIMModuleType -Manufacturer 1 -Model 'M1' -End_Of_Life '2029-12-31'
+            ($Result.Body | ConvertFrom-Json).end_of_life | Should -Be '2029-12-31'
+        }
+
+        It "Set-NBDCIMModuleType serializes end_of_life and sends null to clear" {
+            $Result = Set-NBDCIMModuleType -Id 3 -End_Of_Life (Get-Date '2029-12-31')
+            ($Result.Body | ConvertFrom-Json).end_of_life | Should -Be '2029-12-31'
+
+            $Result = Set-NBDCIMModuleType -Id 3 -End_Of_Life $null
+            $Result.Body | Should -Match '"end_of_life":null'
+        }
+
+        It "Get-NBDCIMModuleType emits the end_of_life filter" {
+            $Result = Get-NBDCIMModuleType -End_Of_Life '2029-12-31'
+            $Result.Uri | Should -Match 'end_of_life=2029-12-31'
+        }
+    }
+    #endregion
+
+    #region Rack cooling
+    Context "Rack / RackType: -Cooling_Capability / -Cooling_Capacity (NetBox 4.7+)" {
+        It "New-NBDCIMRack sends cooling_capability and cooling_capacity" {
+            $Result = New-NBDCIMRack -Name 'R1' -Site 1 -Cooling_Capability 'liquid-only' -Cooling_Capacity 12.5
+            $body = $Result.Body | ConvertFrom-Json
+            $body.cooling_capability | Should -Be 'liquid-only'
+            $body.cooling_capacity | Should -Be 12.5
+        }
+
+        It "New-NBDCIMRack rejects an unknown cooling capability" {
+            { New-NBDCIMRack -Name 'R1' -Site 1 -Cooling_Capability 'water' } | Should -Throw
+        }
+
+        It "New-NBDCIMRack still sends the deprecated geometry fields (verbose note only)" {
+            $Result = New-NBDCIMRack -Name 'R1' -Site 1 -Width 19 -Form_Factor '4-post-cabinet' -Outer_Width 600 -WarningVariable warn -WarningAction SilentlyContinue
+            $body = $Result.Body | ConvertFrom-Json
+            $body.width | Should -Be 19
+            $body.form_factor | Should -Be '4-post-cabinet'
+            $body.outer_width | Should -Be 600
+            $warn | Should -BeNullOrEmpty
+        }
+
+        It "Set-NBDCIMRack sends cooling fields, '' clears capability, `$null clears capacity" {
+            $Result = Set-NBDCIMRack -Id 1 -Cooling_Capability 'hybrid' -Cooling_Capacity 7.25
+            $body = $Result.Body | ConvertFrom-Json
+            $body.cooling_capability | Should -Be 'hybrid'
+            $body.cooling_capacity | Should -Be 7.25
+
+            $Result = Set-NBDCIMRack -Id 1 -Cooling_Capability '' -Cooling_Capacity $null
+            $Result.Body | Should -Match '"cooling_capability":null'
+            $Result.Body | Should -Match '"cooling_capacity":null'
+        }
+
+        It "Get-NBDCIMRack emits repeat-key cooling filters" {
+            $Result = Get-NBDCIMRack -Cooling_Capability 'air-only', 'hybrid' -Cooling_Capacity 10, 12.5
+            $Result.Uri | Should -Match 'cooling_capability=air-only'
+            $Result.Uri | Should -Match 'cooling_capability=hybrid'
+            $Result.Uri | Should -Match 'cooling_capacity=10'
+            $Result.Uri | Should -Match 'cooling_capacity=12.5'
+        }
+
+        It "New-NBDCIMRackType sends cooling_capability and cooling_capacity" {
+            $Result = New-NBDCIMRackType -Manufacturer 1 -Model 'RT1' -Form_Factor '4-post-cabinet' -Cooling_Capability 'air-only' -Cooling_Capacity 5
+            $body = $Result.Body | ConvertFrom-Json
+            $body.cooling_capability | Should -Be 'air-only'
+            $body.cooling_capacity | Should -Be 5
+        }
+
+        It "Set-NBDCIMRackType sends cooling fields and clears them" {
+            $Result = Set-NBDCIMRackType -Id 2 -Cooling_Capability 'liquid-only' -Cooling_Capacity 30
+            $body = $Result.Body | ConvertFrom-Json
+            $body.cooling_capability | Should -Be 'liquid-only'
+            $body.cooling_capacity | Should -Be 30
+
+            $Result = Set-NBDCIMRackType -Id 2 -Cooling_Capability '' -Cooling_Capacity $null
+            $Result.Body | Should -Match '"cooling_capability":null'
+            $Result.Body | Should -Match '"cooling_capacity":null'
+        }
+
+        It "Get-NBDCIMRackType emits cooling filters" {
+            $Result = Get-NBDCIMRackType -Cooling_Capability 'hybrid' -Cooling_Capacity 30
+            $Result.Uri | Should -Match 'cooling_capability=hybrid'
+            $Result.Uri | Should -Match 'cooling_capacity=30'
+        }
+    }
+    #endregion
+
+    #region Version gate
+    Context "Below NetBox 4.7 the new parameters are dropped with a warning" {
+        BeforeAll { InModuleScope -ModuleName 'PowerNetbox' { $script:NetboxConfig.ParsedVersion = [version]'4.6.10' } }
+        AfterAll { InModuleScope -ModuleName 'PowerNetbox' { $script:NetboxConfig.ParsedVersion = [version]'4.7.0' } }
+
+        # One case per (cmdlet, parameter). 'Base' carries the mandatory params
+        # plus a harmless sibling field so the body is never empty.
+        $writeCases = @(
+            @{ Cmd = 'New-NBDCIMInterface'; Param = 'Channels';    Value = 4;                   Field = 'channels';    Base = @{ Device = 1; Name = 'eth0'; Type = '1000base-t' } }
+            @{ Cmd = 'New-NBDCIMInterface'; Param = 'Channel_Id';  Value = 1;                   Field = 'channel_id';  Base = @{ Device = 1; Name = 'eth0'; Type = 'channel' } }
+            @{ Cmd = 'New-NBDCIMInterface'; Param = 'MAC_Address'; Value = '00:11:22:33:44:55'; Field = 'mac_address'; Base = @{ Device = 1; Name = 'eth0'; Type = '1000base-t' } }
+            @{ Cmd = 'Set-NBDCIMInterface'; Param = 'Channels';    Value = 4;                   Field = 'channels';    Base = @{ Id = 1; Description = 'x' } }
+            @{ Cmd = 'Set-NBDCIMInterface'; Param = 'Channel_Id';  Value = 1;                   Field = 'channel_id';  Base = @{ Id = 1; Description = 'x' } }
+            @{ Cmd = 'Set-NBDCIMInterface'; Param = 'MAC_Address'; Value = '00:11:22:33:44:55'; Field = 'mac_address'; Base = @{ Id = 1; Description = 'x' } }
+            @{ Cmd = 'New-NBDCIMInterfaceTemplate'; Param = 'Channels';   Value = 4; Field = 'channels';   Base = @{ Device_Type = 1; Name = 'eth0'; Type = '1000base-t' } }
+            @{ Cmd = 'New-NBDCIMInterfaceTemplate'; Param = 'Channel_Id'; Value = 1; Field = 'channel_id'; Base = @{ Device_Type = 1; Name = 'eth0'; Type = 'channel' } }
+            @{ Cmd = 'Set-NBDCIMInterfaceTemplate'; Param = 'Channels';   Value = 4; Field = 'channels';   Base = @{ Id = 1; Description = 'x' } }
+            @{ Cmd = 'Set-NBDCIMInterfaceTemplate'; Param = 'Channel_Id'; Value = 1; Field = 'channel_id'; Base = @{ Id = 1; Description = 'x' } }
+            @{ Cmd = 'New-NBDCIMDevice';     Param = 'Cooling_Method'; Value = 'air'; Field = 'cooling_method'; Base = @{ Name = 'srv1'; Role = 1; Device_Type = 1; Site = 1 } }
+            @{ Cmd = 'Set-NBDCIMDevice';     Param = 'Cooling_Method'; Value = 'air'; Field = 'cooling_method'; Base = @{ Id = 1; Description = 'x' } }
+            @{ Cmd = 'New-NBDCIMDeviceType'; Param = 'Cooling_Method'; Value = 'air'; Field = 'cooling_method'; Base = @{ Manufacturer = 1; Model = 'X1' } }
+            @{ Cmd = 'New-NBDCIMDeviceType'; Param = 'End_Of_Life';    Value = '2030-06-30'; Field = 'end_of_life'; Base = @{ Manufacturer = 1; Model = 'X1' } }
+            @{ Cmd = 'Set-NBDCIMDeviceType'; Param = 'Cooling_Method'; Value = 'air'; Field = 'cooling_method'; Base = @{ Id = 1; Description = 'x' } }
+            @{ Cmd = 'Set-NBDCIMDeviceType'; Param = 'End_Of_Life';    Value = '2030-06-30'; Field = 'end_of_life'; Base = @{ Id = 1; Description = 'x' } }
+            @{ Cmd = 'New-NBDCIMModuleType'; Param = 'Cooling_Method'; Value = 'air'; Field = 'cooling_method'; Base = @{ Manufacturer = 1; Model = 'M1' } }
+            @{ Cmd = 'New-NBDCIMModuleType'; Param = 'End_Of_Life';    Value = '2030-06-30'; Field = 'end_of_life'; Base = @{ Manufacturer = 1; Model = 'M1' } }
+            @{ Cmd = 'Set-NBDCIMModuleType'; Param = 'Cooling_Method'; Value = 'air'; Field = 'cooling_method'; Base = @{ Id = 1; Description = 'x' } }
+            @{ Cmd = 'Set-NBDCIMModuleType'; Param = 'End_Of_Life';    Value = '2030-06-30'; Field = 'end_of_life'; Base = @{ Id = 1; Description = 'x' } }
+            @{ Cmd = 'New-NBDCIMRack';     Param = 'Cooling_Capability'; Value = 'hybrid'; Field = 'cooling_capability'; Base = @{ Name = 'R1'; Site = 1 } }
+            @{ Cmd = 'New-NBDCIMRack';     Param = 'Cooling_Capacity';   Value = 12.5;     Field = 'cooling_capacity';   Base = @{ Name = 'R1'; Site = 1 } }
+            @{ Cmd = 'Set-NBDCIMRack';     Param = 'Cooling_Capability'; Value = 'hybrid'; Field = 'cooling_capability'; Base = @{ Id = 1; Description = 'x' } }
+            @{ Cmd = 'Set-NBDCIMRack';     Param = 'Cooling_Capacity';   Value = 12.5;     Field = 'cooling_capacity';   Base = @{ Id = 1; Description = 'x' } }
+            @{ Cmd = 'New-NBDCIMRackType'; Param = 'Cooling_Capability'; Value = 'hybrid'; Field = 'cooling_capability'; Base = @{ Manufacturer = 1; Model = 'RT1'; Form_Factor = '4-post-cabinet' } }
+            @{ Cmd = 'New-NBDCIMRackType'; Param = 'Cooling_Capacity';   Value = 12.5;     Field = 'cooling_capacity';   Base = @{ Manufacturer = 1; Model = 'RT1'; Form_Factor = '4-post-cabinet' } }
+            @{ Cmd = 'Set-NBDCIMRackType'; Param = 'Cooling_Capability'; Value = 'hybrid'; Field = 'cooling_capability'; Base = @{ Id = 1; Description = 'x' } }
+            @{ Cmd = 'Set-NBDCIMRackType'; Param = 'Cooling_Capacity';   Value = 12.5;     Field = 'cooling_capacity';   Base = @{ Id = 1; Description = 'x' } }
+        )
+
+        It "<Cmd> drops -<Param> from the body with a warning" -TestCases $writeCases {
+            $splat = @{} + $Base
+            $splat[$Param] = $Value
+            $Result = & $Cmd @splat -WarningVariable warn -WarningAction SilentlyContinue
+            $warn | Should -Match "requires Netbox 4.7.0"
+            $Result.Body | Should -Not -BeNullOrEmpty
+            $body = $Result.Body | ConvertFrom-Json
+            $body.PSObject.Properties.Name | Should -Not -Contain $Field
+        }
+
+        $filterCases = @(
+            @{ Cmd = 'Get-NBDCIMInterface';         Param = 'Channels';           Value = 4;            Field = 'channels' }
+            @{ Cmd = 'Get-NBDCIMInterface';         Param = 'Channel_Id';         Value = 1;            Field = 'channel_id' }
+            @{ Cmd = 'Get-NBDCIMInterfaceTemplate'; Param = 'Channels';           Value = 4;            Field = 'channels' }
+            @{ Cmd = 'Get-NBDCIMInterfaceTemplate'; Param = 'Channel_Id';         Value = 1;            Field = 'channel_id' }
+            @{ Cmd = 'Get-NBDCIMDevice';            Param = 'Cooling_Method';     Value = 'air';        Field = 'cooling_method' }
+            @{ Cmd = 'Get-NBDCIMDeviceType';        Param = 'Cooling_Method';     Value = 'air';        Field = 'cooling_method' }
+            @{ Cmd = 'Get-NBDCIMDeviceType';        Param = 'End_Of_Life';        Value = '2030-06-30'; Field = 'end_of_life' }
+            @{ Cmd = 'Get-NBDCIMModuleType';        Param = 'Cooling_Method';     Value = 'air';        Field = 'cooling_method' }
+            @{ Cmd = 'Get-NBDCIMModuleType';        Param = 'End_Of_Life';        Value = '2030-06-30'; Field = 'end_of_life' }
+            @{ Cmd = 'Get-NBDCIMRack';              Param = 'Cooling_Capability'; Value = 'hybrid';     Field = 'cooling_capability' }
+            @{ Cmd = 'Get-NBDCIMRack';              Param = 'Cooling_Capacity';   Value = 12.5;         Field = 'cooling_capacity' }
+            @{ Cmd = 'Get-NBDCIMRackType';          Param = 'Cooling_Capability'; Value = 'hybrid';     Field = 'cooling_capability' }
+            @{ Cmd = 'Get-NBDCIMRackType';          Param = 'Cooling_Capacity';   Value = 12.5;         Field = 'cooling_capacity' }
+        )
+
+        It "<Cmd> drops the -<Param> filter with a warning" -TestCases $filterCases {
+            $splat = @{ $Param = $Value }
+            $Result = & $Cmd @splat -WarningVariable warn -WarningAction SilentlyContinue
+            $warn | Should -Match "requires Netbox 4.7.0"
+            $Result.Uri | Should -Not -Match $Field
+        }
+    }
+    #endregion
+}

--- a/Tests/DCIM.ModuleBayTypes.Tests.ps1
+++ b/Tests/DCIM.ModuleBayTypes.Tests.ps1
@@ -1,0 +1,392 @@
+<#
+.SYNOPSIS
+    Unit tests for DCIM Module Bay Types (NetBox 4.7+).
+
+.DESCRIPTION
+    Covers the /api/dcim/module-bay-types/ endpoint cmdlets
+    (Get/New/Set/Remove-NBDCIMModuleBayType) and the version-gated
+    -Module_Bay_Types parameter on New/Set-NBDCIMModuleBay,
+    New/Set-NBDCIMModuleBayTemplate and New/Set-NBDCIMModuleType.
+#>
+
+param()
+
+BeforeAll {
+    Import-Module Pester
+    Remove-Module PowerNetbox -Force -ErrorAction SilentlyContinue
+
+    $ModulePath = Join-Path (Join-Path $PSScriptRoot "..") "PowerNetbox/PowerNetbox.psd1"
+    if (Test-Path $ModulePath) {
+        Import-Module $ModulePath -ErrorAction Stop
+    }
+}
+
+Describe "DCIM Module Bay Types Tests" -Tag 'DCIM' {
+    BeforeAll {
+        Mock -CommandName 'CheckNetboxIsConnected' -ModuleName 'PowerNetbox' -MockWith { return $true }
+        Mock -CommandName 'InvokeNetboxRequest' -ModuleName 'PowerNetbox' -MockWith {
+            return [ordered]@{
+                'Method' = if ($Method) { $Method } else { 'GET' }
+                'Uri'    = $URI.Uri.AbsoluteUri
+                'Body'   = if ($Body) { $Body | ConvertTo-Json -Compress -Depth 10 } else { $null }
+            }
+        }
+
+        InModuleScope -ModuleName 'PowerNetbox' {
+            $script:NetboxConfig.Hostname = 'netbox.domain.com'
+            $script:NetboxConfig.HostScheme = 'https'
+            $script:NetboxConfig.HostPort = 443
+        }
+    }
+
+    #region Get-NBDCIMModuleBayType
+    Context "Get-NBDCIMModuleBayType" {
+        It "Should request the list endpoint" {
+            $Result = Get-NBDCIMModuleBayType
+            $Result.Method | Should -Be 'GET'
+            $Result.Uri | Should -Be 'https://netbox.domain.com/api/dcim/module-bay-types/'
+        }
+
+        It "Should request a module bay type by ID" {
+            $Result = Get-NBDCIMModuleBayType -Id 7
+            $Result.Uri | Should -Be 'https://netbox.domain.com/api/dcim/module-bay-types/7/'
+        }
+
+        It "Should request each ID via the detail endpoint" {
+            $Result = @(Get-NBDCIMModuleBayType -Id 1, 2)
+            $Result.Count | Should -Be 2
+            $Result[0].Uri | Should -Be 'https://netbox.domain.com/api/dcim/module-bay-types/1/'
+            $Result[1].Uri | Should -Be 'https://netbox.domain.com/api/dcim/module-bay-types/2/'
+        }
+
+        It "Should pass -Brief through on the detail endpoint" {
+            $Result = Get-NBDCIMModuleBayType -Id 7 -Brief
+            $Result.Uri | Should -Match '/api/dcim/module-bay-types/7/\?brief=True'
+        }
+
+        It "Should filter by name (repeat-key)" {
+            $Result = Get-NBDCIMModuleBayType -Name 'SFP', 'QSFP'
+            $Result.Uri | Should -Match 'name=SFP'
+            $Result.Uri | Should -Match 'name=QSFP'
+        }
+
+        It "Should filter by slug" {
+            $Result = Get-NBDCIMModuleBayType -Slug 'sfp-cage'
+            $Result.Uri | Should -Match 'slug=sfp-cage'
+        }
+
+        It "Should filter by color" {
+            $Result = Get-NBDCIMModuleBayType -Color '00ff00'
+            $Result.Uri | Should -Match 'color=00ff00'
+        }
+
+        It "Should filter by manufacturer_id" {
+            $Result = Get-NBDCIMModuleBayType -Manufacturer_Id 3
+            $Result.Uri | Should -Match 'manufacturer_id=3'
+        }
+
+        It "Should filter by manufacturer slug" {
+            $Result = Get-NBDCIMModuleBayType -Manufacturer 'cisco'
+            $Result.Uri | Should -Match 'manufacturer=cisco'
+        }
+
+        It "Should filter by module_bay_id" {
+            $Result = Get-NBDCIMModuleBayType -Module_Bay_Id 11
+            $Result.Uri | Should -Match 'module_bay_id=11'
+        }
+
+        It "Should filter by module_bay_template_id" {
+            $Result = Get-NBDCIMModuleBayType -Module_Bay_Template_Id 12
+            $Result.Uri | Should -Match 'module_bay_template_id=12'
+        }
+
+        It "Should filter by module_type_id (repeat-key)" {
+            $Result = Get-NBDCIMModuleBayType -Module_Type_Id 13, 14
+            $Result.Uri | Should -Match 'module_type_id=13'
+            $Result.Uri | Should -Match 'module_type_id=14'
+        }
+
+        It "Should filter by description" {
+            $Result = Get-NBDCIMModuleBayType -Description 'Hot-swap'
+            $Result.Uri | Should -Match 'description=Hot-swap'
+        }
+
+        It "Should filter by owner_id" {
+            $Result = Get-NBDCIMModuleBayType -Owner_Id 2
+            $Result.Uri | Should -Match 'owner_id=2'
+        }
+
+        It "Should filter by tag" {
+            $Result = Get-NBDCIMModuleBayType -Tag 'optics'
+            $Result.Uri | Should -Match 'tag=optics'
+        }
+
+        It "Should send free-text search as q" {
+            $Result = Get-NBDCIMModuleBayType -Query 'cage' -WarningAction SilentlyContinue
+            $Result.Uri | Should -Match 'q=cage'
+        }
+
+        It "Should pass limit and offset" {
+            $Result = Get-NBDCIMModuleBayType -Limit 50 -Offset 100
+            $Result.Uri | Should -Match 'limit=50'
+            $Result.Uri | Should -Match 'offset=100'
+        }
+
+        It "Should reject -Brief together with -Fields" {
+            { Get-NBDCIMModuleBayType -Brief -Fields 'id' } | Should -Throw
+        }
+
+        It "Should accept Id from the pipeline by property name" {
+            $Result = [PSCustomObject]@{ Id = 9 } | Get-NBDCIMModuleBayType
+            $Result.Uri | Should -Be 'https://netbox.domain.com/api/dcim/module-bay-types/9/'
+        }
+    }
+    #endregion
+
+    #region New-NBDCIMModuleBayType
+    Context "New-NBDCIMModuleBayType" {
+        It "Should POST to the list endpoint with name and derived slug" {
+            $Result = New-NBDCIMModuleBayType -Name 'SFP Cage'
+            $Result.Method | Should -Be 'POST'
+            $Result.Uri | Should -Be 'https://netbox.domain.com/api/dcim/module-bay-types/'
+            $bodyObj = $Result.Body | ConvertFrom-Json
+            $bodyObj.name | Should -Be 'SFP Cage'
+            $bodyObj.slug | Should -Be 'sfp-cage'
+        }
+
+        It "Should keep an explicit slug" {
+            $Result = New-NBDCIMModuleBayType -Name 'Line Card Slot' -Slug 'lc-slot'
+            $bodyObj = $Result.Body | ConvertFrom-Json
+            $bodyObj.slug | Should -Be 'lc-slot'
+        }
+
+        It "Should send all writable fields" {
+            $Result = New-NBDCIMModuleBayType -Name 'QSFP' -Manufacturer 3 -Color '00ff00' `
+                -Description 'desc' -Owner 5 -Comments 'notes' -Tags 'a', 2 -Custom_Fields @{ rack_unit = 1 }
+            $bodyObj = $Result.Body | ConvertFrom-Json
+            $bodyObj.manufacturer | Should -Be 3
+            $bodyObj.color | Should -Be '00ff00'
+            $bodyObj.description | Should -Be 'desc'
+            $bodyObj.owner | Should -Be 5
+            $bodyObj.comments | Should -Be 'notes'
+            $bodyObj.tags.Count | Should -Be 2
+            $bodyObj.custom_fields.rack_unit | Should -Be 1
+        }
+
+        It "Should lowercase the color for the API" {
+            $Result = New-NBDCIMModuleBayType -Name 'X' -Color 'FF00AA'
+            $bodyObj = $Result.Body | ConvertFrom-Json
+            $bodyObj.color | Should -Be 'ff00aa'
+        }
+
+        It "Should reject an invalid color" {
+            { New-NBDCIMModuleBayType -Name 'X' -Color 'red' } | Should -Throw
+            { New-NBDCIMModuleBayType -Name 'X' -Color '#00ff00' } | Should -Throw
+        }
+
+        It "Should support -WhatIf" {
+            $Result = New-NBDCIMModuleBayType -Name 'X' -WhatIf
+            $Result | Should -BeNullOrEmpty
+        }
+    }
+    #endregion
+
+    #region Set-NBDCIMModuleBayType
+    Context "Set-NBDCIMModuleBayType" {
+        It "Should PATCH the detail endpoint" {
+            $Result = Set-NBDCIMModuleBayType -Id 7 -Name 'Renamed' -Confirm:$false
+            $Result.Method | Should -Be 'PATCH'
+            $Result.Uri | Should -Be 'https://netbox.domain.com/api/dcim/module-bay-types/7/'
+            $bodyObj = $Result.Body | ConvertFrom-Json
+            $bodyObj.name | Should -Be 'Renamed'
+        }
+
+        It "Should send all writable fields" {
+            $Result = Set-NBDCIMModuleBayType -Id 7 -Slug 'new-slug' -Manufacturer 4 -Color 'ff0000' `
+                -Description 'd' -Owner 6 -Comments 'c' -Tags 'x' -Custom_Fields @{ foo = 'bar' } -Confirm:$false
+            $bodyObj = $Result.Body | ConvertFrom-Json
+            $bodyObj.slug | Should -Be 'new-slug'
+            $bodyObj.manufacturer | Should -Be 4
+            $bodyObj.color | Should -Be 'ff0000'
+            $bodyObj.description | Should -Be 'd'
+            $bodyObj.owner | Should -Be 6
+            $bodyObj.comments | Should -Be 'c'
+            $bodyObj.tags | Should -Be @('x')
+            $bodyObj.custom_fields.foo | Should -Be 'bar'
+        }
+
+        It "Should clear manufacturer with null" {
+            $Result = Set-NBDCIMModuleBayType -Id 7 -Manufacturer $null -Confirm:$false
+            $Result.Body | Should -Match '"manufacturer":null'
+        }
+
+        It "Should clear color with an empty string" {
+            $Result = Set-NBDCIMModuleBayType -Id 7 -Color '' -Confirm:$false
+            $Result.Body | Should -Match '"color":""'
+        }
+
+        It "Should reject an invalid color" {
+            { Set-NBDCIMModuleBayType -Id 7 -Color 'zzzzzz' -Confirm:$false } | Should -Throw
+        }
+
+        It "Should accept Id from the pipeline by property name" {
+            $Result = [PSCustomObject]@{ Id = 8 } | Set-NBDCIMModuleBayType -Description 'p' -Confirm:$false
+            $Result.Uri | Should -Be 'https://netbox.domain.com/api/dcim/module-bay-types/8/'
+        }
+
+        It "Should support -WhatIf" {
+            $Result = Set-NBDCIMModuleBayType -Id 7 -Name 'X' -WhatIf
+            $Result | Should -BeNullOrEmpty
+        }
+    }
+    #endregion
+
+    #region Remove-NBDCIMModuleBayType
+    Context "Remove-NBDCIMModuleBayType" {
+        It "Should DELETE the detail endpoint" {
+            $Result = Remove-NBDCIMModuleBayType -Id 7 -Confirm:$false
+            $Result.Method | Should -Be 'DELETE'
+            $Result.Uri | Should -Be 'https://netbox.domain.com/api/dcim/module-bay-types/7/'
+        }
+
+        It "Should accept Id from the pipeline by property name" {
+            $Result = [PSCustomObject]@{ Id = 8 } | Remove-NBDCIMModuleBayType -Confirm:$false
+            $Result.Uri | Should -Be 'https://netbox.domain.com/api/dcim/module-bay-types/8/'
+        }
+
+        It "Should support -WhatIf" {
+            $Result = Remove-NBDCIMModuleBayType -Id 7 -WhatIf
+            $Result | Should -BeNullOrEmpty
+        }
+    }
+    #endregion
+
+    #region -Module_Bay_Types on existing cmdlets (NetBox 4.7+)
+    Context "-Module_Bay_Types on module bays / templates / module types (Netbox 4.7+)" {
+        BeforeAll {
+            $script:parsedVersionBefore = InModuleScope -ModuleName 'PowerNetbox' { $script:NetboxConfig.ParsedVersion }
+            InModuleScope -ModuleName 'PowerNetbox' { $script:NetboxConfig.ParsedVersion = [version]'4.7.0' }
+        }
+        AfterAll {
+            InModuleScope -ModuleName 'PowerNetbox' -Parameters @{ v = $script:parsedVersionBefore } { $script:NetboxConfig.ParsedVersion = $v }
+        }
+
+        It "New-NBDCIMModuleBay should send module_bay_types" {
+            $Result = New-NBDCIMModuleBay -Device 1 -Name 'Bay 1' -Module_Bay_Types 3, 4
+            $bodyObj = $Result.Body | ConvertFrom-Json
+            $bodyObj.module_bay_types | Should -Be @(3, 4)
+            $bodyObj.device | Should -Be 1
+            $bodyObj.name | Should -Be 'Bay 1'
+        }
+
+        It "New-NBDCIMModuleBay should send a single ID as an array" {
+            $Result = New-NBDCIMModuleBay -Device 1 -Name 'Bay 1' -Module_Bay_Types 3
+            $Result.Body | Should -Match '"module_bay_types":\[3\]'
+        }
+
+        It "Set-NBDCIMModuleBay should send module_bay_types" {
+            $Result = Set-NBDCIMModuleBay -Id 5 -Module_Bay_Types 3 -Confirm:$false
+            $Result.Method | Should -Be 'PATCH'
+            $Result.Uri | Should -Be 'https://netbox.domain.com/api/dcim/module-bays/5/'
+            $Result.Body | Should -Match '"module_bay_types":\[3\]'
+        }
+
+        It "Set-NBDCIMModuleBay should clear module_bay_types with an empty array" {
+            $Result = Set-NBDCIMModuleBay -Id 5 -Module_Bay_Types @() -Confirm:$false
+            $Result.Body | Should -Match '"module_bay_types":\[\]'
+        }
+
+        It "New-NBDCIMModuleBayTemplate should send module_bay_types" {
+            $Result = New-NBDCIMModuleBayTemplate -Device_Type 1 -Name 'Slot {module}' -Module_Bay_Types 3, 4
+            $bodyObj = $Result.Body | ConvertFrom-Json
+            $bodyObj.module_bay_types | Should -Be @(3, 4)
+            $bodyObj.device_type | Should -Be 1
+        }
+
+        It "Set-NBDCIMModuleBayTemplate should send module_bay_types" {
+            $Result = Set-NBDCIMModuleBayTemplate -Id 6 -Module_Bay_Types 4 -Confirm:$false
+            $Result.Uri | Should -Be 'https://netbox.domain.com/api/dcim/module-bay-templates/6/'
+            $Result.Body | Should -Match '"module_bay_types":\[4\]'
+        }
+
+        It "Set-NBDCIMModuleBayTemplate should clear module_bay_types with an empty array" {
+            $Result = Set-NBDCIMModuleBayTemplate -Id 6 -Module_Bay_Types @() -Confirm:$false
+            $Result.Body | Should -Match '"module_bay_types":\[\]'
+        }
+
+        It "New-NBDCIMModuleType should send module_bay_types" {
+            $Result = New-NBDCIMModuleType -Manufacturer 1 -Model 'MT-1' -Module_Bay_Types 3, 4
+            $bodyObj = $Result.Body | ConvertFrom-Json
+            $bodyObj.module_bay_types | Should -Be @(3, 4)
+            $bodyObj.model | Should -Be 'MT-1'
+        }
+
+        It "Set-NBDCIMModuleType should send module_bay_types" {
+            $Result = Set-NBDCIMModuleType -Id 8 -Module_Bay_Types 3 -Confirm:$false
+            $Result.Uri | Should -Be 'https://netbox.domain.com/api/dcim/module-types/8/'
+            $Result.Body | Should -Match '"module_bay_types":\[3\]'
+        }
+
+        It "Set-NBDCIMModuleType should clear module_bay_types with an empty array" {
+            $Result = Set-NBDCIMModuleType -Id 8 -Module_Bay_Types @() -Confirm:$false
+            $Result.Body | Should -Match '"module_bay_types":\[\]'
+        }
+
+        It "Existing cmdlets should not emit a warning on 4.7.0" {
+            $null = Set-NBDCIMModuleBay -Id 5 -Module_Bay_Types 3 -Confirm:$false -WarningVariable warn -WarningAction SilentlyContinue
+            $warn | Should -BeNullOrEmpty
+        }
+
+        Context "Below Netbox 4.7" {
+            BeforeAll { InModuleScope -ModuleName 'PowerNetbox' { $script:NetboxConfig.ParsedVersion = [version]'4.6.10' } }
+            AfterAll { InModuleScope -ModuleName 'PowerNetbox' { $script:NetboxConfig.ParsedVersion = [version]'4.7.0' } }
+
+            It "New-NBDCIMModuleBay should drop module_bay_types with a warning" {
+                $Result = New-NBDCIMModuleBay -Device 1 -Name 'Bay 1' -Module_Bay_Types 3 -WarningVariable warn -WarningAction SilentlyContinue
+                $warn | Should -Match 'Module bay types requires Netbox 4.7.0'
+                $bodyObj = $Result.Body | ConvertFrom-Json
+                $bodyObj.PSObject.Properties.Name | Should -Not -Contain 'module_bay_types'
+                $bodyObj.name | Should -Be 'Bay 1'
+            }
+
+            It "Set-NBDCIMModuleBay should drop module_bay_types with a warning" {
+                $Result = Set-NBDCIMModuleBay -Id 5 -Module_Bay_Types 3 -Description 'x' -Confirm:$false -WarningVariable warn -WarningAction SilentlyContinue
+                $warn | Should -Match 'requires Netbox 4.7.0'
+                $bodyObj = $Result.Body | ConvertFrom-Json
+                $bodyObj.PSObject.Properties.Name | Should -Not -Contain 'module_bay_types'
+                $bodyObj.description | Should -Be 'x'
+            }
+
+            It "New-NBDCIMModuleBayTemplate should drop module_bay_types with a warning" {
+                $Result = New-NBDCIMModuleBayTemplate -Device_Type 1 -Name 'Slot' -Module_Bay_Types 3 -WarningVariable warn -WarningAction SilentlyContinue
+                $warn | Should -Match 'requires Netbox 4.7.0'
+                $bodyObj = $Result.Body | ConvertFrom-Json
+                $bodyObj.PSObject.Properties.Name | Should -Not -Contain 'module_bay_types'
+            }
+
+            It "Set-NBDCIMModuleBayTemplate should drop module_bay_types with a warning" {
+                $Result = Set-NBDCIMModuleBayTemplate -Id 6 -Module_Bay_Types 3 -Label 'L' -Confirm:$false -WarningVariable warn -WarningAction SilentlyContinue
+                $warn | Should -Match 'requires Netbox 4.7.0'
+                $bodyObj = $Result.Body | ConvertFrom-Json
+                $bodyObj.PSObject.Properties.Name | Should -Not -Contain 'module_bay_types'
+                $bodyObj.label | Should -Be 'L'
+            }
+
+            It "New-NBDCIMModuleType should drop module_bay_types with a warning" {
+                $Result = New-NBDCIMModuleType -Manufacturer 1 -Model 'MT-1' -Module_Bay_Types 3 -WarningVariable warn -WarningAction SilentlyContinue
+                $warn | Should -Match 'requires Netbox 4.7.0'
+                $bodyObj = $Result.Body | ConvertFrom-Json
+                $bodyObj.PSObject.Properties.Name | Should -Not -Contain 'module_bay_types'
+            }
+
+            It "Set-NBDCIMModuleType should drop module_bay_types with a warning" {
+                $Result = Set-NBDCIMModuleType -Id 8 -Module_Bay_Types 3 -Part_Number 'PN' -Confirm:$false -WarningVariable warn -WarningAction SilentlyContinue
+                $warn | Should -Match 'requires Netbox 4.7.0'
+                $bodyObj = $Result.Body | ConvertFrom-Json
+                $bodyObj.PSObject.Properties.Name | Should -Not -Contain 'module_bay_types'
+                $bodyObj.part_number | Should -Be 'PN'
+            }
+        }
+    }
+    #endregion
+}

--- a/Tests/DCIM.ModuleBayTypes.Tests.ps1
+++ b/Tests/DCIM.ModuleBayTypes.Tests.ps1
@@ -211,7 +211,7 @@ Describe "DCIM Module Bay Types Tests" -Tag 'DCIM' {
             $bodyObj.description | Should -Be 'd'
             $bodyObj.owner | Should -Be 6
             $bodyObj.comments | Should -Be 'c'
-            $bodyObj.tags | Should -Be @('x')
+            $bodyObj.tags[0].name | Should -Be 'x'
             $bodyObj.custom_fields.foo | Should -Be 'bar'
         }
 

--- a/Tests/IPAM.Tests.ps1
+++ b/Tests/IPAM.Tests.ps1
@@ -1153,9 +1153,11 @@ Describe "IPAM tests" -Tag 'Ipam' {
         }
 
         It "New-NBIPAMService should send tags" {
-            $Result = New-NBIPAMService -Name 'HTTP' -Ports 80 -Device 1 -Tags 'web', 'prod'
+            $Result = New-NBIPAMService -Name 'HTTP' -Ports 80 -Device 1 -Tags 'web', 12
             $bodyObj = $Result.Body | ConvertFrom-Json
-            $bodyObj.tags | Should -Be @('web', 'prod')
+            # names become attribute dictionaries, IDs stay numeric (Netbox rejects bare name strings)
+            $bodyObj.tags[0].name | Should -Be 'web'
+            $bodyObj.tags[1] | Should -Be 12
         }
 
         It "New-NBIPAMService should throw when neither -Ports nor -Port_Mappings is given" {

--- a/Tests/QueryOptions47.Tests.ps1
+++ b/Tests/QueryOptions47.Tests.ps1
@@ -1,0 +1,378 @@
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingConvertToSecureStringWithPlainText", "")]
+param()
+
+BeforeAll {
+    Import-Module Pester
+    Remove-Module PowerNetbox -Force -ErrorAction SilentlyContinue
+
+    $ModulePath = Join-Path (Join-Path $PSScriptRoot "..") "PowerNetbox/PowerNetbox.psd1"
+    if (-not (Test-Path $ModulePath)) {
+        $ModulePath = Join-Path (Join-Path $PSScriptRoot "..") "PowerNetbox.psd1"
+    }
+    Import-Module $ModulePath -ErrorAction Stop
+}
+
+Describe "Query options added for Netbox 4.6/4.7 (cursor pagination, TagMatch, optimistic concurrency)" -Tag 'Core', 'Setup' {
+    BeforeAll {
+        Mock -CommandName 'CheckNetboxIsConnected' -ModuleName 'PowerNetbox' -MockWith { return $true }
+        Mock -CommandName 'Get-NBRequestHeaders' -ModuleName 'PowerNetbox' -MockWith { return @{ 'Authorization' = 'Token faketoken'; 'Accept' = 'application/json' } }
+        Mock -CommandName 'Get-NBInvokeParams' -ModuleName 'PowerNetbox' -MockWith { return @{} }
+
+        $script:stateBefore = InModuleScope -ModuleName 'PowerNetbox' {
+            @{
+                ParsedVersion         = $script:NetboxConfig.ParsedVersion
+                Pagination            = $script:NetboxConfig.Pagination
+                TagMatch              = $script:NetboxConfig.TagMatch
+                OptimisticConcurrency = $script:NetboxConfig.OptimisticConcurrency
+            }
+            $script:NetboxConfig.Hostname = 'netbox.domain.com'
+            $script:NetboxConfig.HostScheme = 'https'
+            $script:NetboxConfig.HostPort = 443
+            $script:NetboxConfig.Connected = $true
+            $script:NetboxConfig.Timeout = 30
+            $script:NetboxConfig.ParsedVersion = [version]'4.7.0'
+        }
+    }
+    AfterAll {
+        InModuleScope -ModuleName 'PowerNetbox' -Parameters @{ s = $script:stateBefore } {
+            $script:NetboxConfig.ParsedVersion = $s.ParsedVersion
+            $script:NetboxConfig.Pagination = $s.Pagination
+            $script:NetboxConfig.TagMatch = $s.TagMatch
+            $script:NetboxConfig.OptimisticConcurrency = $s.OptimisticConcurrency
+            $script:NetboxConfig.ETagCache = @{}
+        }
+    }
+
+    Context "Set-NBQueryOption / Get-NBQueryOption" {
+        AfterEach {
+            $null = Set-NBQueryOption -Pagination Offset
+            $null = Set-NBQueryOption -TagMatch All
+            $null = Set-NBQueryOption -OptimisticConcurrency:$false
+        }
+
+        It "Should expose the three new options with their defaults" {
+            $o = Get-NBQueryOption
+            ($o | Where-Object Name -eq 'Pagination').Value | Should -Be 'Offset'
+            ($o | Where-Object Name -eq 'TagMatch').Value | Should -Be 'All'
+            ($o | Where-Object Name -eq 'OptimisticConcurrency').Value | Should -Be $false
+        }
+
+        It "Should set and return Pagination" {
+            Set-NBQueryOption -Pagination Cursor | Should -Be 'Cursor'
+            (Get-NBQueryOption | Where-Object Name -eq 'Pagination').Value | Should -Be 'Cursor'
+        }
+
+        It "Should set and return TagMatch" {
+            Set-NBQueryOption -TagMatch Any | Should -Be 'Any'
+            (Get-NBQueryOption | Where-Object Name -eq 'TagMatch').Value | Should -Be 'Any'
+        }
+
+        It "Should set OptimisticConcurrency and clear the ETag cache when disabled" {
+            Set-NBQueryOption -OptimisticConcurrency | Should -Be $true
+            InModuleScope -ModuleName 'PowerNetbox' { $script:NetboxConfig.ETagCache['https://x/api/dcim/sites/1/'] = 'W/"1"' }
+            Set-NBQueryOption -OptimisticConcurrency:$false | Should -Be $false
+            InModuleScope -ModuleName 'PowerNetbox' { $script:NetboxConfig.ETagCache.Count | Should -Be 0 }
+        }
+
+        It "Should warn when the connected Netbox is too old for the option" {
+            InModuleScope -ModuleName 'PowerNetbox' { $script:NetboxConfig.ParsedVersion = [version]'4.5.10' }
+            try {
+                $null = Set-NBQueryOption -Pagination Cursor -WarningVariable w1 -WarningAction SilentlyContinue
+                $w1 | Should -Match 'requires Netbox 4.6.0'
+                $null = Set-NBQueryOption -TagMatch Any -WarningVariable w2 -WarningAction SilentlyContinue
+                $w2 | Should -Match 'requires Netbox 4.6.6'
+                $null = Set-NBQueryOption -OptimisticConcurrency -WarningVariable w3 -WarningAction SilentlyContinue
+                $w3 | Should -Match 'requires Netbox 4.6.0'
+            }
+            finally {
+                InModuleScope -ModuleName 'PowerNetbox' { $script:NetboxConfig.ParsedVersion = [version]'4.7.0' }
+            }
+        }
+
+        It "Should not allow combining the option parameter sets" {
+            { Set-NBQueryOption -Pagination Cursor -TagMatch Any } | Should -Throw
+        }
+    }
+
+    Context "TagMatch Any rewrites tag / tag_id filters (BuildNewURI)" {
+        AfterAll { $null = Set-NBQueryOption -TagMatch All }
+
+        It "Should send plain tag= with the default TagMatch All" {
+            InModuleScope -ModuleName 'PowerNetbox' {
+                $u = BuildNewURI -Segments 'dcim', 'devices' -Parameters @{ tag = @('edge', 'core') } -SkipConnectedCheck
+                $u.Query | Should -Match '(^|[?&])tag=edge'
+                $u.Query | Should -Not -Match '__any'
+            }
+        }
+
+        It "Should send tag__any= / tag_id__any= on Netbox 4.6.6+" {
+            $null = Set-NBQueryOption -TagMatch Any
+            InModuleScope -ModuleName 'PowerNetbox' {
+                $u = BuildNewURI -Segments 'dcim', 'devices' -Parameters @{ tag = @('edge', 'core'); tag_id = 7; name = 'x' } -SkipConnectedCheck
+                $u.Query | Should -Match 'tag__any=edge'
+                $u.Query | Should -Match 'tag__any=core'
+                $u.Query | Should -Match 'tag_id__any=7'
+                $u.Query | Should -Match '(^|[?&])name=x'
+                $u.Query | Should -Not -Match 'name__any'
+            }
+        }
+
+        It "Should keep plain tag= below Netbox 4.6.6 (unknown lookups would return everything)" {
+            $null = Set-NBQueryOption -TagMatch Any -WarningAction SilentlyContinue
+            InModuleScope -ModuleName 'PowerNetbox' {
+                $script:NetboxConfig.ParsedVersion = [version]'4.6.3'
+                try {
+                    $u = BuildNewURI -Segments 'dcim', 'devices' -Parameters @{ tag = 'edge' } -SkipConnectedCheck
+                    $u.Query | Should -Match '(^|[?&])tag=edge'
+                    $u.Query | Should -Not -Match '__any'
+                }
+                finally { $script:NetboxConfig.ParsedVersion = [version]'4.7.0' }
+            }
+        }
+    }
+
+    Context "Cursor pagination (InvokeNetboxRequest -All)" {
+        BeforeAll {
+            Mock -CommandName 'Invoke-RestMethod' -ModuleName 'PowerNetbox' -MockWith {
+                [PSCustomObject]@{ count = $null; next = $null; previous = $null; results = @([PSCustomObject]@{ id = 1 }) }
+            }
+        }
+        AfterAll { $null = Set-NBQueryOption -Pagination Offset }
+
+        It "Should not add start= with the default Offset pagination" {
+            $null = Set-NBQueryOption -Pagination Offset
+            InModuleScope -ModuleName 'PowerNetbox' {
+                $r = InvokeNetboxRequest -URI (BuildNewURI -Segments 'dcim', 'sites' -SkipConnectedCheck) -All -PageSize 50
+                @($r).Count | Should -Be 1
+            }
+            Should -Invoke -CommandName 'Invoke-RestMethod' -ModuleName 'PowerNetbox' -Times 1 -Exactly -ParameterFilter { $Uri -match 'limit=50' -and $Uri -notmatch 'start=' }
+        }
+
+        It "Should add start=0 on Netbox 4.6+ with Cursor pagination" {
+            $null = Set-NBQueryOption -Pagination Cursor
+            InModuleScope -ModuleName 'PowerNetbox' {
+                $null = InvokeNetboxRequest -URI (BuildNewURI -Segments 'dcim', 'sites' -SkipConnectedCheck) -All -PageSize 50
+            }
+            Should -Invoke -CommandName 'Invoke-RestMethod' -ModuleName 'PowerNetbox' -Times 1 -Exactly -ParameterFilter { $Uri -match 'limit=50&start=0' }
+        }
+
+        It "Should leave an explicit offset alone" {
+            $null = Set-NBQueryOption -Pagination Cursor
+            InModuleScope -ModuleName 'PowerNetbox' {
+                $null = InvokeNetboxRequest -URI (BuildNewURI -Segments 'dcim', 'sites' -Parameters @{ offset = 200 } -SkipConnectedCheck) -All
+            }
+            Should -Invoke -CommandName 'Invoke-RestMethod' -ModuleName 'PowerNetbox' -Times 1 -Exactly -ParameterFilter { $Uri -match 'offset=200' -and $Uri -notmatch 'start=' }
+        }
+
+        It "Should fall back to offset pagination below Netbox 4.6" {
+            $null = Set-NBQueryOption -Pagination Cursor
+            InModuleScope -ModuleName 'PowerNetbox' {
+                $script:NetboxConfig.ParsedVersion = [version]'4.5.10'
+                try {
+                    $null = InvokeNetboxRequest -URI (BuildNewURI -Segments 'dcim', 'sites' -SkipConnectedCheck) -All
+                }
+                finally { $script:NetboxConfig.ParsedVersion = [version]'4.7.0' }
+            }
+            Should -Invoke -CommandName 'Invoke-RestMethod' -ModuleName 'PowerNetbox' -Times 1 -Exactly -ParameterFilter { $Uri -notmatch 'start=' }
+        }
+
+        It "Should still refuse a next URL on another origin (SSRF guard) in cursor mode" {
+            Mock -CommandName 'Invoke-RestMethod' -ModuleName 'PowerNetbox' -MockWith {
+                [PSCustomObject]@{ count = $null; next = 'https://evil.example.com/api/dcim/sites/?start=5'; previous = $null; results = @([PSCustomObject]@{ id = 1 }) }
+            }
+            $null = Set-NBQueryOption -Pagination Cursor
+            InModuleScope -ModuleName 'PowerNetbox' {
+                { InvokeNetboxRequest -URI (BuildNewURI -Segments 'dcim', 'sites' -SkipConnectedCheck) -All } | Should -Throw '*different origin*'
+            }
+        }
+    }
+
+    Context "Optimistic concurrency (ETag / If-Match)" -Skip:($PSVersionTable.PSEdition -ne 'Core') {
+        BeforeAll {
+            Mock -CommandName 'Invoke-RestMethod' -ModuleName 'PowerNetbox' -MockWith {
+                # Emulate -ResponseHeadersVariable: the caller reads it with Get-Variable, so a global works in the mock.
+                if ($ResponseHeadersVariable) {
+                    Set-Variable -Name $ResponseHeadersVariable -Scope Global -Value @{ 'ETag' = @('W/"2026-09-09T00:00:00+00:00"') }
+                }
+                [PSCustomObject]@{ id = 42; name = 'site-42' }
+            }
+            $null = Set-NBQueryOption -OptimisticConcurrency
+        }
+        AfterAll {
+            $null = Set-NBQueryOption -OptimisticConcurrency:$false
+            Remove-Variable -Name nbResponseHeaders -Scope Global -ErrorAction SilentlyContinue
+        }
+
+        It "Should cache the ETag of a single-object GET and send it as If-Match on the next PATCH" {
+            InModuleScope -ModuleName 'PowerNetbox' {
+                $uri = BuildNewURI -Segments 'dcim', 'sites', 42 -SkipConnectedCheck
+                $null = InvokeNetboxRequest -URI $uri
+                $script:NetboxConfig.ETagCache[$uri.Uri.GetLeftPart([System.UriPartial]::Path)] | Should -Be 'W/"2026-09-09T00:00:00+00:00"'
+                $null = InvokeNetboxRequest -URI $uri -Method PATCH -Body @{ description = 'x' }
+            }
+            Should -Invoke -CommandName 'Invoke-RestMethod' -ModuleName 'PowerNetbox' -Times 1 -Exactly -ParameterFilter { $Method -eq 'PATCH' -and $Headers['If-Match'] -eq 'W/"2026-09-09T00:00:00+00:00"' }
+        }
+
+        It "Should not send If-Match for an object it has not read" {
+            InModuleScope -ModuleName 'PowerNetbox' {
+                $uri = BuildNewURI -Segments 'dcim', 'sites', 99 -SkipConnectedCheck
+                $null = InvokeNetboxRequest -URI $uri -Method PATCH -Body @{ description = 'x' }
+            }
+            Should -Invoke -CommandName 'Invoke-RestMethod' -ModuleName 'PowerNetbox' -Times 1 -Exactly -ParameterFilter { $Method -eq 'PATCH' -and $Uri -match '/99/' -and -not $Headers.ContainsKey('If-Match') }
+        }
+
+        It "Should drop the cached ETag after DELETE" {
+            InModuleScope -ModuleName 'PowerNetbox' {
+                $uri = BuildNewURI -Segments 'dcim', 'sites', 42 -SkipConnectedCheck
+                $null = InvokeNetboxRequest -URI $uri
+                $null = InvokeNetboxRequest -URI $uri -Method DELETE
+                $script:NetboxConfig.ETagCache.ContainsKey($uri.Uri.GetLeftPart([System.UriPartial]::Path)) | Should -Be $false
+            }
+        }
+
+        It "Should never send If-Match or ask for headers while the option is off" {
+            $null = Set-NBQueryOption -OptimisticConcurrency:$false
+            try {
+                InModuleScope -ModuleName 'PowerNetbox' {
+                    $uri = BuildNewURI -Segments 'dcim', 'sites', 42 -SkipConnectedCheck
+                    $null = InvokeNetboxRequest -URI $uri
+                    $null = InvokeNetboxRequest -URI $uri -Method PATCH -Body @{ description = 'x' }
+                }
+                Should -Invoke -CommandName 'Invoke-RestMethod' -ModuleName 'PowerNetbox' -Times 1 -Exactly -ParameterFilter { $Method -eq 'PATCH' -and -not $Headers.ContainsKey('If-Match') -and -not $ResponseHeadersVariable }
+            }
+            finally { $null = Set-NBQueryOption -OptimisticConcurrency }
+        }
+    }
+
+    Context "HTTP 412 Precondition Failed is explained" {
+        It "Should name the status and hint at re-reading the object" {
+            InModuleScope -ModuleName 'PowerNetbox' {
+                $msg = BuildDetailedErrorMessage -StatusCode 412 -StatusName (GetHttpStatusName -StatusCode 412) -Method 'PATCH' -Endpoint 'PATCH /api/dcim/sites/1/' -ErrorMessage 'precondition failed'
+                $msg | Should -Match 'Precondition Failed'
+                $msg | Should -Match 'Re-read the object'
+            }
+        }
+    }
+}
+
+Describe "Set-NBObjectTag (partial tag assignment, Netbox 4.6+)" -Tag 'Extras' {
+    BeforeAll {
+        Mock -CommandName 'CheckNetboxIsConnected' -ModuleName 'PowerNetbox' -MockWith { return $true }
+        Mock -CommandName 'InvokeNetboxRequest' -ModuleName 'PowerNetbox' -MockWith {
+            return [ordered]@{
+                'Method' = if ($Method) { $Method } else { 'GET' }
+                'Uri'    = $URI.Uri.AbsoluteUri
+                'Body'   = if ($Body) { $Body | ConvertTo-Json -Compress -Depth 10 } else { $null }
+            }
+        }
+        $script:pvBefore = InModuleScope -ModuleName 'PowerNetbox' {
+            $script:NetboxConfig.ParsedVersion
+            $script:NetboxConfig.Hostname = 'netbox.domain.com'
+            $script:NetboxConfig.HostScheme = 'https'
+            $script:NetboxConfig.HostPort = 443
+            $script:NetboxConfig.ParsedVersion = [version]'4.7.0'
+        }
+    }
+    AfterAll {
+        InModuleScope -ModuleName 'PowerNetbox' -Parameters @{ v = $script:pvBefore } { $script:NetboxConfig.ParsedVersion = $v }
+    }
+
+    It "Should PATCH add_tags/remove_tags to the object's own path on the configured host" {
+        $obj = [PSCustomObject]@{ id = 42; url = 'http://internal-proxy:8080/api/dcim/devices/42/'; display = 'core-01' }
+        $r = $obj | Set-NBObjectTag -Add 'maintenance', 12 -Remove 'staging' -Confirm:$false
+        $r.Method | Should -Be 'PATCH'
+        $r.Uri | Should -Be 'https://netbox.domain.com/api/dcim/devices/42/'
+        $b = $r.Body | ConvertFrom-Json
+        $b.add_tags[0].name | Should -Be 'maintenance'
+        $b.add_tags[1] | Should -Be 12
+        $b.remove_tags[0].name | Should -Be 'staging'
+    }
+
+    It "Should accept -Url with a bare API path" {
+        $r = Set-NBObjectTag -Url '/api/ipam/prefixes/7/' -Add 'audited' -Confirm:$false
+        $r.Uri | Should -Be 'https://netbox.domain.com/api/ipam/prefixes/7/'
+        ($r.Body | ConvertFrom-Json).add_tags[0].name | Should -Be 'audited'
+    }
+
+    It "Should require -Add or -Remove" {
+        { Set-NBObjectTag -Url '/api/ipam/prefixes/7/' -Confirm:$false } | Should -Throw '*-Add*-Remove*'
+    }
+
+    It "Should reject objects without a url" {
+        { [PSCustomObject]@{ id = 1 } | Set-NBObjectTag -Add 'x' -Confirm:$false } | Should -Throw "*no 'url' property*"
+    }
+
+    It "Should refuse below Netbox 4.6 instead of silently no-op-ing" {
+        InModuleScope -ModuleName 'PowerNetbox' { $script:NetboxConfig.ParsedVersion = [version]'4.5.10' }
+        try {
+            { Set-NBObjectTag -Url '/api/ipam/prefixes/7/' -Add 'x' -Confirm:$false } | Should -Throw '*requires Netbox 4.6.0*'
+        }
+        finally {
+            InModuleScope -ModuleName 'PowerNetbox' { $script:NetboxConfig.ParsedVersion = [version]'4.7.0' }
+        }
+    }
+}
+
+Describe "Bulk -Background (Netbox 4.7+)" -Tag 'Bulk' {
+    BeforeAll {
+        Mock -CommandName 'CheckNetboxIsConnected' -ModuleName 'PowerNetbox' -MockWith { return $true }
+        Mock -CommandName 'Get-NBRequestHeaders' -ModuleName 'PowerNetbox' -MockWith { return @{ 'Authorization' = 'Token faketoken' } }
+        Mock -CommandName 'Get-NBInvokeParams' -ModuleName 'PowerNetbox' -MockWith { return @{} }
+        Mock -CommandName 'Invoke-RestMethod' -ModuleName 'PowerNetbox' -MockWith {
+            if ($Uri -match 'background=true') {
+                # 202 Accepted: {"job": {...}} instead of the created objects
+                return [PSCustomObject]@{ job = [PSCustomObject]@{ id = 501; url = 'https://netbox.domain.com/api/core/jobs/501/'; status = 'pending' } }
+            }
+            $items = $Body | ConvertFrom-Json
+            $id = 100
+            return @($items | ForEach-Object { [PSCustomObject]@{ id = $id++; name = $_.name } })
+        }
+        $script:pvBefore = InModuleScope -ModuleName 'PowerNetbox' {
+            $script:NetboxConfig.ParsedVersion
+            $script:NetboxConfig.Hostname = 'netbox.domain.com'
+            $script:NetboxConfig.HostScheme = 'https'
+            $script:NetboxConfig.HostPort = 443
+            $script:NetboxConfig.Timeout = 30
+            $script:NetboxConfig.ParsedVersion = [version]'4.7.0'
+        }
+    }
+    AfterAll {
+        InModuleScope -ModuleName 'PowerNetbox' -Parameters @{ v = $script:pvBefore } { $script:NetboxConfig.ParsedVersion = $v }
+    }
+
+    It "Send-NBBulkRequest -Background should append ?background=true and return the job" {
+        InModuleScope -ModuleName 'PowerNetbox' {
+            $uri = BuildNewURI -Segments 'dcim', 'sites' -SkipConnectedCheck
+            $r = Send-NBBulkRequest -URI $uri -Items @(@{ name = 'a'; slug = 'a' }, @{ name = 'b'; slug = 'b' }) -Method POST -Background
+            $r.Succeeded.Count | Should -Be 1
+            $r.Succeeded[0].id | Should -Be 501
+        }
+        Should -Invoke -CommandName 'Invoke-RestMethod' -ModuleName 'PowerNetbox' -Times 1 -Exactly -ParameterFilter { $Uri -match '/api/dcim/sites/\?background=true$' }
+    }
+
+    It "Send-NBBulkRequest without -Background should be unchanged" {
+        InModuleScope -ModuleName 'PowerNetbox' {
+            $uri = BuildNewURI -Segments 'dcim', 'sites' -SkipConnectedCheck
+            $r = Send-NBBulkRequest -URI $uri -Items @(@{ name = 'a'; slug = 'a' }) -Method POST
+            $r.Succeeded[0].id | Should -Be 100
+        }
+        Should -Invoke -CommandName 'Invoke-RestMethod' -ModuleName 'PowerNetbox' -Times 1 -Exactly -ParameterFilter { $Uri -notmatch 'background' }
+    }
+
+    It "New-NBDCIMDevice -Background should queue the batch on Netbox 4.7" {
+        $r = @([PSCustomObject]@{ Name = 'd1'; Role = 1; Device_Type = 1; Site = 1 }) | New-NBDCIMDevice -BatchSize 10 -Background -Force
+        Should -Invoke -CommandName 'Invoke-RestMethod' -ModuleName 'PowerNetbox' -Times 1 -Exactly -ParameterFilter { $Uri -match 'background=true' }
+    }
+
+    It "New-NBDCIMDevice -Background should warn and run synchronously below Netbox 4.7" {
+        InModuleScope -ModuleName 'PowerNetbox' { $script:NetboxConfig.ParsedVersion = [version]'4.6.10' }
+        try {
+            $r = @([PSCustomObject]@{ Name = 'd1'; Role = 1; Device_Type = 1; Site = 1 }) | New-NBDCIMDevice -BatchSize 10 -Background -Force -WarningVariable w -WarningAction SilentlyContinue
+            $w | Should -Match 'requires Netbox 4.7.0'
+            Should -Invoke -CommandName 'Invoke-RestMethod' -ModuleName 'PowerNetbox' -Times 1 -Exactly -ParameterFilter { $Uri -notmatch 'background' }
+        }
+        finally {
+            InModuleScope -ModuleName 'PowerNetbox' { $script:NetboxConfig.ParsedVersion = [version]'4.7.0' }
+        }
+    }
+}

--- a/Tests/TagFilters.Tests.ps1
+++ b/Tests/TagFilters.Tests.ps1
@@ -1,0 +1,114 @@
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingConvertToSecureStringWithPlainText", "")]
+param()
+
+BeforeAll {
+    Import-Module Pester
+    Remove-Module PowerNetbox -Force -ErrorAction SilentlyContinue
+
+    $ModulePath = Join-Path (Join-Path $PSScriptRoot "..") "PowerNetbox/PowerNetbox.psd1"
+    if (-not (Test-Path $ModulePath)) {
+        $ModulePath = Join-Path (Join-Path $PSScriptRoot "..") "PowerNetbox.psd1"
+    }
+    Import-Module $ModulePath -ErrorAction Stop
+}
+
+Describe "Tag filters and tag references" -Tag 'Core', 'Tags' {
+    BeforeAll {
+        Mock -CommandName 'CheckNetboxIsConnected' -ModuleName 'PowerNetbox' -MockWith { return $true }
+        Mock -CommandName 'InvokeNetboxRequest' -ModuleName 'PowerNetbox' -MockWith {
+            return [ordered]@{
+                'Method' = if ($Method) { $Method } else { 'GET' }
+                'Uri'    = $URI.Uri.AbsoluteUri
+                'Body'   = if ($Body) { $Body | ConvertTo-Json -Compress -Depth 10 } else { $null }
+            }
+        }
+        $script:pvBefore = InModuleScope -ModuleName 'PowerNetbox' {
+            $script:NetboxConfig.ParsedVersion
+            $script:NetboxConfig.Hostname = 'netbox.domain.com'
+            $script:NetboxConfig.HostScheme = 'https'
+            $script:NetboxConfig.HostPort = 443
+            $script:NetboxConfig.ParsedVersion = [version]'4.7.0'
+        }
+        # Every Get-NB* cmdlet that exposes -Tag must also expose -Tag_Id and route both to the query string
+        $script:TagGetCmdlets = Get-Command -Module PowerNetbox -Verb Get | Where-Object { $_.Parameters.ContainsKey('Tag') }
+    }
+    AfterAll {
+        InModuleScope -ModuleName 'PowerNetbox' -Parameters @{ v = $script:pvBefore } { $script:NetboxConfig.ParsedVersion = $v }
+        $null = Set-NBQueryOption -TagMatch All
+    }
+
+    Context "-Tag / -Tag_Id on Get cmdlets" {
+        It "Should exist on (at least) 90 Get cmdlets, always as a pair" {
+            $script:TagGetCmdlets.Count | Should -BeGreaterOrEqual 90
+            foreach ($c in $script:TagGetCmdlets) {
+                $c.Parameters.ContainsKey('Tag_Id') | Should -Be $true -Because "$($c.Name) has -Tag"
+                $c.Parameters['Tag'].ParameterType.FullName | Should -Be 'System.String[]' -Because "$($c.Name) -Tag"
+                $c.Parameters['Tag_Id'].ParameterType.FullName | Should -Be 'System.UInt64[]' -Because "$($c.Name) -Tag_Id"
+            }
+        }
+
+        It "Should emit repeat-key tag= and tag_id= filters on every cmdlet that has them" {
+            foreach ($c in $script:TagGetCmdlets) {
+                $r = & $c.Name -Tag 'edge', 'core' -Tag_Id 7, 8
+                $r.Method | Should -Be 'GET' -Because $c.Name
+                $r.Uri | Should -Match 'tag=edge' -Because $c.Name
+                $r.Uri | Should -Match 'tag=core' -Because $c.Name
+                $r.Uri | Should -Match 'tag_id=7' -Because $c.Name
+                $r.Uri | Should -Match 'tag_id=8' -Because $c.Name
+            }
+        }
+
+        It "Should switch to tag__any= with Set-NBQueryOption -TagMatch Any" {
+            $null = Set-NBQueryOption -TagMatch Any
+            try {
+                $r = Get-NBDCIMDevice -Tag 'edge', 'core' -Tag_Id 7
+                $r.Uri | Should -Match 'tag__any=edge'
+                $r.Uri | Should -Match 'tag__any=core'
+                $r.Uri | Should -Match 'tag_id__any=7'
+            }
+            finally { $null = Set-NBQueryOption -TagMatch All }
+        }
+    }
+
+    Context "Tag references in request bodies (names become attribute dictionaries)" {
+        It "ConvertToNBTagReference should map names, numeric strings, numbers and dictionaries" {
+            InModuleScope -ModuleName 'PowerNetbox' {
+                $refs = ConvertToNBTagReference -Tags 'web', '12', 13, @{ slug = 'prod' }, ([PSCustomObject]@{ name = 'x' })
+                $refs.Count | Should -Be 5
+                $refs[0].name | Should -Be 'web'
+                $refs[1] | Should -Be 12
+                $refs[1] | Should -BeOfType [uint64]
+                $refs[2] | Should -Be 13
+                $refs[3].slug | Should -Be 'prod'
+                $refs[4].name | Should -Be 'x'
+                (ConvertToNBTagReference -Tags $null).Count | Should -Be 0
+            }
+        }
+
+        It "New-NBDCIMSite -Tags 'web', 12 should send [{name:web}, 12] (BuildURIComponents path)" {
+            $r = New-NBDCIMSite -Name 's' -Slug 's' -Tags 'web', 12 -Confirm:$false
+            $b = $r.Body | ConvertFrom-Json
+            $b.tags[0].name | Should -Be 'web'
+            $b.tags[1] | Should -Be 12
+        }
+
+        It "Set-NBDCIMDevice -Tags should send tag references too" {
+            $r = Set-NBDCIMDevice -Id 1 -Tags 'edge' -Confirm:$false
+            ($r.Body | ConvertFrom-Json).tags[0].name | Should -Be 'edge'
+        }
+
+        It "New-NBIPAMService (manual body) should send tag references" {
+            $r = New-NBIPAMService -Name 'HTTP' -Ports 80 -Device 1 -Tags 'web', 3
+            $b = $r.Body | ConvertFrom-Json
+            $b.tags[0].name | Should -Be 'web'
+            $b.tags[1] | Should -Be 3
+        }
+
+        It "New-NBDCIMCable (manual body) should send tag references" {
+            $aTerm = @(@{ object_type = 'dcim.interface'; object_id = 1 })
+            $bTerm = @(@{ object_type = 'dcim.interface'; object_id = 2 })
+            $r = New-NBDCIMCable -A_Terminations $aTerm -B_Terminations $bTerm -Tags 'fiber' -Confirm:$false
+            ($r.Body | ConvertFrom-Json).tags[0].name | Should -Be 'fiber'
+        }
+    }
+}

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -170,6 +170,23 @@ services:
       - netbox-network
     restart: unless-stopped
 
+  # ==========================================================================
+  # Optional RQ worker (docker compose --profile worker ...)
+  # ==========================================================================
+  # Not started in CI. Needed locally to exercise Netbox 4.7 background bulk
+  # writes (?background=true), custom-field provisioning jobs, etc.
+  netbox-worker:
+    profiles: ["worker"]
+    extends:
+      service: netbox
+    command: /opt/netbox/venv/bin/python /opt/netbox/netbox/manage.py rqworker high default low
+    ports: !reset []
+    healthcheck:
+      disable: true
+    depends_on:
+      netbox:
+        condition: service_healthy
+
 # ==========================================================================
 # Volumes - Persist data between restarts (but not between CI runs)
 # ==========================================================================

--- a/docs/guides/bulk-operations.md
+++ b/docs/guides/bulk-operations.md
@@ -421,3 +421,24 @@ Measure-Command {
 - [Common Workflows](common-workflows.md) - General workflow examples
 - [DCIM Examples](dcim-examples.md) - Device management examples
 - [IPAM Examples](ipam-examples.md) - IP address management examples
+
+## Background Processing (NetBox 4.7+)
+
+Add `-Background` to any bulk-capable cmdlet to queue each batch as a NetBox background job instead of waiting for the synchronous response:
+
+```powershell
+$result = $devices | New-NBDCIMDevice -BatchSize 500 -Background -Force
+$result.Succeeded | ForEach-Object { Get-NBJob -Id $_.id }     # the returned items are job objects
+```
+
+- NetBox answers `202 Accepted` with the job; validation runs in the worker, so inspect the job status for the real outcome.
+- Requires NetBox 4.7+ and a running RQ worker. On older servers the switch warns and the batch is processed synchronously.
+- `docker compose --profile worker` starts a worker in the local test stack.
+
+## Partial Tag Updates
+
+`Set-NBObjectTag` adds or removes tags on any object without resending its whole tag list (NetBox 4.6+):
+
+```powershell
+Get-NBDCIMDevice -Tag 'staging' | Set-NBObjectTag -Add 'production' -Remove 'staging'
+```

--- a/docs/guides/compatibility.md
+++ b/docs/guides/compatibility.md
@@ -91,8 +91,15 @@ The `Get-NBContentType` function automatically detects your Netbox version and u
 | Token plaintext read-only | Clients can no longer choose the token value on create | No impact (`New-NBToken` never exposed it) |
 | v2 tokens only in netbox-docker 5.0.2+ | `SUPERUSER_API_TOKEN` alone no longer creates a token | `docker-compose.ci.yml` sets `SUPERUSER_API_KEY` for a deterministic `nbt_` token |
 | New interface/port types | `channel`, `100gbase-x-sfp112`, InfiniBand 4X, HPE Synergy; `mdc` port; `breakout-1c8p-8c1p` cable profile | Added to the ValidateSets |
+| Cooling infrastructure | `cooling-sources`, `cooling-feeds`, `cooling-intakes`, `cooling-outflows` (+ templates) | `Get/New/Set/Remove-NBDCIMCooling*` (v4.7.1.0) |
+| Module bay types | `module-bay-types` + `module_bay_types` on module bays / templates / module types | `Get/New/Set/Remove-NBDCIMModuleBayType`, `-Module_Bay_Types` (v4.7.1.0) |
+| New fields | Interface `channels`/`channel_id`/`mac_address`, `cooling_method`, `end_of_life`, Rack `cooling_capability`/`cooling_capacity` | Parameters + filters, version-gated (v4.7.1.0) |
+| Background bulk writes | `?background=true` -> 202 + job | `-Background` on bulk-capable cmdlets (v4.7.1.0) |
+| `tag__any` (4.6.6) | OR semantics for tag filters | `-Tag`/`-Tag_Id` on all Get cmdlets + `Set-NBQueryOption -TagMatch Any` (v4.7.1.0) |
+| Cursor pagination (4.6) | `?start=<pk>` | `Set-NBQueryOption -Pagination Cursor` (v4.7.1.0) |
+| ETag / If-Match (4.6) | optimistic concurrency, 412 on conflict | `Set-NBQueryOption -OptimisticConcurrency` (v4.7.1.0) |
+| `add_tags` / `remove_tags` (4.6) | partial tag assignment | `Set-NBObjectTag` (v4.7.1.0) |
 
-New 4.7 models (cooling infrastructure, module bay types) and fields (`channels`, `end_of_life`, `cooling_method`, ...) are tracked for a follow-up release.
 
 ## Running Compatibility Tests Locally
 

--- a/docs/guides/performance.md
+++ b/docs/guides/performance.md
@@ -198,3 +198,41 @@ Get-NBDCIMDevice -Status 'active' -Brief -Limit 100 -Offset 0
 - [Bulk Operations](bulk-operations.md) - High-performance batch processing
 - [Common Workflows](common-workflows.md) - Real-world examples
 - [NetBox Best Practices](https://github.com/netboxlabs/netbox-best-practices) - Official documentation
+
+## Cursor Pagination (NetBox 4.6+)
+
+`-All` pages with `limit`/`offset` by default. On very large tables (IP addresses, interfaces, change log) offset paging gets slower with every page because the database has to skip the preceding rows. NetBox 4.6 added cursor pagination (`?start=<pk>`), which is constant-time per page.
+
+```powershell
+Set-NBQueryOption -Pagination Cursor
+$ips = Get-NBIPAMAddress -All -PageSize 500     # walks the table by primary key
+Set-NBQueryOption -Pagination Offset            # back to the default
+```
+
+- Results are ordered by primary key, not by the endpoint's default ordering.
+- `count` is not reported per page in cursor mode; the returned array is complete.
+- Below NetBox 4.6 the option is ignored (offset paging, with a one-time warning when you set it).
+- The pagination `next` URL is still validated against the original host (same SSRF guard as offset paging).
+
+## Background Bulk Writes (NetBox 4.7+)
+
+Large bulk creates/updates can exceed proxy or gateway timeouts. NetBox 4.7 can queue a bulk write as a background job:
+
+```powershell
+$devices | New-NBDCIMDevice -BatchSize 500 -Background -Force   # returns job objects (HTTP 202)
+Get-NBJob -Id <job id>                                           # status, and the response the sync call would have returned
+```
+
+Validation happens in the worker, so a 202 only means "accepted"; check the job for the real outcome. Requires a running RQ worker on the NetBox server.
+
+## Optimistic Concurrency (NetBox 4.6+)
+
+When several people or scripts edit the same objects, enable ETag / If-Match checking so a stale write fails instead of overwriting:
+
+```powershell
+Set-NBQueryOption -OptimisticConcurrency
+$dev = Get-NBDCIMDevice -Id 42                      # ETag cached
+Set-NBDCIMDevice -Id 42 -Description 'changed'      # sent with If-Match; 412 if the device changed in between
+```
+
+Needs PowerShell 7+ (response headers are not exposed on Windows PowerShell 5.1; the option then warns once and updates are sent without If-Match).

--- a/scripts/validateset-parity-exclusions.txt
+++ b/scripts/validateset-parity-exclusions.txt
@@ -70,3 +70,7 @@ DCIM/Racks/Set-NBDCIMRack.ps1::Form_Factor
 # airflow enum does include "" + null, but the parity matcher treats the
 # '' as a PowerNetbox-only null-clearing sentinel, not an enum value.
 DCIM/Devices/Set-NBDCIMDevice.ps1::Airflow
+# NetBox 4.7 cooling infrastructure (CoolingSource fluid_type, CoolingFeed
+# max_flow_unit) - same '' sentinel pattern for PATCH null-clearing.
+DCIM/CoolingSources/Set-NBDCIMCoolingSource.ps1::Fluid_Type
+DCIM/CoolingFeeds/Set-NBDCIMCoolingFeed.ps1::Max_Flow_Unit

--- a/scripts/validateset-parity-exclusions.txt
+++ b/scripts/validateset-parity-exclusions.txt
@@ -70,3 +70,28 @@ DCIM/Racks/Set-NBDCIMRack.ps1::Form_Factor
 # airflow enum does include "" + null, but the parity matcher treats the
 # '' as a PowerNetbox-only null-clearing sentinel, not an enum value.
 DCIM/Devices/Set-NBDCIMDevice.ps1::Airflow
+# NetBox 4.7 cooling components (CoolingIntake / CoolingOutflow + templates).
+# -Type carries the '' sentinel on Set-* for null-clearing (same pattern as above).
+DCIM/CoolingIntakes/Set-NBDCIMCoolingIntake.ps1::Type
+DCIM/CoolingOutflows/Set-NBDCIMCoolingOutflow.ps1::Type
+DCIM/CoolingIntakeTemplates/Set-NBDCIMCoolingIntakeTemplate.ps1::Type
+DCIM/CoolingOutflowTemplates/Set-NBDCIMCoolingOutflowTemplate.ps1::Type
+
+# ---------------------------------------------------------------------------
+# Parameters whose ChoiceSet lives in netbox/netbox/choices.py (the global,
+# app-less module) which the parity script does not scan - it only fetches
+# <app>/choices.py. The heuristic then picks an app ChoiceSet by value overlap.
+# ---------------------------------------------------------------------------
+
+# -Diameter_Unit is netbox.choices.DiameterUnitChoices ('mm', 'cm', 'in').
+# The matcher picks dcim.RackDimensionUnitChoices ('mm', 'in') and flags 'cm'
+# as extra. Verified against the v4.7.0 OpenAPI schema (diameter_unit enum)
+# and netbox/netbox/choices.py. Set-* variants also carry the '' sentinel.
+DCIM/CoolingIntakes/New-NBDCIMCoolingIntake.ps1::Diameter_Unit
+DCIM/CoolingIntakes/Set-NBDCIMCoolingIntake.ps1::Diameter_Unit
+DCIM/CoolingOutflows/New-NBDCIMCoolingOutflow.ps1::Diameter_Unit
+DCIM/CoolingOutflows/Set-NBDCIMCoolingOutflow.ps1::Diameter_Unit
+DCIM/CoolingIntakeTemplates/New-NBDCIMCoolingIntakeTemplate.ps1::Diameter_Unit
+DCIM/CoolingIntakeTemplates/Set-NBDCIMCoolingIntakeTemplate.ps1::Diameter_Unit
+DCIM/CoolingOutflowTemplates/New-NBDCIMCoolingOutflowTemplate.ps1::Diameter_Unit
+DCIM/CoolingOutflowTemplates/Set-NBDCIMCoolingOutflowTemplate.ps1::Diameter_Unit

--- a/scripts/validateset-parity-exclusions.txt
+++ b/scripts/validateset-parity-exclusions.txt
@@ -70,3 +70,11 @@ DCIM/Racks/Set-NBDCIMRack.ps1::Form_Factor
 # airflow enum does include "" + null, but the parity matcher treats the
 # '' as a PowerNetbox-only null-clearing sentinel, not an enum value.
 DCIM/Devices/Set-NBDCIMDevice.ps1::Airflow
+# NetBox 4.7 cooling fields (fields-47) - same '' sentinel pattern on the
+# Set-* cmdlets: '' is translated to JSON null in process {} to clear the
+# nullable enum server-side.
+DCIM/Devices/Set-NBDCIMDevice.ps1::Cooling_Method
+DCIM/Devices/Set-NBDCIMDeviceType.ps1::Cooling_Method
+DCIM/ModuleTypes/Set-NBDCIMModuleType.ps1::Cooling_Method
+DCIM/Racks/Set-NBDCIMRack.ps1::Cooling_Capability
+DCIM/RackTypes/Set-NBDCIMRackType.ps1::Cooling_Capability


### PR DESCRIPTION
## Summary

Realises the NetBox 4.7 residual backlog (#473) plus the two long-standing REST enhancements (#439 ETag/If-Match, #440 cursor pagination). Bumps `ModuleVersion` to **4.7.1.0**.

### New endpoints (24 cmdlets)
- **Cooling infrastructure** (mirrors PowerPanel/PowerFeed/PowerPort/PowerOutlet): `Get/New/Set/Remove-NBDCIMCoolingSource`, `-CoolingFeed`, `-CoolingIntake`, `-CoolingOutflow`, `-CoolingIntakeTemplate`, `-CoolingOutflowTemplate`.
- **Module bay types**: `Get/New/Set/Remove-NBDCIMModuleBayType` + `-Module_Bay_Types` on `New/Set-NBDCIMModuleBay`, `-NBDCIMModuleBayTemplate`, `-NBDCIMModuleType` (4.7-gated). Module relocation verified via the existing `Set-NBDCIMModule -Module_Bay/-Device` (help documents it; NetBox enforces bay-type compatibility).

### New 4.7 fields on existing cmdlets (all version-gated with `Test-NBMinimumVersion 4.7.0`)
Interface `-Channels`/`-Channel_Id`/`-MAC_Address` (+ templates), `-Cooling_Method` (Device/DeviceType/ModuleType), `-End_Of_Life` (DeviceType/ModuleType), Rack/RackType `-Cooling_Capability`/`-Cooling_Capacity`, matching Get filters; Rack `form_factor`/`width`/`outer_*` deprecation noted in help.

### Query options (`Set-NBQueryOption`, applied centrally)
- `-Pagination Offset|Cursor` — `-All` uses NetBox 4.6+ `?start=<pk>`; offset fallback below 4.6; SSRF origin guard unchanged (#440).
- `-OptimisticConcurrency` — ETag cached per object on GET, `If-Match` on PATCH/PUT/DELETE, 412 mapped to "Precondition Failed" with a re-read hint; PS 7+ (#439).
- `-TagMatch All|Any` — `tag__any`/`tag_id__any` on 4.6.6+ (older servers keep AND semantics on purpose).

### Tags
- **`-Tag [string[]]` / `-Tag_Id [uint64[]]` filters on 100 Get cmdlets** (every list endpoint that exposes `tag` in the 4.7 schema) — they did not exist before.
- **Bug fix:** `-Tags 'name'` always failed with `400 Related objects must be referenced by numeric ID or by dictionary of attributes` despite the help promising "tag names or IDs". `ConvertToNBTagReference` now turns names into `@{ name = ... }` centrally (`BuildURIComponents` + the two hand-built bodies).
- `Set-NBObjectTag` — partial tag assignment via `add_tags`/`remove_tags` (4.6+), refuses on older servers instead of silently no-op-ing.

### Bulk
- `-Background` on `Send-NBBulkRequest` and the 13 bulk-capable cmdlets: `?background=true` → `202 {job}`; job objects returned (4.7-gated). `docker-compose.ci.yml` gains an optional `worker` profile (RQ worker) for local verification.

### Docs / tooling
README (tags, cursor, concurrency, background), guides (performance, bulk-operations, compatibility), `new-netbox-endpoint` skill (Docker live verification, gating recipe, `-Tag/-Tag_Id` in the Get template, new pitfalls incl. `Set-ItResult` in `BeforeAll`, Pester 6 `Should -Invoke`, `-is [PSCustomObject]` on strings).

## Test plan
- [x] Unit suite: **2874 passed, 0 failed** (Pester 5.7.1); CodeQuality parity gate green; `Verify-ValidateSetParity v4.7.0` clean; `Verify-FilterExclusion` clean; PSScriptAnalyzer (repo settings) 0 findings on 163 changed files; ASCII check clean
- [x] Live Docker **4.7.0** (+ RQ worker): every new endpoint/field exercised create→read→filter→update→delete by the implementing agents; TagMatch All/Any, `Set-NBObjectTag`, cursor `-All` (same set as offset), ETag 412 on a stale write, background bulk job completed (VLANs created by the worker)
- [x] Live Docker **4.3.7**: options degrade safely (warnings, plain `tag`, offset paging, `Set-NBObjectTag` refuses)
- [x] `Integration.Tests.ps1` Live: 4.7.0 **113/113**, 4.3.7 **96 + 14 skipped**
- [ ] Integration matrix on push to `dev` (5 legs)

Closes #439, closes #440, closes #473.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rudf2aZUmnQQsbmpoLoWh5