### PR TITLE
fix(scenario): Scenario suite green on the Docker matrix; per-object rendering of pre-4.7 bulk errors

### DIFF
--- a/Functions/Helpers/InvokeNetboxRequest.ps1
+++ b/Functions/Helpers/InvokeNetboxRequest.ps1
@@ -345,7 +345,19 @@ function InvokeNetboxRequest {
                 # Try to parse as JSON first (Netbox API returns JSON errors)
                 try {
                     $errorData = $errorBody | ConvertFrom-Json -ErrorAction Stop
-                    if ($errorData.detail) {
+                    if ($errorData -is [System.Array]) {
+                        # Pre-4.7 bulk create/update failure: one entry per submitted object, empty for
+                        # the ones that were fine. Render '[index] field: message' like the 4.7 format.
+                        $perObject = for ($i = 0; $i -lt $errorData.Count; $i++) {
+                            $entry = $errorData[$i]
+                            if ($null -eq $entry) { continue }
+                            $props = @($entry.PSObject.Properties)
+                            if ($props.Count -eq 0) { continue }
+                            "[$i] " + (($props | ForEach-Object { "$($_.Name): $($_.Value -join ', ')" }) -join '; ')
+                        }
+                        $errorMessage = if ($perObject) { "$($perObject.Count) of $($errorData.Count) objects failed validation.`n" + ($perObject -join "`n") } else { $errorBody }
+                    }
+                    elseif ($errorData.detail) {
                         $errorMessage = $errorData.detail
                         # Netbox 4.7+ bulk create/update failures return
                         # {"detail": ..., "errors": [{"index": N, "errors": {field: [msg]}}]}

--- a/Tests/Scenario/Filters.Tests.ps1
+++ b/Tests/Scenario/Filters.Tests.ps1
@@ -286,10 +286,11 @@ Describe "IPAM Filter Tests" -Tag 'Scenario', 'Filters', 'IPAM' {
         It "Should filter prefixes by site" {
             $sites = Get-NBDCIMSite -Query $script:Prefix -Limit 1
             if ($sites) {
-                $prefixesBySite = Get-NBIPAMPrefix -Site_Id $sites[0].id
+                # Prefix.site was replaced by the generic scope (scope_type/scope_id) in NetBox 4.2
+                $prefixesBySite = Get-NBIPAMPrefix -Scope_Type 'dcim.site' -Scope_Id $sites[0].id
 
                 if ($prefixesBySite) {
-                    $prefixesBySite | ForEach-Object { $_.site.id | Should -Be $sites[0].id }
+                    $prefixesBySite | ForEach-Object { $_.scope.id | Should -Be $sites[0].id }
                 }
             }
             else {
@@ -614,15 +615,26 @@ Describe "VPN Filter Tests" -Tag 'Scenario', 'Filters', 'VPN' {
 Describe "Tag Filter Tests" -Tag 'Scenario', 'Filters', 'Extras' {
     Context "Tag-Based Filtering" {
         It "Should filter objects by tag" {
-            # Get-NBDCIMDevice doesn't have a Tag parameter - skip for now
-            # TODO: Add Tag parameter to Get-NBDCIMDevice
-            Set-ItResult -Skipped -Because "Tag filtering not yet implemented in Get-NBDCIMDevice"
+            # -Tag / -Tag_Id exist on every taggable Get cmdlet since v4.7.0.1 (AND semantics by default)
+            $tag = Get-NBTag -All | Where-Object { $_.slug -like 'pnb-test-*' } | Select-Object -First 1
+            if (-not $tag) { Set-ItResult -Skipped -Because 'No PNB-Test tags found'; return }
+
+            $devices = Get-NBDCIMDevice -Tag $tag.slug -All
+            $byId = Get-NBDCIMDevice -Tag_Id $tag.id -All
+            @($devices).Count | Should -Be @($byId).Count
+            foreach ($d in $devices) { $d.tags.slug | Should -Contain $tag.slug }
         }
 
         It "Should filter sites by tag" {
-            # Get-NBDCIMSite doesn't have a Tag parameter - skip for now
-            # TODO: Add Tag parameter to Get-NBDCIMSite
-            Set-ItResult -Skipped -Because "Tag filtering not yet implemented in Get-NBDCIMSite"
+            $tag = Get-NBTag -All | Where-Object { $_.slug -like 'pnb-test-*' } | Select-Object -First 1
+            if (-not $tag) { Set-ItResult -Skipped -Because 'No PNB-Test tags found'; return }
+
+            $sites = Get-NBDCIMSite -Tag $tag.slug -All
+            foreach ($s in $sites) { $s.tags.slug | Should -Contain $tag.slug }
+            @(Get-NBDCIMSite -Tag_Id $tag.id -All).Count | Should -Be @($sites).Count
+
+            # NetBox validates the tag filter against existing tags: an unknown slug is a 400, not an empty list
+            { Get-NBDCIMSite -Tag 'pnb-test-no-such-tag-zzz' -ErrorAction Stop } | Should -Throw '*not one of the available choices*'
         }
     }
 }

--- a/Tests/Scenario/Workflows.Tests.ps1
+++ b/Tests/Scenario/Workflows.Tests.ps1
@@ -112,6 +112,21 @@ Describe "Server Lifecycle Workflow" -Tag 'Scenario', 'Workflow', 'Lifecycle' {
         $script:WF_Type = Get-NBDCIMDeviceType -Query $script:Prefix | Select-Object -First 1
         $script:WF_Rack = Get-NBDCIMRack -Query $script:Prefix | Select-Object -First 1
 
+        # The imported test data already fills part of the rack; find a free front-face unit for the
+        # (1U) test server instead of hard-coding one that collides with existing devices.
+        $script:WF_Position = $null
+        if ($script:WF_Rack) {
+            $occupied = @{}
+            foreach ($d in (Get-NBDCIMDevice -Rack_Id $script:WF_Rack.id -All)) {
+                if ($d.position) {
+                    $height = [Math]::Max(1, [int][Math]::Ceiling([double]$d.device_type.u_height))
+                    for ($u = [int][Math]::Floor([double]$d.position); $u -lt ([int][Math]::Floor([double]$d.position) + $height); $u++) { $occupied[$u] = $true }
+                }
+            }
+            $script:WF_Position = ([int]$script:WF_Rack.u_height)..1 | Where-Object { -not $occupied.ContainsKey($_) } | Select-Object -First 1
+            if (-not $script:WF_Position) { $script:WF_Rack = $null }
+        }
+
         if (-not $script:WF_Site -or -not $script:WF_Role -or -not $script:WF_Type) {
             $script:SkipLifecycleTests = $true
         }
@@ -135,7 +150,7 @@ Describe "Server Lifecycle Workflow" -Tag 'Scenario', 'Workflow', 'Lifecycle' {
 
             if ($script:WF_Rack) {
                 $params.Rack = $script:WF_Rack.id
-                $params.Position = 10
+                $params.Position = $script:WF_Position
                 $params.Face = 'front'
             }
 
@@ -194,7 +209,7 @@ Describe "Server Lifecycle Workflow" -Tag 'Scenario', 'Workflow', 'Lifecycle' {
                 [PSCustomObject]@{
                     Device = $script:WF_Device.id
                     Name   = "eth$_"
-                    Type   = '10gbase-sr'
+                    Type   = '10gbase-x-sfpp'   # exists on every supported NetBox (10gbase-sr only since 4.4)
                 }
             } | New-NBDCIMInterface -Force
 


### PR DESCRIPTION
## Summary

Closes #479.

- **Filters scenario** — `Get-NBIPAMPrefix -Site_Id` → `-Scope_Type dcim.site -Scope_Id` (Prefix scope since NetBox 4.2); the two `Tag filtering not yet implemented` skips now test `-Tag` / `-Tag_Id` from v4.7.0.1 (an unknown tag slug is a NetBox 400 and is asserted as such).
- **Workflows scenario** — finds a free front-face unit in the test rack instead of hard-coding U10 (collided with imported devices); interface type `10gbase-x-sfpp` instead of `10gbase-sr` (only exists since NetBox 4.4).
- **`InvokeNetboxRequest`** — pre-4.7 bulk failures come back as a JSON array (one entry per submitted object) and were rendered as `[] null []` (member enumeration made `.detail` an array of nulls, i.e. truthy). Now `N of M objects failed validation` + `[index] field: message`, matching the 4.7 format. Verified live on 4.3.7:
  ```
  Message: 1 of 2 objects failed validation.
  [1] type: 10gbase-sr is not a valid choice.
  ```
- The project-local `TestData/import_testdata.py` was made idempotent in the same sweep (existing-object detection for overlaps/reservations/terminations, device-scoped component lookups — the root cause of the "cable connects an interface to itself" error — plus tunnel-termination and cable lookups).

## Test plan
- [x] Scenario suite via `Start-NetboxDocker.ps1`: **4.7.0 115 passed / 0 failed / 10 skipped**, **4.3.7 115 / 0 / 10** (skips are data-dependent: no primary IPs / aggregates / circuits in the imported set)
- [x] `TestData/import_testdata.py 4.7.0` twice in a row: 0 errors
- [x] Unit: ErrorHandling, BulkOperations, QueryOptions47, Helpers, CodeQuality → 311 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rudf2aZUmnQQsbmpoLoWh5