### PR TITLE
docs: publish the PowerShell support policy; fix manifest prerequisites (#496)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ Be respectful, inclusive, and constructive. We're all here to build great softwa
 
 ### Prerequisites
 
-- PowerShell 5.1+ (Desktop) or PowerShell 7+ (Core)
+- PowerShell 7.6 LTS, 7.4 LTS, or Windows PowerShell 5.1 (see the [Compatibility guide](https://docs.powernetbox.dev/guides/compatibility/#powershell-support))
 - Git
 - A Netbox instance for testing (or use Docker)
 - [Pester](https://pester.dev/) 5.0+ for running tests
@@ -213,10 +213,14 @@ PRs must pass these automated checks before merge:
 
 | Check | Required |
 |-------|----------|
-| PSScriptAnalyzer (Lint) | ✅ |
-| Pester Tests (Ubuntu) | ✅ |
-| Pester Tests (Windows) | ✅ |
+| PSScriptAnalyzer | ✅ |
+| Pester Tests (ubuntu-latest, PS 7.6) | ✅ |
+| Pester Tests (windows-latest, PS 7.6) | ✅ |
+| Pester Tests (windows-latest, PS 5.1) | ✅ |
 | Code Review (1 approval) | ✅ |
+
+The full matrix runs seven legs (three operating systems on PowerShell 7.4 and 7.6, plus
+Windows PowerShell 5.1); the four above are the ones branch protection requires.
 
 ### Review Process
 

--- a/Functions/Helpers/_ArgumentCompleters.ps1
+++ b/Functions/Helpers/_ArgumentCompleters.ps1
@@ -461,7 +461,7 @@ function Register-NBArgumentCompleters {
     # $env:PSModulePath. A fork developer who also has a PSGallery build
     # installed then ends up with two PowerNetbox modules in one session,
     # breaking Pester ("Multiple script or manifest modules named
-    # 'PowerNetbox'") — see #418. Reading FunctionsToExport from the manifest
+    # 'PowerNetbox'") - see #418. Reading FunctionsToExport from the manifest
     # is auto-load-free, also works under $PSModuleAutoLoadingPreference='None',
     # and mirrors whatever deploy.ps1 wrote (dev build = all functions,
     # prod build = public only).

--- a/Functions/Plugins/Branching/Branch/Wait-NBBranch.ps1
+++ b/Functions/Plugins/Branching/Branch/Wait-NBBranch.ps1
@@ -157,13 +157,13 @@ function Wait-NBBranch {
             $lastStatus = $currentStatus
             Write-Verbose "Branch '$currentName' (id=$currentId) status: $currentStatus"
 
-            # Target reached — return the fully-resolved branch object.
+            # Target reached - return the fully-resolved branch object.
             if ($currentStatus -eq $TargetStatus) {
                 Write-Verbose "Branch '$currentName' reached target status '$TargetStatus'"
                 return $branch
             }
 
-            # Terminal failure — surface plugin-reported errors if present.
+            # Terminal failure - surface plugin-reported errors if present.
             if ($currentStatus -eq 'failed') {
                 $errorDetail = if ($branch.errors) {
                     " Details: $(@($branch.errors) -join '; ')"
@@ -174,7 +174,7 @@ function Wait-NBBranch {
                 throw "Branch '$currentName' entered 'failed' state while waiting for '$TargetStatus'.$errorDetail"
             }
 
-            # Still transitional — sleep and poll again.
+            # Still transitional - sleep and poll again.
             if ($currentStatus -in $transitionalStatuses) {
                 if ((Get-Date) -ge $deadline) {
                     throw "Timed out after $TimeoutSeconds seconds waiting for branch '$currentName' to reach status '$TargetStatus' (last observed: '$lastStatus')."
@@ -184,7 +184,7 @@ function Wait-NBBranch {
             }
 
             # Any other terminal status (ready/merged/archived/pending-migrations)
-            # that isn't our target means we'll never reach it — fail fast rather
+            # that isn't our target means we'll never reach it - fail fast rather
             # than burn the whole timeout.
             throw "Branch '$currentName' is in terminal status '$currentStatus', cannot reach target '$TargetStatus'."
         }

--- a/PowerNetbox.psd1
+++ b/PowerNetbox.psd1
@@ -42,10 +42,13 @@ PowerShellVersion = '5.1'
 # PowerShellHostVersion = ''
 
 # Minimum version of Microsoft .NET Framework required by this module. This prerequisite is valid for the PowerShell Desktop edition only.
-DotNetFrameworkVersion = '2.0'
+# Windows PowerShell 5.1 itself requires .NET Framework 4.5.2 or later, and TLS 1.2 in
+# Set-NBCipherSSL requires 4.5+. The previous value of '2.0' understated the requirement.
+DotNetFrameworkVersion = '4.5.2'
 
 # Minimum version of the common language runtime (CLR) required by this module. This prerequisite is valid for the PowerShell Desktop edition only.
-ClrVersion = '2.0.50727'
+# .NET Framework 4.x runs on CLR 4.0; the previous value of '2.0.50727' was the CLR 2.0 build.
+ClrVersion = '4.0'
 
 # Processor architecture (None, X86, Amd64) required by this module
 # ProcessorArchitecture = ''

--- a/README.md
+++ b/README.md
@@ -125,9 +125,13 @@ Depending on the version of the NetBox API used, the API supports these options 
 
 ## Requirements
 
-PowerShell **5.1** (Windows Desktop) or **7.0+** (Windows / macOS / Linux), and
+PowerShell **7.6 LTS** (baseline), **7.4 LTS** (until its end-of-support on 2026-11-10)
+or **Windows PowerShell 5.1**, on Windows / macOS / Linux. Every one of those is exercised
+in CI. Windows PowerShell 5.1 is supported and will not be dropped; features needing .NET
+capabilities it lacks are PowerShell 7+ and degrade with a warning.
+
 NetBox **4.3+** (tested against 4.3.7, 4.4.10, 4.5.10, 4.6.10, 4.7.0). Version-specific
-behaviour and the support matrix are documented in the
+behaviour and both support matrices are documented in the
 [Compatibility guide](https://docs.powernetbox.dev/guides/compatibility/).
 
 ## Contributing

--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -24,8 +24,15 @@ Both `dev` and `main` branches are protected:
 | Check | Description |
 |-------|-------------|
 | PSScriptAnalyzer | PowerShell linting |
-| Pester Tests (Ubuntu) | Unit tests on Linux |
-| Pester Tests (Windows) | Unit tests on Windows |
+| Pester Tests (ubuntu-latest, PS 7.6) | Unit tests on Linux, PowerShell 7.6 LTS |
+| Pester Tests (windows-latest, PS 7.6) | Unit tests on Windows, PowerShell 7.6 LTS |
+| Pester Tests (windows-latest, PS 5.1) | Unit tests on Windows PowerShell 5.1 |
+
+The test workflow runs seven legs in total (Linux, Windows and macOS on PowerShell 7.4 and
+7.6, plus Windows PowerShell 5.1); the four above are the ones branch protection requires.
+
+The Windows PowerShell 5.1 leg is required deliberately - see
+[Keep .ps1 files ASCII-only](#keep-ps1-files-ascii-only) below.
 
 ### Requirements
 
@@ -33,6 +40,47 @@ Both `dev` and `main` branches are protected:
 - ✅ At least 1 code review approval
 - ❌ Force push disabled
 - ❌ Branch deletion disabled
+
+## Keep .ps1 files ASCII-only
+
+Use only ASCII characters in `.ps1` files - no em-dashes, arrows, curly quotes or accented
+characters. Markdown files are unaffected; this rule is about PowerShell sources only.
+
+If code needs to *emit* a non-ASCII character, build it from its code point instead of
+pasting the glyph. `Functions/Helpers/ConvertTo-NBRackConsole.ps1` is the pattern to copy:
+
+```powershell
+TopLeft    = [string][char]0x2554  # the glyph may appear in the trailing comment
+Horizontal = [string][char]0x2550
+```
+
+The source stays ASCII, so it parses identically on every edition, and the comment still
+shows a reader what the constant renders as.
+
+**Why:** Windows PowerShell 5.1 reads script files as Windows-1252, not UTF-8. A multi-byte
+UTF-8 character is decoded as two garbage characters, which usually breaks the parse
+somewhere *after* the offending line. The result is an error that points at the wrong place
+and does not mention encoding at all:
+
+```
+Missing closing ')' in expression.
+Missing closing '}' in statement block.
+```
+
+PowerShell 7 parses the same file without complaint, so this only ever fails on the Windows
+PowerShell 5.1 leg - which is one of the reasons that leg is a required check. If a build
+fails with an inexplicable "missing closing bracket" error on 5.1 only, search the file for
+non-ASCII characters first:
+
+```powershell
+# Every .ps1 in the repo that contains a non-ASCII character
+Get-ChildItem ./Functions -Recurse -Filter *.ps1 |
+    Select-String -Pattern '[^\x00-\x7F]'
+```
+
+The only hits this should return are the annotated glyphs in
+`ConvertTo-NBRackConsole.ps1`, which live in trailing comments. Anything else is a bug
+waiting for the next Windows PowerShell 5.1 run.
 
 ## Why These Practices?
 

--- a/docs/guides/compatibility.md
+++ b/docs/guides/compatibility.md
@@ -1,8 +1,8 @@
-# Netbox Version Compatibility
+# Compatibility
 
 PowerNetbox is tested against multiple Netbox versions to ensure broad compatibility.
 
-## Supported Versions
+## NetBox Versions
 
 > The exact versions exercised in CI are shown on the
 > [home page compatibility table](../index.md#compatibility), which is
@@ -22,6 +22,53 @@ PowerNetbox is tested against multiple Netbox versions to ensure broad compatibi
 | 3.x | ❌ Not Supported | Missing required API endpoints |
 
 **Minimum supported version: Netbox 4.3+**
+
+## PowerShell Support
+
+These are the versions exercised in CI on every push and pull request. Each leg installs
+its PowerShell version explicitly and verifies `$PSVersionTable` before running the suite,
+so this table is a contract rather than an intention.
+
+| PowerShell | Edition | Status | Supported until |
+|------------|---------|--------|-----------------|
+| 7.6 LTS | Core | Baseline | 2028-11-14 (.NET 10) |
+| 7.4 LTS | Core | Tested | **2026-11-10** (.NET 8) - the CI leg is removed on that date |
+| 5.1 | Desktop | Supported, frozen | Tied to the Windows release that ships it |
+
+PowerShell 7.0-7.3 and 7.5 are past end-of-support and are not tested. They will generally
+work, but no compatibility claim is made for them.
+
+### Windows PowerShell 5.1: supported, frozen
+
+The module loads and every cmdlet works on Windows PowerShell 5.1. There is no plan to drop
+it: Windows PowerShell has no end-of-life date of its own, because it is supported as a
+component of the Windows release that bundles it. Windows Server 2022 runs to October 2031
+and Windows Server 2025 to November 2034.
+
+"Frozen" means:
+
+- Features that require .NET capabilities 5.1 does not have ship as **PowerShell 7+
+  features**, with a warning and documented degradation rather than a hard failure.
+- No new 5.1-specific code is written.
+
+The support decision is revisited only if one of these happens:
+
+1. Microsoft announces an actual deprecation of Windows PowerShell 5.1.
+2. The edition-specific code in the module grows materially beyond its current footprint.
+3. A NetBox API feature turns out to be unimplementable on .NET Framework.
+
+### PowerShell 7+ only features
+
+One feature is genuinely gated on PowerShell 7, because it needs a capability that
+.NET Framework does not provide:
+
+| Feature | Requires | Behaviour on 5.1 |
+|---------|----------|------------------|
+| `Set-NBQueryOption -OptimisticConcurrency` (ETag / If-Match) | `Invoke-RestMethod -ResponseHeadersVariable` to read response headers | A warning is emitted once, and requests are sent without `If-Match` |
+
+Everything else that branches on edition - TLS configuration, certificate validation
+bypass, multipart image upload - takes a different code path to reach **the same
+behaviour**, and needs no change to your scripts.
 
 ## Compatibility Testing
 


### PR DESCRIPTION
Closes #496.

## The problem

Three things were wrong at once:

1. **The README claimed more than CI proved.** "PowerShell 5.1 or **7.0+**" - but 7.0-7.3 and 7.5 are all past end-of-support and are not tested. A support claim nobody verifies is worse than no claim.
2. **The 5.1 position had never been written down.** #496 decided it (supported, frozen) but the decision lived in an issue, not in anything a user reads.
3. **Three documents restated the required status checks**, all stale after #482 renamed the jobs.

## Single source of truth

The Compatibility guide. Everything else links to it rather than restating it - which is exactly how the three stale copies came to exist.

| File | Change |
|---|---|
| `docs/guides/compatibility.md` | New **PowerShell Support** section: tested versions, the frozen-5.1 policy with its three revisit triggers, and the one genuinely PS7-gated feature. Retitled `Netbox Version Compatibility` -> `Compatibility` (the page now covers two axes); the URL is unchanged, so no links break. |
| `README.md` | Requirements now name the versions CI exercises, plus one line on the 5.1 position. |
| `CONTRIBUTING.md` | Prerequisites and the required-checks table corrected; links to the guide. |
| `docs/contributing/development.md` | Required-checks table corrected; the ASCII-only rule documented. |

### One feature is genuinely PS7-only

Verified by reading every edition branch in `Functions/`, not by assumption. Exactly one is a *feature gate*:

| Feature | Requires | On 5.1 |
|---|---|---|
| `Set-NBQueryOption -OptimisticConcurrency` | `Invoke-RestMethod -ResponseHeadersVariable` | warns once, sends without `If-Match` |

The other four branches (`Set-NBCipherSSL`, `Set-NBuntrustedSSL`, `New-NBImageAttachment`, `Connect-NBAPI`) take a different code path to reach **the same behaviour**. The docs say so, rather than implying 5.1 is a degraded tier.

## The ASCII rule now states its cause

It existed only as tribal knowledge. It is now documented with the mechanism - Windows PowerShell 5.1 decodes sources as Windows-1252, so a UTF-8 character becomes garbage that breaks the parse *after* the offending line, producing `Missing closing ')'` pointing at the wrong place - plus a detection one-liner and the `[char]0xNNNN` pattern for code that must emit non-ASCII.

**Writing the rule immediately found five violations of it**: em-dashes in comments in `Wait-NBBranch.ps1` and `_ArgumentCompleters.ps1`, now hyphens. They were harmless - a `#` comment runs to end of line - but a repo that documents a rule should follow it. The 11 remaining hits are the annotated glyphs in `ConvertTo-NBRackConsole.ps1`, which is the good example: its functional code builds the box characters with `[char]0x2554`, so the source is ASCII and only the trailing comment shows the glyph.

## Manifest prerequisites

Both Desktop-only, both understated since the fork:

| Field | Was | Now | Why |
|---|---|---|---|
| `DotNetFrameworkVersion` | `2.0` | `4.5.2` | Windows PowerShell 5.1 itself requires 4.5.2+; TLS 1.2 in `Set-NBCipherSSL` requires 4.5+ |
| `ClrVersion` | `2.0.50727` | `4.0` | .NET Framework 4.x runs on CLR 4.0 |

## Verification

- `Test-ModuleManifest` accepts both values on the source manifest.
- `./deploy.ps1 -Environment dev` produces a built manifest carrying `4.5.2` / `4.0`.
- Unit suite: **2874 passed, 0 failed, 4 skipped**.
- The documented detection one-liner was run against this repo and returns exactly the 11 expected hits.
- The psd1 was restored with `git checkout` after the build and the two edits re-applied, so the diff carries no `Generated on:` churn or `FunctionsToExport` reflow.

## Test plan

- [ ] All required checks green
- [ ] Docs build succeeds and the Compatibility page renders both matrices
- [ ] `https://docs.powernetbox.dev/guides/compatibility/` still resolves (retitle, not a rename)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011QZsivVeYLDwsuoY5iUM4i
