### PR TITLE
feat: warn about fields Netbox 5.0 removes (#483, #484)

### DIFF
--- a/Functions/DCIM/Racks/New-NBDCIMRack.ps1
+++ b/Functions/DCIM/Racks/New-NBDCIMRack.ps1
@@ -201,12 +201,13 @@ function New-NBDCIMRack {
         Write-Verbose "Creating DCIM Rack"
         $Segments = [System.Collections.ArrayList]::new(@('dcim', 'racks'))
 
-        # Rack-level geometry is now inferred from the rack type (NetBox 4.7);
-        # these params still work but go away in NetBox 5.0.
+        # Rack-level geometry is now inferred from the rack type (Netbox 4.7); these params
+        # still work but go away in Netbox 5.0. Version-gated: on 4.6 and older the rack type
+        # does not carry the geometry, so these fields are the only way to express it.
         foreach ($p in @('Form_Factor', 'Width', 'Outer_Width', 'Outer_Depth', 'Outer_Height')) {
-            if ($PSBoundParameters.ContainsKey($p)) {
-                Write-Verbose "-$p is deprecated in NetBox 4.7 in favour of the rack type and will be removed in NetBox 5.0."
-            }
+            $null = Test-NBDeprecatedParameter -ParameterName $p -DeprecatedInVersion '4.7.0' `
+                -RemovedInVersion '5.0' -BoundParameters $PSBoundParameters `
+                -ReplacementMessage 'Set the geometry on the rack type instead.'
         }
 
         # NetBox 4.7+ only fields: drop them with a warning on older servers.

--- a/Functions/DCIM/Racks/Set-NBDCIMRack.ps1
+++ b/Functions/DCIM/Racks/Set-NBDCIMRack.ps1
@@ -221,12 +221,13 @@ function Set-NBDCIMRack {
             }
         }
 
-        # Rack-level geometry is now inferred from the rack type (NetBox 4.7);
-        # these params still work but go away in NetBox 5.0.
+        # Rack-level geometry is now inferred from the rack type (Netbox 4.7); these params
+        # still work but go away in Netbox 5.0. Version-gated: on 4.6 and older the rack type
+        # does not carry the geometry, so these fields are the only way to express it.
         foreach ($p in @('Form_Factor', 'Width', 'Outer_Width', 'Outer_Depth', 'Outer_Height')) {
-            if ($PSBoundParameters.ContainsKey($p)) {
-                Write-Verbose "-$p is deprecated in NetBox 4.7 in favour of the rack type and will be removed in NetBox 5.0."
-            }
+            $null = Test-NBDeprecatedParameter -ParameterName $p -DeprecatedInVersion '4.7.0' `
+                -RemovedInVersion '5.0' -BoundParameters $PSBoundParameters `
+                -ReplacementMessage 'Set the geometry on the rack type instead.'
         }
 
         # NetBox 4.7+ only fields: drop them with a warning on older servers.

--- a/Functions/Helpers/Test-NBDeprecatedParameter.ps1
+++ b/Functions/Helpers/Test-NBDeprecatedParameter.ps1
@@ -18,6 +18,12 @@ function Test-NBDeprecatedParameter {
     .PARAMETER DeprecatedInVersion
         The Netbox version where this parameter was deprecated/removed.
 
+    .PARAMETER RemovedInVersion
+        The Netbox version that will remove the field entirely. Supplying this switches the
+        helper to warn-only mode: the caller is told the parameter is on its way out, but the
+        function returns $false so the value is still sent. Use this while a deprecated field
+        is deprecated-but-functional; omit it once the server ignores the field.
+
     .PARAMETER BoundParameters
         The $PSBoundParameters from the calling function.
 
@@ -33,6 +39,12 @@ function Test-NBDeprecatedParameter {
             $PSBoundParameters.Remove('Is_Staff') | Out-Null
         }
 
+    .EXAMPLE
+        # Deprecated but still functional until Netbox 5.0 - warn, but keep sending the value:
+        $null = Test-NBDeprecatedParameter -ParameterName 'Ports' -DeprecatedInVersion '4.7.0' `
+            -RemovedInVersion '5.0' -BoundParameters $PSBoundParameters `
+            -ReplacementMessage 'Use -Port_Mappings instead.'
+
     .NOTES
     AddedInVersion: v4.5.0.0
         This function requires that Connect-NBAPI has been called and
@@ -46,6 +58,8 @@ function Test-NBDeprecatedParameter {
 
         [Parameter(Mandatory)]
         [string]$DeprecatedInVersion,
+
+        [string]$RemovedInVersion,
 
         [Parameter(Mandatory)]
         [hashtable]$BoundParameters,
@@ -68,13 +82,33 @@ function Test-NBDeprecatedParameter {
     }
 
     if ($currentVersion -ge $deprecatedVersion) {
-        # Parameter is deprecated in this version
-        $warningMsg = "The '$ParameterName' parameter is deprecated in Netbox $DeprecatedInVersion and will be ignored."
+        # Parameter is deprecated in this version. Two flavours:
+        #  - no -RemovedInVersion: the server ignores the field, so drop it from the request
+        #  - with -RemovedInVersion: still functional, so warn but keep sending it
+        $stillSent = -not [string]::IsNullOrEmpty($RemovedInVersion)
+
+        $warningMsg = if ($stillSent) {
+            "The '-$ParameterName' parameter is deprecated in Netbox $DeprecatedInVersion and will be removed in Netbox $RemovedInVersion."
+        } else {
+            "The '$ParameterName' parameter is deprecated in Netbox $DeprecatedInVersion and will be ignored."
+        }
         if ($ReplacementMessage) {
             $warningMsg += " $ReplacementMessage"
         }
-        Write-Warning $warningMsg
-        return $true  # Exclude from request
+
+        # Report each distinct message once per connection. A bulk pipeline would otherwise
+        # emit hundreds of identical warnings and train users to silence all of them.
+        if ($null -eq $script:NetboxConfig.DeprecationWarned) {
+            $script:NetboxConfig.DeprecationWarned = @{}
+        }
+        if (-not $script:NetboxConfig.DeprecationWarned.ContainsKey($warningMsg)) {
+            $script:NetboxConfig.DeprecationWarned[$warningMsg] = $true
+            Write-Warning $warningMsg
+        } else {
+            Write-Verbose "Deprecation already reported this session: $warningMsg"
+        }
+
+        return (-not $stillSent)
     }
 
     # Older version - parameter is still valid

--- a/Functions/IPAM/Service/New-NBIPAMService.ps1
+++ b/Functions/IPAM/Service/New-NBIPAMService.ps1
@@ -103,6 +103,14 @@ function New-NBIPAMService {
         $Segments = [System.Collections.ArrayList]::new(@('ipam', 'services'))
 
         # Netbox 4.7 replaced protocol/ports with a unified port_mappings list; the legacy pair is
+        # Netbox 4.7 deprecates -Ports/-Protocol in favour of -Port_Mappings. They still work
+        # (removed in Netbox 5.0), so warn but keep sending whichever the caller used.
+        foreach ($p in @('Ports', 'Protocol')) {
+            $null = Test-NBDeprecatedParameter -ParameterName $p -DeprecatedInVersion '4.7.0' `
+                -RemovedInVersion '5.0' -BoundParameters $PSBoundParameters `
+                -ReplacementMessage 'Use -Port_Mappings (e.g. tcp/80, udp/53) instead.'
+        }
+
         # still accepted (deprecated) so we send whichever the caller used.
         $excludePortMappings = Test-NBMinimumVersion -ParameterName 'Port_Mappings' -MinimumVersion '4.7.0' -BoundParameters $PSBoundParameters -FeatureName 'Multi-protocol port mappings (-Port_Mappings)'
 

--- a/Functions/IPAM/Service/Set-NBIPAMService.ps1
+++ b/Functions/IPAM/Service/Set-NBIPAMService.ps1
@@ -86,6 +86,14 @@ function Set-NBIPAMService {
         Write-Verbose "Updating IPAM Service"
         $Segments = [System.Collections.ArrayList]::new(@('ipam', 'services', $Id))
 
+        # Netbox 4.7 deprecates -Ports/-Protocol in favour of -Port_Mappings. They still work
+        # (removed in Netbox 5.0), so warn but keep sending whichever the caller used.
+        foreach ($p in @('Ports', 'Protocol')) {
+            $null = Test-NBDeprecatedParameter -ParameterName $p -DeprecatedInVersion '4.7.0' `
+                -RemovedInVersion '5.0' -BoundParameters $PSBoundParameters `
+                -ReplacementMessage 'Use -Port_Mappings (e.g. tcp/80, udp/53) instead.'
+        }
+
         # Netbox 4.7+ only: drop -Port_Mappings (with a warning) on older servers
         $skipParams = @('Id', 'Raw')
         if (Test-NBMinimumVersion -ParameterName 'Port_Mappings' -MinimumVersion '4.7.0' -BoundParameters $PSBoundParameters -FeatureName 'Multi-protocol port mappings (-Port_Mappings)') { $skipParams += 'Port_Mappings' }

--- a/Functions/IPAM/ServiceTemplate/New-NBIPAMServiceTemplate.ps1
+++ b/Functions/IPAM/ServiceTemplate/New-NBIPAMServiceTemplate.ps1
@@ -84,6 +84,14 @@ function New-NBIPAMServiceTemplate {
         $Segments = [System.Collections.ArrayList]::new(@('ipam', 'service-templates'))
 
         # Netbox 4.7 replaced protocol/ports with a unified port_mappings list; the legacy pair is
+        # Netbox 4.7 deprecates -Ports/-Protocol in favour of -Port_Mappings. They still work
+        # (removed in Netbox 5.0), so warn but keep sending whichever the caller used.
+        foreach ($p in @('Ports', 'Protocol')) {
+            $null = Test-NBDeprecatedParameter -ParameterName $p -DeprecatedInVersion '4.7.0' `
+                -RemovedInVersion '5.0' -BoundParameters $PSBoundParameters `
+                -ReplacementMessage 'Use -Port_Mappings (e.g. tcp/80, udp/53) instead.'
+        }
+
         # still accepted (deprecated). Drop -Port_Mappings (with a warning) on older servers.
         $skipParams = @('Raw')
         $excludePortMappings = Test-NBMinimumVersion -ParameterName 'Port_Mappings' -MinimumVersion '4.7.0' -BoundParameters $PSBoundParameters -FeatureName 'Multi-protocol port mappings (-Port_Mappings)'

--- a/Functions/IPAM/ServiceTemplate/Set-NBIPAMServiceTemplate.ps1
+++ b/Functions/IPAM/ServiceTemplate/Set-NBIPAMServiceTemplate.ps1
@@ -81,6 +81,14 @@ function Set-NBIPAMServiceTemplate {
         Write-Verbose "Updating IPAM Service Template"
         $Segments = [System.Collections.ArrayList]::new(@('ipam', 'service-templates', $Id))
 
+        # Netbox 4.7 deprecates -Ports/-Protocol in favour of -Port_Mappings. They still work
+        # (removed in Netbox 5.0), so warn but keep sending whichever the caller used.
+        foreach ($p in @('Ports', 'Protocol')) {
+            $null = Test-NBDeprecatedParameter -ParameterName $p -DeprecatedInVersion '4.7.0' `
+                -RemovedInVersion '5.0' -BoundParameters $PSBoundParameters `
+                -ReplacementMessage 'Use -Port_Mappings (e.g. tcp/80, udp/53) instead.'
+        }
+
         # Netbox 4.7+ only: drop -Port_Mappings (with a warning) on older servers
         $skipParams = @('Id', 'Raw')
         if (Test-NBMinimumVersion -ParameterName 'Port_Mappings' -MinimumVersion '4.7.0' -BoundParameters $PSBoundParameters -FeatureName 'Multi-protocol port mappings (-Port_Mappings)') { $skipParams += 'Port_Mappings' }

--- a/Functions/Setup/Connect-NBAPI.ps1
+++ b/Functions/Setup/Connect-NBAPI.ps1
@@ -205,6 +205,21 @@ function Connect-NBAPI {
     $script:NetboxConfig.Connected = $true
     Write-Verbose "Successfully connected!"
 
+    # A new connection starts with a clean deprecation slate, so each deprecation warning is
+    # reported once per connection rather than once per process.
+    $script:NetboxConfig.DeprecationWarned = @{}
+
+    # v1 (legacy) tokens are deprecated as of Netbox 4.6 and removed in Netbox 5.0. The
+    # 'nbt_' discriminator is the same one Get-NBRequestHeaders uses to pick the auth scheme.
+    if (($null -ne $script:NetboxConfig.ParsedVersion) -and ($script:NetboxConfig.ParsedVersion -ge [version]'4.6')) {
+        $tokenValue = $script:NetboxConfig.Credential.GetNetworkCredential().Password
+        if ($tokenValue -notmatch '^nbt_') {
+            Write-Warning ("This connection uses a legacy (v1) API token. v1 tokens are deprecated as of " +
+                "Netbox 4.6 and will be removed in Netbox 5.0. Create a v2 token under Users > API Tokens " +
+                "in the Netbox UI and reconnect. See https://netboxlabs.com/docs/netbox/models/users/token/")
+        }
+    }
+
     # This needs a valid ParsedVersion to work, so it must be called after the version check
     $null = Set-NBQueryOption -IgnoreCase:$IgnoreCase
     $null = Set-NBQueryOption -MatchMode $MatchMode

--- a/Functions/Setup/Support/SetupNetboxConfigVariable.ps1
+++ b/Functions/Setup/Support/SetupNetboxConfigVariable.ps1
@@ -25,6 +25,7 @@ function SetupNetboxConfigVariable {
             'TagMatch'      = 'All'         # Set-NBQueryOption -TagMatch All|Any   (Netbox 4.6.6+ tag__any)
             'OptimisticConcurrency' = $false  # Set-NBQueryOption -OptimisticConcurrency (Netbox 4.6+ ETag/If-Match)
             'ETagCache'     = @{}           # object URL -> last seen ETag (only used with OptimisticConcurrency)
+            'DeprecationWarned' = @{}       # warning text -> $true, so each deprecation is reported once per connection
         }
     }
     else {

--- a/Tests/DCIM.Fields47.Tests.ps1
+++ b/Tests/DCIM.Fields47.Tests.ps1
@@ -272,13 +272,20 @@ Describe "DCIM NetBox 4.7 field tests" -Tag 'DCIM', 'Fields47' {
             { New-NBDCIMRack -Name 'R1' -Site 1 -Cooling_Capability 'water' } | Should -Throw
         }
 
-        It "New-NBDCIMRack still sends the deprecated geometry fields (verbose note only)" {
+        It "New-NBDCIMRack warns about the deprecated geometry fields but still sends them" {
+            # The warning was a Write-Verbose note until #484; it is a real warning from 4.7 on,
+            # because the rack type carries the geometry from that release. Sending the fields
+            # anyway is the part that must not change - they work until Netbox 5.0.
+            InModuleScope -ModuleName 'PowerNetbox' { $script:NetboxConfig.DeprecationWarned = @{} }
+
             $Result = New-NBDCIMRack -Name 'R1' -Site 1 -Width 19 -Form_Factor '4-post-cabinet' -Outer_Width 600 -WarningVariable warn -WarningAction SilentlyContinue
             $body = $Result.Body | ConvertFrom-Json
             $body.width | Should -Be 19
             $body.form_factor | Should -Be '4-post-cabinet'
             $body.outer_width | Should -Be 600
-            $warn | Should -BeNullOrEmpty
+
+            ($warn -join ' ') | Should -Match 'Width'
+            ($warn -join ' ') | Should -Match 'removed in Netbox 5\.0'
         }
 
         It "Set-NBDCIMRack sends cooling fields, '' clears capability, `$null clears capacity" {

--- a/Tests/DCIM.Racks.Tests.ps1
+++ b/Tests/DCIM.Racks.Tests.ps1
@@ -229,4 +229,56 @@ Describe "DCIM Racks Tests" -Tag 'DCIM', 'Racks' {
         }
     }
     #endregion
+
+    #region Netbox 5.0 deprecation warnings
+    Context "Rack geometry deprecation" {
+        BeforeAll {
+            $parsedVersionBefore = InModuleScope -ModuleName 'PowerNetbox' { $script:NetboxConfig.ParsedVersion }
+        }
+        AfterAll {
+            InModuleScope -ModuleName 'PowerNetbox' -Parameters @{ V = $parsedVersionBefore } {
+                $script:NetboxConfig.ParsedVersion = $V
+            }
+        }
+        BeforeEach {
+            InModuleScope -ModuleName 'PowerNetbox' { $script:NetboxConfig.DeprecationWarned = @{} }
+        }
+
+        It "New-NBDCIMRack warns on <Parameter> on Netbox 4.7 and still sends it" -ForEach @(
+            @{ Parameter = 'Width';        Value = 19 }
+            @{ Parameter = 'Outer_Width';  Value = 600 }
+            @{ Parameter = 'Outer_Depth';  Value = 1000 }
+            @{ Parameter = 'Outer_Height'; Value = 2000 }
+        ) {
+            InModuleScope -ModuleName 'PowerNetbox' { $script:NetboxConfig.ParsedVersion = [version]'4.7.0' }
+
+            $splat = @{ Name = 'rack-01'; Site = 1; $Parameter = $Value; WarningVariable = 'w'; WarningAction = 'SilentlyContinue' }
+            $Result = New-NBDCIMRack @splat
+
+            ($w -join ' ') | Should -Match "-$Parameter"
+            ($w -join ' ') | Should -Match '5\.0'
+            ($Result.Body | ConvertFrom-Json).$($Parameter.ToLower()) | Should -Be $Value
+        }
+
+        It "Set-NBDCIMRack warns on -Form_Factor on Netbox 4.7" {
+            InModuleScope -ModuleName 'PowerNetbox' { $script:NetboxConfig.ParsedVersion = [version]'4.7.0' }
+
+            $null = Set-NBDCIMRack -Id 1 -Form_Factor '4-post-frame' -Confirm:$false `
+                -WarningVariable w -WarningAction SilentlyContinue
+
+            ($w -join ' ') | Should -Match '-Form_Factor'
+        }
+
+        It "Does not warn on Netbox 4.6, where the rack type does not carry the geometry" {
+            InModuleScope -ModuleName 'PowerNetbox' { $script:NetboxConfig.ParsedVersion = [version]'4.6.10' }
+
+            $Result = New-NBDCIMRack -Name 'rack-01' -Site 1 -Width 19 `
+                -WarningVariable w -WarningAction SilentlyContinue
+
+            @($w | Where-Object { $_ -match 'deprecated' }).Count | Should -Be 0
+            ($Result.Body | ConvertFrom-Json).width | Should -Be 19
+        }
+    }
+    #endregion
+
 }

--- a/Tests/Helpers.Tests.ps1
+++ b/Tests/Helpers.Tests.ps1
@@ -1236,4 +1236,70 @@ Describe "Helpers tests" -Tag 'Core', 'Helpers' {
             }
         }
     }
+
+    Context 'Test-NBDeprecatedParameter' {
+        BeforeAll {
+            $parsedVersionBefore = InModuleScope -ModuleName 'PowerNetbox' { $script:NetboxConfig.ParsedVersion }
+        }
+        AfterAll {
+            InModuleScope -ModuleName 'PowerNetbox' -Parameters @{ V = $parsedVersionBefore } {
+                $script:NetboxConfig.ParsedVersion = $V
+            }
+        }
+
+        It "Excludes the parameter and warns when no removal version is given" {
+            InModuleScope -ModuleName 'PowerNetbox' {
+                $script:NetboxConfig.ParsedVersion = [version]'4.7.0'
+                $script:NetboxConfig.DeprecationWarned = @{}
+                $result = Test-NBDeprecatedParameter -ParameterName 'Is_Staff' -DeprecatedInVersion '4.5.0' `
+                    -BoundParameters @{ 'Is_Staff' = $true } -WarningVariable w -WarningAction SilentlyContinue
+                $result | Should -BeTrue
+                ($w -join ' ') | Should -Match 'ignored'
+            }
+        }
+
+        It "Keeps the parameter but still warns when -RemovedInVersion is given" {
+            InModuleScope -ModuleName 'PowerNetbox' {
+                $script:NetboxConfig.ParsedVersion = [version]'4.7.0'
+                $script:NetboxConfig.DeprecationWarned = @{}
+                $result = Test-NBDeprecatedParameter -ParameterName 'Ports' -DeprecatedInVersion '4.7.0' `
+                    -RemovedInVersion '5.0' -BoundParameters @{ 'Ports' = @(80) } `
+                    -ReplacementMessage 'Use -Port_Mappings instead.' -WarningVariable w -WarningAction SilentlyContinue
+                $result | Should -BeFalse
+                ($w -join ' ') | Should -Match 'removed in Netbox 5\.0'
+                ($w -join ' ') | Should -Match 'Port_Mappings'
+                ($w -join ' ') | Should -Not -Match 'ignored'
+            }
+        }
+
+        It "Warns only once per distinct message" {
+            InModuleScope -ModuleName 'PowerNetbox' {
+                $script:NetboxConfig.ParsedVersion = [version]'4.7.0'
+                $script:NetboxConfig.DeprecationWarned = @{}
+                $splat = @{
+                    ParameterName       = 'Ports'
+                    DeprecatedInVersion = '4.7.0'
+                    RemovedInVersion    = '5.0'
+                    BoundParameters     = @{ 'Ports' = @(80) }
+                }
+                $null = Test-NBDeprecatedParameter @splat -WarningVariable first -WarningAction SilentlyContinue
+                $null = Test-NBDeprecatedParameter @splat -WarningVariable second -WarningAction SilentlyContinue
+                @($first).Count | Should -Be 1
+                @($second).Count | Should -Be 0
+            }
+        }
+
+        It "Does not warn on a Netbox version older than the deprecation" {
+            InModuleScope -ModuleName 'PowerNetbox' {
+                $script:NetboxConfig.ParsedVersion = [version]'4.6.10'
+                $script:NetboxConfig.DeprecationWarned = @{}
+                $result = Test-NBDeprecatedParameter -ParameterName 'Ports' -DeprecatedInVersion '4.7.0' `
+                    -RemovedInVersion '5.0' -BoundParameters @{ 'Ports' = @(80) } `
+                    -WarningVariable w -WarningAction SilentlyContinue
+                $result | Should -BeFalse
+                @($w).Count | Should -Be 0
+            }
+        }
+    }
+
 }

--- a/Tests/IPAM.Tests.ps1
+++ b/Tests/IPAM.Tests.ps1
@@ -1540,4 +1540,61 @@ Describe "IPAM tests" -Tag 'Ipam' {
         }
     }
     #endregion
+
+    #region Netbox 5.0 deprecation warnings
+    Context "Service legacy -Ports/-Protocol deprecation" {
+        BeforeAll {
+            $parsedVersionBefore = InModuleScope -ModuleName 'PowerNetbox' { $script:NetboxConfig.ParsedVersion }
+        }
+        AfterAll {
+            InModuleScope -ModuleName 'PowerNetbox' -Parameters @{ V = $parsedVersionBefore } {
+                $script:NetboxConfig.ParsedVersion = $V
+            }
+        }
+        BeforeEach {
+            InModuleScope -ModuleName 'PowerNetbox' { $script:NetboxConfig.DeprecationWarned = @{} }
+        }
+
+        It "Warns on Netbox 4.7 but still sends the legacy fields" {
+            InModuleScope -ModuleName 'PowerNetbox' { $script:NetboxConfig.ParsedVersion = [version]'4.7.0' }
+
+            $Result = New-NBIPAMService -Name 'HTTP' -Protocol 'tcp' -Ports @(80) -Device 1 `
+                -WarningVariable w -WarningAction SilentlyContinue
+
+            ($w -join ' ') | Should -Match 'Port_Mappings'
+            ($w -join ' ') | Should -Match '5\.0'
+
+            # The regression that actually matters: deprecated is not removed.
+            $bodyObj = $Result.Body | ConvertFrom-Json
+            $bodyObj.ports | Should -Be @(80)
+            $bodyObj.protocol | Should -Be 'tcp'
+        }
+
+        It "Does not warn on Netbox 4.6" {
+            InModuleScope -ModuleName 'PowerNetbox' { $script:NetboxConfig.ParsedVersion = [version]'4.6.10' }
+
+            $Result = New-NBIPAMService -Name 'HTTP' -Protocol 'tcp' -Ports @(80) -Device 1 `
+                -WarningVariable w -WarningAction SilentlyContinue
+
+            @($w | Where-Object { $_ -match 'Port_Mappings' }).Count | Should -Be 0
+            ($Result.Body | ConvertFrom-Json).ports | Should -Be @(80)
+        }
+
+        It "<Command> warns on Netbox 4.7" -ForEach @(
+            @{ Command = 'Set-NBIPAMService' }
+            @{ Command = 'New-NBIPAMServiceTemplate' }
+            @{ Command = 'Set-NBIPAMServiceTemplate' }
+        ) {
+            InModuleScope -ModuleName 'PowerNetbox' { $script:NetboxConfig.ParsedVersion = [version]'4.7.0' }
+
+            $splat = @{ Ports = @(80); Protocol = 'tcp'; WarningVariable = 'w'; WarningAction = 'SilentlyContinue' }
+            if ($Command -like 'Set-*') { $splat['Id'] = 1; $splat['Confirm'] = $false }
+            if ($Command -like '*Template') { $splat['Name'] = 'HTTP' } elseif ($Command -like 'New-*') { $splat['Name'] = 'HTTP'; $splat['Device'] = 1 }
+
+            $null = & $Command @splat
+            ($w -join ' ') | Should -Match 'Port_Mappings'
+        }
+    }
+    #endregion
+
 }

--- a/Tests/Setup.Tests.ps1
+++ b/Tests/Setup.Tests.ps1
@@ -515,4 +515,40 @@ Describe "Setup tests" -Tag 'Core', 'Setup' {
             $Result.Uri | Should -Match 'format=yaml'
         }
     }
+
+    Context "Legacy v1 API token warning" {
+        BeforeAll {
+            Mock -CommandName 'CheckNetboxIsConnected' -ModuleName 'PowerNetbox' -MockWith { return $true }
+            $parsedVersionBefore = InModuleScope -ModuleName 'PowerNetbox' { $script:NetboxConfig.ParsedVersion }
+        }
+        AfterAll {
+            InModuleScope -ModuleName 'PowerNetbox' -Parameters @{ V = $parsedVersionBefore } {
+                $script:NetboxConfig.ParsedVersion = $V
+            }
+        }
+
+        It "Netbox <Version> with a <TokenKind> token should warn: <ShouldWarn>" -ForEach @(
+            @{ Version = '4.6.1';  TokenKind = 'v1'; ShouldWarn = $true;  Token = '0123456789abcdef0123456789abcdef01234567' }
+            @{ Version = '4.7.0';  TokenKind = 'v1'; ShouldWarn = $true;  Token = '0123456789abcdef0123456789abcdef01234567' }
+            @{ Version = '4.6.1';  TokenKind = 'v2'; ShouldWarn = $false; Token = 'nbt_powernetbox1.0123456789abcdef0123456789abcdef01234567' }
+            @{ Version = '4.5.10'; TokenKind = 'v1'; ShouldWarn = $false; Token = '0123456789abcdef0123456789abcdef01234567' }
+        ) {
+            # The mock has to carry the version literally: -MockWith scriptblocks run in module
+            # scope and cannot see the -ForEach variables of the test.
+            Mock -CommandName 'InvokeNetboxRequest' -ModuleName 'PowerNetbox' -MockWith `
+                ([scriptblock]::Create("[pscustomobject]@{ 'netbox-version' = '$Version' }"))
+
+            Set-NBCredential -Token (ConvertTo-SecureString -String $Token -AsPlainText -Force) | Out-Null
+            Connect-NBAPI -Hostname 'netbox.domain.local' -Scheme 'https' -Port 443 `
+                -WarningVariable warnings -WarningAction SilentlyContinue | Out-Null
+
+            $legacy = @($warnings | Where-Object { $_ -match 'v1' -and $_ -match '5\.0' })
+            if ($ShouldWarn) {
+                $legacy.Count | Should -BeGreaterThan 0 -Because "a v1 token on Netbox $Version is deprecated"
+            } else {
+                $legacy.Count | Should -Be 0 -Because "no v1 deprecation applies to a $TokenKind token on Netbox $Version"
+            }
+        }
+    }
+
 }

--- a/docs/guides/compatibility.md
+++ b/docs/guides/compatibility.md
@@ -23,6 +23,31 @@ PowerNetbox is tested against multiple Netbox versions to ensure broad compatibi
 
 **Minimum supported version: Netbox 4.3+**
 
+## Deprecations ahead of Netbox 5.0
+
+Netbox 5.0 removes several fields that still work today. PowerNetbox keeps sending them - your
+scripts do not change behaviour - but warns once per connection so the migration is not a
+surprise at upgrade time. Warnings are version-gated: nothing is reported while you are
+connected to a release where the old field is still the only option.
+
+| What | Deprecated in | Removed in | Use instead |
+|------|---------------|------------|-------------|
+| v1 API tokens (40-char hex, `Token` auth header) | Netbox 4.6 | Netbox 5.0 | A v2 token (`nbt_`-prefixed, `Bearer` auth). Create one under **Users > API Tokens**. |
+| `-Ports` / `-Protocol` on `New-`/`Set-NBIPAMService` and `-NBIPAMServiceTemplate` | Netbox 4.7 | Netbox 5.0 | `-Port_Mappings`, e.g. `-Port_Mappings 'tcp/80','udp/53'` |
+| `-Form_Factor`, `-Width`, `-Outer_Width`, `-Outer_Depth`, `-Outer_Height` on `New-`/`Set-NBDCIMRack` | Netbox 4.7 | Netbox 5.0 | Set the geometry on the rack type |
+
+The v1 token warning is raised by `Connect-NBAPI` when the connected server is Netbox 4.6 or
+newer. Migrating is a one-liner once the new token exists:
+
+```powershell
+Connect-NBAPI -URI https://netbox.example.com -Credential (
+    [PSCredential]::new('api', (ConvertTo-SecureString 'nbt_...' -AsPlainText -Force))
+)
+```
+
+Each distinct warning appears once per connection, so a bulk pipeline reports it once rather
+than once per object. Reconnecting resets that.
+
 ## PowerShell Support
 
 These are the versions exercised in CI on every push and pull request. Each leg installs


### PR DESCRIPTION
Closes #483. Closes #484.

## The problem

Three things are deprecated today and removed in Netbox 5.0, and PowerNetbox said nothing about any of them. A user upgrading their server would have met all three as a `401` or a silently dropped field.

| What | Deprecated | Removed | Replacement |
|---|---|---|---|
| v1 API tokens (40-char hex, `Token` header) | Netbox 4.6 | 5.0 | v2 token (`nbt_`, `Bearer`) |
| Service `-Ports` / `-Protocol` | Netbox 4.7 | 5.0 | `-Port_Mappings` |
| Rack `-Form_Factor` / `-Width` / `-Outer_*` | Netbox 4.7 | 5.0 | the rack type |

**Everything keeps working.** Nothing is filtered out of the request - dropping a field that the connected server still accepts would break working scripts to make a point about a future release.

## The helper needed a second mode

`Test-NBDeprecatedParameter`'s contract is *"warn and drop the parameter"*, with the message `...will be ignored`. That fits a field the server already ignores (`Is_Staff`), but is exactly wrong for one that still works.

New optional `-RemovedInVersion` switches it to warn-but-keep-sending:

```powershell
# existing behaviour, untouched: warn + return $true (caller removes it)
Test-NBDeprecatedParameter -ParameterName 'Is_Staff' -DeprecatedInVersion '4.5.0' ...

# new: warn + return $false, value still sent
Test-NBDeprecatedParameter -ParameterName 'Ports' -DeprecatedInVersion '4.7.0' `
    -RemovedInVersion '5.0' -ReplacementMessage 'Use -Port_Mappings instead.'
```

**Warnings fire once per connection**, keyed on the full message text and reset by `Connect-NBAPI`. `Get-NBDCIMRack | Set-NBDCIMRack -Width 19` over 800 racks would otherwise emit 800 identical lines, which teaches people to run with `-WarningAction SilentlyContinue` - silencing the real warnings too.

**Version gating is not cosmetic.** On Netbox 4.6 the rack type does not carry the geometry, so `-Width` is the *only* way to express it. Warning there would be noise about something the user cannot act on.

## Two corrections to the issues' own text

- **The Rack parameter is `-Outer_Height`**, not `-Outer_Unit` as #484 said.
- **The Rack notice was not missing.** `New-NBDCIMRack.ps1:206` and `Set-NBDCIMRack.ps1:226` already had one - but as `Write-Verbose` (invisible in normal use) and **ungated**, so it would have fired on Netbox 4.3 where those fields are the only option. Replaced by the gated helper call.

## One existing test had to change

`Tests/DCIM.Fields47.Tests.ps1:275` asserted `$warn | Should -BeNullOrEmpty` - it locked in the "verbose note only" behaviour this PR deliberately changes. The assertion is flipped; **the assertions that the fields are still sent are kept**, because that is the part that must not regress.

## Verification

Written test-first; the 14 new cases failed for the right reasons before the implementation existed.

- Unit suite: **2893 passed, 0 failed**, 4 skipped.
- PSScriptAnalyzer clean on every changed file under `Functions/` (with the repo settings).
- No non-ASCII introduced in any `.ps1`.
- The tests assert both halves: that the warning appears *and* that `ports`, `protocol`, `width`, `outer_width`, `outer_depth` and `outer_height` are still present in the request body.
- Negative cases covered: v2 token on 4.6, v1 token on 4.5.10, Service and Rack on 4.6.10 - all silent.

## Docs

The Compatibility guide gains a **Deprecations ahead of Netbox 5.0** section with the table above, the migration snippet for v2 tokens, and a note that each warning appears once per connection. This satisfies the docs item in both issues' acceptance criteria.

## Test plan

- [ ] All required checks green
- [ ] Docs build renders the new section
- [ ] Live check against the local 4.7.0 stack: `-Ports` still creates a service, and the warning appears exactly once across repeated calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011QZsivVeYLDwsuoY5iUM4i
